### PR TITLE
Fix: Rename to "Gun Boost" and "Gun Amp" in Royal

### DIFF
--- a/data/PersonaDataRoyal.js
+++ b/data/PersonaDataRoyal.js
@@ -3015,7 +3015,7 @@ var personaMapRoyal = {
             "One-shot Kill": 0,
             "Agidyne": 0,
             "Masukukaja": 0,
-            "Cripple": 53,
+            "Gun Amp": 53,
             "Fire Break": 54,
             "Fortify Spirit": 56
         },
@@ -3401,7 +3401,7 @@ var personaMapRoyal = {
             "Abysmal Surge": 0,
             "Brain Buster": 0,
             "Fortify Spirit": 61,
-            "Cripple": 62,
+            "Gun Amp": 62,
             "Life Aid": 63,
             "Debilitate": 65
         },
@@ -3527,8 +3527,8 @@ var personaMapRoyal = {
     },
     "White Rider": {
         "inherits": "curse",
-        "item": "Snipe",
-        "itemr": "Cripple",
+        "item": "Gun Boost",
+        "itemr": "Gun Amp",
         "level": 38,
         "arcana": "Chariot",
         "elems": ["-", "-", "nu", "wk", "-", "-", "-", "-", "nu", "rp"],
@@ -3536,7 +3536,7 @@ var personaMapRoyal = {
             "Triple Down": 0,
             "Evil Touch": 0,
             "Oni Kagura": 0,
-            "Snipe": 40,
+            "Gun Boost": 40,
             "Maeiga": 41,
             "Masukukaja": 42,
             "Foul Breath": 43,
@@ -3652,7 +3652,7 @@ var personaMapRoyal = {
             "God's Hand": 0,
             "Evade Physical": 82,
             "Enduring Soul": 83,
-            "Cripple": 84,
+            "Gun Amp": 84,
             "Blazing Hell": 86
         },
         "stats": [57, 45, 50, 56, 39],

--- a/data/PersonaDataRoyal.ts
+++ b/data/PersonaDataRoyal.ts
@@ -3015,7 +3015,7 @@ const personaMapRoyal: PersonaMap = {
             "One-shot Kill": 0,
             "Agidyne": 0,
             "Masukukaja": 0,
-            "Cripple": 53,
+            "Gun Amp": 53,
             "Fire Break": 54,
             "Fortify Spirit": 56
         },
@@ -3401,7 +3401,7 @@ const personaMapRoyal: PersonaMap = {
             "Abysmal Surge": 0,
             "Brain Buster": 0,
             "Fortify Spirit": 61,
-            "Cripple": 62,
+            "Gun Amp": 62,
             "Life Aid": 63,
             "Debilitate": 65
         },
@@ -3527,8 +3527,8 @@ const personaMapRoyal: PersonaMap = {
     },
     "White Rider": {
         "inherits": "curse",
-        "item": "Snipe",
-        "itemr": "Cripple",
+        "item": "Gun Boost",
+        "itemr": "Gun Amp",
         "level": 38,
         "arcana": "Chariot",
         "elems": ["-", "-", "nu", "wk", "-", "-", "-", "-", "nu", "rp"],
@@ -3536,7 +3536,7 @@ const personaMapRoyal: PersonaMap = {
             "Triple Down": 0,
             "Evil Touch": 0,
             "Oni Kagura": 0,
-            "Snipe": 40,
+            "Gun Boost": 40,
             "Maeiga": 41,
             "Masukukaja": 42,
             "Foul Breath": 43,
@@ -3652,7 +3652,7 @@ const personaMapRoyal: PersonaMap = {
             "God's Hand": 0,
             "Evade Physical": 82,
             "Enduring Soul": 83,
-            "Cripple": 84,
+            "Gun Amp": 84,
             "Blazing Hell": 86
         },
         "stats": [57, 45, 50, 56, 39],

--- a/data/SkillDataRoyal.js
+++ b/data/SkillDataRoyal.js
@@ -527,12 +527,6 @@ var skillMapRoyal = {
         "personas": { "Byakko": 0, "Kin-Ki": 31, "Ose": 0, "Rakshasa": 28, "Rangda": 0, "Valkyrie": 0, "Kaguya": 0 },
         "talk": "Funerary Warrior (Valkyrie)"
     },
-    "Cripple": {
-        "effect": "Strengthen Gun attacks by 50%.",
-        "element": "passive",
-        "fuse": ["White Rider"],
-        "personas": { "Seth": 53, "Trumpeter": 62, "Zaou-Gongen": 84 }
-    },
     "Cross Slash": {
         "cost": 20,
         "effect": "Deal 2 times heavy Phys damage to 1 foe. High accuracy.",
@@ -1183,6 +1177,17 @@ var skillMapRoyal = {
         "element": "passive",
         "fuse": ["Izanagi Picaro"],
         "personas": { "Narcissus": 50, "Quetzalcoatl": 68, "Raphael": 81, "Izanagi": 25, "Izanagi Picaro": 28 }
+    },
+    "Gun Amp": {
+        "effect": "Strengthen Gun attacks by 50%.",
+        "element": "passive",
+        "fuse": ["White Rider"],
+        "personas": { "Seth": 53, "Trumpeter": 62, "Zaou-Gongen": 84 }
+    },
+    "Gun Boost": {
+        "effect": "Strengthen Gun attacks by 25%.",
+        "element": "passive",
+        "personas": { "White Rider": 40 }
     },
     "Hama": {
         "cost": 800,
@@ -2616,7 +2621,6 @@ var skillMapRoyal = {
         "personas": { "Obariyon": 0, "Oni": 0 },
         "talk": "Night-Walking Warrior (Mokoi)"
     },
-    "Snipe": { "effect": "Strengthen Gun attacks by 25%.", "element": "passive", "personas": { "White Rider": 40 } },
     "Soul Chain": {
         "card": "Network Fusion",
         "effect": "Recover 20 SP when performing Baton Pass.",

--- a/data/SkillDataRoyal.ts
+++ b/data/SkillDataRoyal.ts
@@ -527,12 +527,6 @@ const skillMapRoyal: SkillMap = {
         "personas": {"Byakko": 0, "Kin-Ki": 31, "Ose": 0, "Rakshasa": 28, "Rangda": 0, "Valkyrie": 0, "Kaguya": 0},
         "talk": "Funerary Warrior (Valkyrie)"
     },
-    "Cripple": {
-        "effect": "Strengthen Gun attacks by 50%.",
-        "element": "passive",
-        "fuse": ["White Rider"],
-        "personas": {"Seth": 53, "Trumpeter": 62, "Zaou-Gongen": 84}
-    },
     "Cross Slash": {
         "cost": 20,
         "effect": "Deal 2 times heavy Phys damage to 1 foe. High accuracy.",
@@ -1183,6 +1177,17 @@ const skillMapRoyal: SkillMap = {
         "element": "passive",
         "fuse": ["Izanagi Picaro"],
         "personas": {"Narcissus": 50, "Quetzalcoatl": 68, "Raphael": 81, "Izanagi": 25, "Izanagi Picaro": 28}
+    },
+    "Gun Amp": {
+        "effect": "Strengthen Gun attacks by 50%.",
+        "element": "passive",
+        "fuse": ["White Rider"],
+        "personas": {"Seth": 53, "Trumpeter": 62, "Zaou-Gongen": 84}
+    },
+    "Gun Boost": {
+        "effect": "Strengthen Gun attacks by 25%.",
+        "element": "passive",
+        "personas": {"White Rider": 40}
     },
     "Hama": {
         "cost": 800,
@@ -2616,7 +2621,6 @@ const skillMapRoyal: SkillMap = {
         "personas": {"Obariyon": 0, "Oni": 0},
         "talk": "Night-Walking Warrior (Mokoi)"
     },
-    "Snipe": {"effect": "Strengthen Gun attacks by 25%.", "element": "passive", "personas": {"White Rider": 40}},
     "Soul Chain": {
         "card": "Network Fusion",
         "effect": "Recover 20 SP when performing Baton Pass.",


### PR DESCRIPTION
Just replaced the instances where previously said "Snipe" and "Cripple" with "Gun Boost" and "Gun Amp".