### PR TITLE
Fix an issue where rare fusions could yield a special persona (ex. Regent + Cu Chulainn)

### DIFF
--- a/src/FusionCalculator.js
+++ b/src/FusionCalculator.js
@@ -134,7 +134,7 @@ var FusionCalculator = (function () {
         if (!newPersona) {
             return null;
         }
-        if (newPersona.special) {
+        while (newPersona.special) {
             if (modifier > 0)
                 modifier++;
             else if (modifier < 0)

--- a/src/FusionCalculator.ts
+++ b/src/FusionCalculator.ts
@@ -151,7 +151,7 @@ class FusionCalculator {
             return null;
         }
 
-        if (newPersona.special) {
+        while (newPersona.special) {
             if (modifier > 0) modifier++;
             else if (modifier < 0) modifier--;
 


### PR DESCRIPTION
When performing a Rare Fusion, the existing code ensures that the resulting persona is not a special persona; if it is, it proceeds to the next persona of the same arcana, and returns the result. However, it does not check whether this next persona is special, so it can yield false results.

Example:
Regent (Emperor/10) + Cu Chulainn (Star/67)
When fusing with a Star persona, Regent yields a modifier of +1.
We look for the next Star persona after Cu Chulainn: Sraosha (Star/80).
Sraosha is a special persona, so we skip to the next Star persona: Lucifer (Star/93).
The existing code would return Lucifer. This is improper, since Lucifer is also special.
The intended result would be to look for the next Star persona after Lucifer, and again return the result (in this case null -- the fusion is invalid).