### PR TITLE
replace 'grave' with 'colossal' damage as used in  official translation

### DIFF
--- a/data/SkillData.js
+++ b/data/SkillData.js
@@ -460,7 +460,7 @@ var skillMap = {
     },
     "Brave Blade": {
         "cost": 24,
-        "effect": "Deal grave Phys damage to 1 foe.",
+        "effect": "Deal colossal Phys damage to 1 foe.",
         "element": "phys",
         "fuse": "Futsunushi",
         "personas": {
@@ -628,7 +628,7 @@ var skillMap = {
     },
     "Sword Dance": {
         "cost": 21,
-        "effect": "Deal grave Phys damage to 1 foe.",
+        "effect": "Deal colossal Phys damage to 1 foe.",
         "element": "phys",
         "personas": {
             "Metatron": 0,
@@ -1469,7 +1469,7 @@ var skillMap = {
     },
     "Gigantomachia": {
         "cost": 25,
-        "effect": "Deal grave Phys damage to all foes.",
+        "effect": "Deal colossal Phys damage to all foes.",
         "element": "phys",
         "personas": {
             "Abaddon": 80,
@@ -1482,7 +1482,7 @@ var skillMap = {
     },
     "God's Hand": {
         "cost": 25,
-        "effect": "Deal grave Phys damage to 1 foe.",
+        "effect": "Deal colossal Phys damage to 1 foe.",
         "element": "phys",
         "fuse": "Zaou-Gongen",
         "personas": {
@@ -3583,7 +3583,7 @@ var skillMap = {
     "Beast Weaver": {
         "cost": 20,
         "dlc": true,
-        "effect": "Deal grave Phys damage to 1 foe and user is debuffed with Tarunda.",
+        "effect": "Deal colossal Phys damage to 1 foe and user is debuffed with Tarunda.",
         "element": "phys",
         "personas": {
             "Ariadne": 0,

--- a/data/SkillData.ts
+++ b/data/SkillData.ts
@@ -488,7 +488,7 @@ const skillMap: SkillMap = {
     },
     "Brave Blade": {
         "cost": 24,
-        "effect": "Deal grave Phys damage to 1 foe.",
+        "effect": "Deal colossal Phys damage to 1 foe.",
         "element": "phys",
         "fuse": "Futsunushi",
         "personas": {
@@ -656,7 +656,7 @@ const skillMap: SkillMap = {
     },
     "Sword Dance": {
         "cost": 21,
-        "effect": "Deal grave Phys damage to 1 foe.",
+        "effect": "Deal colossal Phys damage to 1 foe.",
         "element": "phys",
         "personas": {
             "Metatron": 0,
@@ -1497,7 +1497,7 @@ const skillMap: SkillMap = {
     },
     "Gigantomachia": {
         "cost": 25,
-        "effect": "Deal grave Phys damage to all foes.",
+        "effect": "Deal colossal Phys damage to all foes.",
         "element": "phys",
         "personas": {
             "Abaddon": 80,
@@ -1510,7 +1510,7 @@ const skillMap: SkillMap = {
     },
     "God's Hand": {
         "cost": 25,
-        "effect": "Deal grave Phys damage to 1 foe.",
+        "effect": "Deal colossal Phys damage to 1 foe.",
         "element": "phys",
         "fuse": "Zaou-Gongen",
         "personas": {
@@ -3611,7 +3611,7 @@ const skillMap: SkillMap = {
     "Beast Weaver": {
         "cost": 20,
         "dlc": true,
-        "effect": "Deal grave Phys damage to 1 foe and user is debuffed with Tarunda.",
+        "effect": "Deal colossal Phys damage to 1 foe and user is debuffed with Tarunda.",
         "element": "phys",
         "personas": {
             "Ariadne": 0,


### PR DESCRIPTION
see attached photos below 
<br>

![2018-10-23 18 09 24](https://user-images.githubusercontent.com/16578306/47375799-6254ff00-d6f1-11e8-8318-9783b2c93c31.jpg)
<br>
![2018-10-23 18 09 51](https://user-images.githubusercontent.com/16578306/47375807-654fef80-d6f1-11e8-9fa4-db8427b7a73f.jpg)

