### PR TITLE
Improve search styling on iOS

### DIFF
--- a/style.css
+++ b/style.css
@@ -149,3 +149,22 @@ tr:hover td:last-child {
 .persona-name {
     vertical-align: inherit;
 }
+
+@supports (-webkit-overflow-scrolling: touch) {
+    .search-label,
+    select,
+    textarea,
+    input,
+    .ui.input input {
+        font-size: 16px;
+    }
+    .ui.button.clear-button {
+        padding: 1.4em 1.5em;
+    }
+}
+
+.search-container {
+    align-items: center;
+    justify-content: center;
+    max-width: 50%;
+}

--- a/view/list.html
+++ b/view/list.html
@@ -1,11 +1,11 @@
 <p>
-    <div class="ui mini input">
-        <label>
+    <div class="ui mini input search-container">
+        <label class="search-label">
           Filter:
-          <input type="text" size="30" ng-model="filterStr" autocorrect="off" autocomplete="off" spellcheck="false">
         </label>
+        <input type="text" size="30" ng-model="filterStr" autocorrect="off" autocomplete="off" spellcheck="false" class="search-box">
         &nbsp;
-        <button ng:click="filterStr = ''" class="ui mini button">Clear</button>
+        <button ng:click="filterStr = ''" class="ui mini button clear-button">Clear</button>
     </div>
 </p>
 


### PR DESCRIPTION
This improves the stying of the search bar iOS. Previously, the font size of the search box was too small for mobile, so you would have to pinch to zoom out the page after typing in the search field. This bumps up the font size slightly. Desktop behavior should be unchanged.

![IMG_17F94CF81A02-1](https://user-images.githubusercontent.com/650034/81046503-64af2200-8e6d-11ea-9f50-104b25153ffc.jpeg)