### PR TITLE
Display notes for royal

### DIFF
--- a/data/PersonaData.ts
+++ b/data/PersonaData.ts
@@ -781,6 +781,7 @@ const personaMap : PersonaMap = {
             "Assault Dive": 29,
             "Dekaja": 0,
             "Dodge Physical": 26,
+            "Apt Pupil": 28,
             "Dormin Rush": 0,
             "Giant Slice": 0,
             "Heat Up": 30

--- a/data/PersonaDataRoyal.js
+++ b/data/PersonaDataRoyal.js
@@ -67,7 +67,8 @@ var personaMapRoyal = {
             "Ice Age": 87
         },
         "stats": [45, 54, 57, 49, 45],
-        "trait": "Ice Lineage"
+        "trait": "Ice Lineage",
+        "note": "Only available after 1/12"
     },
     "Ame-no-Uzume": {
         "inherits": "almighty",
@@ -475,7 +476,8 @@ var personaMapRoyal = {
             "Heat Riser": 75
         },
         "stats": [42, 49, 43, 51, 32],
-        "trait": "Fire Lineage"
+        "trait": "Fire Lineage",
+        "note": "Only available after 1/12"
     },
     "Black Frost": {
         "special": true,
@@ -660,7 +662,8 @@ var personaMapRoyal = {
             "Ice Amp": 79
         },
         "stats": [51, 40, 42, 48, 48],
-        "trait": "Stagnant Aura"
+        "trait": "Stagnant Aura",
+        "note": "Only available after 1/12"
     },
     "Choronzon": {
         "inherits": "curse",
@@ -917,7 +920,8 @@ var personaMapRoyal = {
             "Absorb Nuke": 92
         },
         "stats": [61, 55, 58, 48, 43],
-        "trait": "Pandemic Gaze"
+        "trait": "Pandemic Gaze",
+        "note": "Only available after 1/12"
     },
     "Flauros": {
         "special": true,
@@ -934,8 +938,7 @@ var personaMapRoyal = {
             "Dodge Physical": 20,
             "Rebellion": 22,
             "Cornered Fang": 23,
-            "Heat Up": 24,
-            "Apt Pupil": 28,
+            "Heat Up": 24
         },
         "stats": [15, 11, 13, 14, 11],
         "trait": "Life Focus"
@@ -1144,7 +1147,8 @@ var personaMapRoyal = {
             "Repel Wind": 89
         },
         "stats": [51, 59, 52, 56, 41],
-        "trait": "Spirit Focus"
+        "trait": "Spirit Focus",
+        "note": "Only available after 1/12"
     },
     "Hecatoncheires": {
         "inherits": "phys",
@@ -1809,7 +1813,8 @@ var personaMapRoyal = {
             "Fortify Spirit": 75
         },
         "stats": [45, 47, 43, 46, 39],
-        "trait": "Bloodsucker"
+        "trait": "Bloodsucker",
+        "note": "Only available after 1/12"
     },
     "Lucifer": {
         "special": true,
@@ -1849,7 +1854,8 @@ var personaMapRoyal = {
             "Ali Dance": 78
         },
         "stats": [48, 49, 42, 48, 39],
-        "trait": "Pandemic Gaze"
+        "trait": "Pandemic Gaze",
+        "note": "Only available after 1/12"
     },
     "Mada": {
         "inherits": "fire",

--- a/data/PersonaDataRoyal.js
+++ b/data/PersonaDataRoyal.js
@@ -47,7 +47,8 @@ var personaMapRoyal = {
             "Survival Trick": 88
         },
         "stats": [45, 61, 49, 54, 47],
-        "trait": "Die Already!"
+        "trait": "Die Already!",
+        "max": true
     },
     "Alilat": {
         "inherits": "ice",
@@ -229,7 +230,8 @@ var personaMapRoyal = {
             "Salvation": 90
         },
         "stats": [54, 56, 55, 54, 40],
-        "trait": "Naranari"
+        "trait": "Naranari",
+        "max": true
     },
     "Arsene": {
         "inherits": "curse",
@@ -260,7 +262,8 @@ var personaMapRoyal = {
             "Unshaken Will": 81
         },
         "stats": [52, 48, 51, 49, 35],
-        "trait": "Path of Carnage"
+        "trait": "Path of Carnage",
+        "max": true
     },
     "Atavaka": {
         "inherits": "phys",
@@ -317,7 +320,8 @@ var personaMapRoyal = {
             "Blazing Hell": 88
         },
         "stats": [49, 50, 48, 54, 52],
-        "trait": "Dying Will"
+        "trait": "Dying Will",
+        "max": true
     },
     "Baal": {
         "inherits": "wind",
@@ -386,7 +390,8 @@ var personaMapRoyal = {
             "Megidolaon": 92
         },
         "stats": [55, 61, 54, 56, 42],
-        "trait": "Reaper's Despair"
+        "trait": "Reaper's Despair",
+        "max": true
     },
     "Belial": {
         "inherits": "curse",
@@ -764,7 +769,8 @@ var personaMapRoyal = {
             "Salvation": 89
         },
         "stats": [44, 57, 49, 51, 55],
-        "trait": "Chained Lineage"
+        "trait": "Chained Lineage",
+        "max": true
     },
     "Daisoujou": {
         "inherits": "bless",
@@ -999,7 +1005,8 @@ var personaMapRoyal = {
             "Auto-Maraku": 92
         },
         "stats": [60, 58, 55, 52, 40],
-        "trait": "Sword God"
+        "trait": "Sword God",
+        "max": true
     },
     "Fuu-Ki": {
         "inherits": "wind",
@@ -1319,7 +1326,8 @@ var personaMapRoyal = {
             "Salvation": 90
         },
         "stats": [48, 59, 49, 58, 48],
-        "trait": "Mother Blessing"
+        "trait": "Mother Blessing",
+        "max": true
     },
     "Isis": {
         "inherits": "healing",
@@ -1559,7 +1567,8 @@ var personaMapRoyal = {
             "Spell Master": 82
         },
         "stats": [43, 51, 50, 53, 38],
-        "trait": "Five Elements"
+        "trait": "Five Elements",
+        "max": true
     },
     "Koppa Tengu": {
         "inherits": "wind",
@@ -1707,7 +1716,8 @@ var personaMapRoyal = {
             "Life Aid": 74
         },
         "stats": [39, 49, 41, 47, 38],
-        "trait": "Lotus Dance"
+        "trait": "Lotus Dance",
+        "max": true
     },
     "Lamia": {
         "inherits": "fire",
@@ -1835,7 +1845,8 @@ var personaMapRoyal = {
             "Absorb Phys": 99
         },
         "stats": [61, 59, 59, 56, 51],
-        "trait": "Forbidden Knowledge"
+        "trait": "Forbidden Knowledge",
+        "max": true
     },
     "Macabre": {
         "inherits": "curse",
@@ -1875,7 +1886,8 @@ var personaMapRoyal = {
             "Spell Master": 96
         },
         "stats": [55, 54, 61, 59, 48],
-        "trait": "Drunken Frenzy"
+        "trait": "Drunken Frenzy",
+        "max": true
     },
     "Makami": {
         "inherits": "nuke",
@@ -1943,7 +1955,8 @@ var personaMapRoyal = {
             "Saintly Words": 98
         },
         "stats": [52, 66, 53, 54, 61],
-        "trait": "Ave Maria"
+        "trait": "Ave Maria",
+        "max": true
     },
     "Matador": {
         "inherits": "psy",
@@ -2145,7 +2158,8 @@ var personaMapRoyal = {
             "Debilitate": 90
         },
         "stats": [55, 54, 48, 50, 55],
-        "trait": "Goblet of Sin"
+        "trait": "Goblet of Sin",
+        "max": true
     },
     "Mothman": {
         "inherits": "elec",
@@ -2359,7 +2373,8 @@ var personaMapRoyal = {
             "Elec Amp": 89
         },
         "stats": [53, 58, 54, 52, 42],
-        "trait": "Hunting Premonition"
+        "trait": "Hunting Premonition",
+        "max": true
     },
     "Okuninushi": {
         "inherits": "psy",
@@ -2398,7 +2413,8 @@ var personaMapRoyal = {
             "Agneyastra": 95
         },
         "stats": [56, 53, 57, 59, 49],
-        "trait": "Oni Whisper"
+        "trait": "Oni Whisper",
+        "max": true
     },
     "Oni": {
         "inherits": "phys",
@@ -2854,7 +2870,8 @@ var personaMapRoyal = {
             "Megidolaon": 81
         },
         "stats": [46, 51, 49, 48, 38],
-        "trait": "Herald's Verdict"
+        "trait": "Herald's Verdict",
+        "max": true
     },
     "Sandman": {
         "inherits": "wind",
@@ -2912,7 +2929,8 @@ var personaMapRoyal = {
             "Absorb Ice": 98
         },
         "stats": [62, 59, 55, 52, 55],
-        "trait": "Cocytus"
+        "trait": "Cocytus",
+        "max": true
     },
     "Satanael": {
         "special": true,
@@ -2933,7 +2951,8 @@ var personaMapRoyal = {
             "Victory Cry": 99
         },
         "stats": [63, 60, 57, 56, 56],
-        "trait": "Heretic Charisma"
+        "trait": "Heretic Charisma",
+        "note": "Only available on NG+"
     },
     "Scathach": {
         "inherits": "wind",
@@ -3483,7 +3502,8 @@ var personaMapRoyal = {
             "Riot Gun": 90
         },
         "stats": [56, 51, 49, 57, 43],
-        "trait": "Vahana"
+        "trait": "Vahana",
+        "max": true
     },
     "Vohu Manah": {
         "inherits": "almighty",
@@ -3502,7 +3522,8 @@ var personaMapRoyal = {
             "Salvation": 85
         },
         "stats": [46, 59, 45, 56, 41],
-        "trait": "Enlightenment"
+        "trait": "Enlightenment",
+        "max": true
     },
     "White Rider": {
         "inherits": "curse",
@@ -3635,7 +3656,8 @@ var personaMapRoyal = {
             "Blazing Hell": 86
         },
         "stats": [57, 45, 50, 56, 39],
-        "trait": "Apocalyptic Fury"
+        "trait": "Apocalyptic Fury",
+        "max": true
     },
     "Zouchouten": {
         "inherits": "elec",

--- a/data/PersonaDataRoyal.ts
+++ b/data/PersonaDataRoyal.ts
@@ -47,7 +47,8 @@ const personaMapRoyal: PersonaMap = {
             "Survival Trick": 88
         },
         "stats": [45, 61, 49, 54, 47],
-        "trait": "Die Already!"
+        "trait": "Die Already!",
+        "max": true
     },
     "Alilat": {
         "inherits": "ice",
@@ -229,7 +230,8 @@ const personaMapRoyal: PersonaMap = {
             "Salvation": 90
         },
         "stats": [54, 56, 55, 54, 40],
-        "trait": "Naranari"
+        "trait": "Naranari",
+        "max": true
     },
     "Arsene": {
         "inherits": "curse",
@@ -260,7 +262,8 @@ const personaMapRoyal: PersonaMap = {
             "Unshaken Will": 81
         },
         "stats": [52, 48, 51, 49, 35],
-        "trait": "Path of Carnage"
+        "trait": "Path of Carnage",
+        "max": true
     },
     "Atavaka": {
         "inherits": "phys",
@@ -317,7 +320,8 @@ const personaMapRoyal: PersonaMap = {
             "Blazing Hell": 88
         },
         "stats": [49, 50, 48, 54, 52],
-        "trait": "Dying Will"
+        "trait": "Dying Will",
+        "max": true
     },
     "Baal": {
         "inherits": "wind",
@@ -386,7 +390,8 @@ const personaMapRoyal: PersonaMap = {
             "Megidolaon": 92
         },
         "stats": [55, 61, 54, 56, 42],
-        "trait": "Reaper's Despair"
+        "trait": "Reaper's Despair",
+        "max": true
     },
     "Belial": {
         "inherits": "curse",
@@ -764,7 +769,8 @@ const personaMapRoyal: PersonaMap = {
             "Salvation": 89
         },
         "stats": [44, 57, 49, 51, 55],
-        "trait": "Chained Lineage"
+        "trait": "Chained Lineage",
+        "max": true
     },
     "Daisoujou": {
         "inherits": "bless",
@@ -999,7 +1005,8 @@ const personaMapRoyal: PersonaMap = {
             "Auto-Maraku": 92
         },
         "stats": [60, 58, 55, 52, 40],
-        "trait": "Sword God"
+        "trait": "Sword God",
+        "max": true
     },
     "Fuu-Ki": {
         "inherits": "wind",
@@ -1319,7 +1326,8 @@ const personaMapRoyal: PersonaMap = {
             "Salvation": 90
         },
         "stats": [48, 59, 49, 58, 48],
-        "trait": "Mother Blessing"
+        "trait": "Mother Blessing",
+        "max": true
     },
     "Isis": {
         "inherits": "healing",
@@ -1559,7 +1567,8 @@ const personaMapRoyal: PersonaMap = {
             "Spell Master": 82
         },
         "stats": [43, 51, 50, 53, 38],
-        "trait": "Five Elements"
+        "trait": "Five Elements",
+        "max": true
     },
     "Koppa Tengu": {
         "inherits": "wind",
@@ -1707,7 +1716,8 @@ const personaMapRoyal: PersonaMap = {
             "Life Aid": 74
         },
         "stats": [39, 49, 41, 47, 38],
-        "trait": "Lotus Dance"
+        "trait": "Lotus Dance",
+        "max": true
     },
     "Lamia": {
         "inherits": "fire",
@@ -1835,7 +1845,8 @@ const personaMapRoyal: PersonaMap = {
             "Absorb Phys": 99
         },
         "stats": [61, 59, 59, 56, 51],
-        "trait": "Forbidden Knowledge"
+        "trait": "Forbidden Knowledge",
+        "max": true
     },
     "Macabre": {
         "inherits": "curse",
@@ -1875,7 +1886,8 @@ const personaMapRoyal: PersonaMap = {
             "Spell Master": 96
         },
         "stats": [55, 54, 61, 59, 48],
-        "trait": "Drunken Frenzy"
+        "trait": "Drunken Frenzy",
+        "max": true
     },
     "Makami": {
         "inherits": "nuke",
@@ -1943,7 +1955,8 @@ const personaMapRoyal: PersonaMap = {
             "Saintly Words": 98
         },
         "stats": [52, 66, 53, 54, 61],
-        "trait": "Ave Maria"
+        "trait": "Ave Maria",
+        "max": true
     },
     "Matador": {
         "inherits": "psy",
@@ -2145,7 +2158,8 @@ const personaMapRoyal: PersonaMap = {
             "Debilitate": 90
         },
         "stats": [55, 54, 48, 50, 55],
-        "trait": "Goblet of Sin"
+        "trait": "Goblet of Sin",
+        "max": true
     },
     "Mothman": {
         "inherits": "elec",
@@ -2359,7 +2373,8 @@ const personaMapRoyal: PersonaMap = {
             "Elec Amp": 89
         },
         "stats": [53, 58, 54, 52, 42],
-        "trait": "Hunting Premonition"
+        "trait": "Hunting Premonition",
+        "max": true
     },
     "Okuninushi": {
         "inherits": "psy",
@@ -2398,7 +2413,8 @@ const personaMapRoyal: PersonaMap = {
             "Agneyastra": 95
         },
         "stats": [56, 53, 57, 59, 49],
-        "trait": "Oni Whisper"
+        "trait": "Oni Whisper",
+        "max": true
     },
     "Oni": {
         "inherits": "phys",
@@ -2854,7 +2870,8 @@ const personaMapRoyal: PersonaMap = {
             "Megidolaon": 81
         },
         "stats": [46, 51, 49, 48, 38],
-        "trait": "Herald's Verdict"
+        "trait": "Herald's Verdict",
+        "max": true
     },
     "Sandman": {
         "inherits": "wind",
@@ -2912,7 +2929,8 @@ const personaMapRoyal: PersonaMap = {
             "Absorb Ice": 98
         },
         "stats": [62, 59, 55, 52, 55],
-        "trait": "Cocytus"
+        "trait": "Cocytus",
+        "max": true
     },
     "Satanael": {
         "special": true,
@@ -2933,7 +2951,8 @@ const personaMapRoyal: PersonaMap = {
             "Victory Cry": 99
         },
         "stats": [63, 60, 57, 56, 56],
-        "trait": "Heretic Charisma"
+        "trait": "Heretic Charisma",
+        "note": "Only available on NG+"
     },
     "Scathach": {
         "inherits": "wind",
@@ -3483,7 +3502,8 @@ const personaMapRoyal: PersonaMap = {
             "Riot Gun": 90
         },
         "stats": [56, 51, 49, 57, 43],
-        "trait": "Vahana"
+        "trait": "Vahana",
+        "max": true
     },
     "Vohu Manah": {
         "inherits": "almighty",
@@ -3502,7 +3522,8 @@ const personaMapRoyal: PersonaMap = {
             "Salvation": 85
         },
         "stats": [46, 59, 45, 56, 41],
-        "trait": "Enlightenment"
+        "trait": "Enlightenment",
+        "max": true
     },
     "White Rider": {
         "inherits": "curse",
@@ -3635,7 +3656,8 @@ const personaMapRoyal: PersonaMap = {
             "Blazing Hell": 86
         },
         "stats": [57, 45, 50, 56, 39],
-        "trait": "Apocalyptic Fury"
+        "trait": "Apocalyptic Fury",
+        "max": true
     },
     "Zouchouten": {
         "inherits": "elec",

--- a/data/PersonaDataRoyal.ts
+++ b/data/PersonaDataRoyal.ts
@@ -67,7 +67,8 @@ const personaMapRoyal: PersonaMap = {
             "Ice Age": 87
         },
         "stats": [45, 54, 57, 49, 45],
-        "trait": "Ice Lineage"
+        "trait": "Ice Lineage",
+        "note": "Only available after 1/12"
     },
     "Ame-no-Uzume": {
         "inherits": "almighty",
@@ -475,7 +476,8 @@ const personaMapRoyal: PersonaMap = {
             "Heat Riser": 75
         },
         "stats": [42, 49, 43, 51, 32],
-        "trait": "Fire Lineage"
+        "trait": "Fire Lineage",
+        "note": "Only available after 1/12"
     },
     "Black Frost": {
         "special": true,
@@ -660,7 +662,8 @@ const personaMapRoyal: PersonaMap = {
             "Ice Amp": 79
         },
         "stats": [51, 40, 42, 48, 48],
-        "trait": "Stagnant Aura"
+        "trait": "Stagnant Aura",
+        "note": "Only available after 1/12"
     },
     "Choronzon": {
         "inherits": "curse",
@@ -917,7 +920,8 @@ const personaMapRoyal: PersonaMap = {
             "Absorb Nuke": 92
         },
         "stats": [61, 55, 58, 48, 43],
-        "trait": "Pandemic Gaze"
+        "trait": "Pandemic Gaze",
+        "note": "Only available after 1/12"
     },
     "Flauros": {
         "special": true,
@@ -1143,7 +1147,8 @@ const personaMapRoyal: PersonaMap = {
             "Repel Wind": 89
         },
         "stats": [51, 59, 52, 56, 41],
-        "trait": "Spirit Focus"
+        "trait": "Spirit Focus",
+        "note": "Only available after 1/12"
     },
     "Hecatoncheires": {
         "inherits": "phys",
@@ -1808,7 +1813,8 @@ const personaMapRoyal: PersonaMap = {
             "Fortify Spirit": 75
         },
         "stats": [45, 47, 43, 46, 39],
-        "trait": "Bloodsucker"
+        "trait": "Bloodsucker",
+        "note": "Only available after 1/12"
     },
     "Lucifer": {
         "special": true,
@@ -1848,7 +1854,8 @@ const personaMapRoyal: PersonaMap = {
             "Ali Dance": 78
         },
         "stats": [48, 49, 42, 48, 39],
-        "trait": "Pandemic Gaze"
+        "trait": "Pandemic Gaze",
+        "note": "Only available after 1/12"
     },
     "Mada": {
         "inherits": "fire",

--- a/view/persona.html
+++ b/view/persona.html
@@ -2,13 +2,18 @@
 <div ng:show="fusionTo" style="margin-top:10px">
     <h2>{{personaName}} ({{persona.level}} / {{persona.arcana}})</h2>
 
-    <div ng:show='persona.max || persona.item || persona.rare || persona.note || persona.dlc'>
+    <div ng:if='persona.max || persona.rare || persona.note || persona.dlc'>
         <h3>Note</h3>
         <span style='color: red;' ng:show='persona.max'>Social link must be maxed!</span>
-        <span style='color: slateblue;' ng:show='persona.item'>Requires an item from one of Elizabeth's requests!</span>
         <span style='color: slateblue;' ng:show='persona.rare'>This is a rare persona and cannot be fused!</span>
         <span style='color: slateblue;' ng:show='persona.note'>{{persona.note}}</span>
         <span style='color: slateblue;' ng:show='persona.dlc'>This is a DLC persona!</span>
+    </div>
+
+    <div ng:if='persona.item || persona.itemr' style="margin-top:10px">
+        <h3>Itemization</h3>
+        <p ng:show='persona.item'><b>Normal:</b> {{persona.item}}</p>
+        <p ng:show='persona.itemr'><b>Fusion Alarm:</b> {{persona.itemr}}</p>
     </div>
 
     <h3>Stats</h3>


### PR DESCRIPTION
Hello! Thanks for putting together this calculator, I've been finding it useful, so I hope that my contribution will be helpful.


Notes have been displaying `Requires an item from one of Elizabeth's requests!` for all Personas. This has been removed to instead show itemization results. (Fixes https://github.com/chinhodado/persona5_calculator/issues/42)

Also, included the keys for max social link and some notes on Personas that are only available after 3rd semester.