### PR TITLE
Disable autocorrect/spelling on filter fields

### DIFF
--- a/view/list.html
+++ b/view/list.html
@@ -1,6 +1,9 @@
 <p>
     <div class="ui mini input">
-        <label>Filter: <input type="text" size="30" ng-model="filterStr"></label>
+        <label>
+          Filter:
+          <input type="text" size="30" ng-model="filterStr" autocorrect="off" autocomplete="off" spellcheck="false">
+        </label>
         &nbsp;
         <button ng:click="filterStr = ''" class="ui mini button">Clear</button>
     </div>

--- a/view/persona.html
+++ b/view/persona.html
@@ -107,7 +107,10 @@
     </div>
 
     <div class="ui mini input">
-        <label>Filter: <input type="text" size="30" ng-model="fusionTo.filterStr"></label>
+        <label>
+          Filter:
+          <input type="text" size="30" ng-model="fusionTo.filterStr" autocorrect="off" autocomplete="off" spellcheck="false">
+        </label>
         &nbsp;
         <button ng:click="fusionTo.filterStr = ''" class="ui mini button">Clear</button>
     </div>
@@ -151,7 +154,10 @@
     </div>
 
     <div class="ui mini input">
-        <label>Filter: <input type="text" size="30" ng-model="fusionFrom.filterStr"></label>
+        <label>
+          Filter:
+          <input type="text" size="30" ng-model="fusionFrom.filterStr" autocorrect="off" autocomplete="off" spellcheck="false">
+        </label>
         &nbsp;
         <button ng:click="fusionFrom.filterStr = ''" class="ui mini button">Clear</button>
     </div>


### PR DESCRIPTION
Adds `input` properties that disable browser autocorrect and spell check on the filter fields. Autocorrect features keep trying to fix the uncommon words and names in persona and skill names I type.