### PR TITLE
Correct skills for  Black Ooze

### DIFF
--- a/data/PersonaDataRoyal.js
+++ b/data/PersonaDataRoyal.js
@@ -514,7 +514,7 @@ var personaMapRoyal = {
         "skills": {
             "Sledgehammer": 0,
             "Evil Touch": 0,
-            "Stagnant Air": 0,
+            "Foul Breath": 0,
             "Ambient Aid": 20,
             "Headbutt": 21,
             "Brain Jack": 23,

--- a/data/SkillData.ts
+++ b/data/SkillData.ts
@@ -1367,7 +1367,6 @@ const skillMap: SkillMap = {
         "element": "almighty",
         "fuse": "Mothman",
         "personas": {
-            "Black Ooze": 0,
             "Girimehkala": 46,
             "Hecatoncheires": 45,
             "Lamia": 28,
@@ -3602,6 +3601,7 @@ const skillMap: SkillMap = {
         "element": "almighty",
         "fuse": "Black Ooze",
         "personas": {
+            "Black Ooze": 0,
             "Chernobog": 63,
             "Forneus": 66,
             "Kumbhanda": 0,

--- a/data/SkillDataRoyal.js
+++ b/data/SkillDataRoyal.js
@@ -1055,7 +1055,7 @@ var skillMapRoyal = {
         "cost": 800,
         "effect": "Increase susceptibility to all ailments of 1 foe.",
         "element": "almighty",
-        "personas": { "Andras": 0, "Biyarky": 0, "Lamia": 28, "Legion": 39, "White Rider": 43 },
+        "personas": { "Andras": 0, "Biyarky": 0, "Black Ooze": 0, "Lamia": 28, "Legion": 39, "White Rider": 43 },
         "talk": "Pulsing Mud (Black Ooze)"
     },
     "Freeze Boost": {
@@ -2660,7 +2660,6 @@ var skillMapRoyal = {
         "element": "almighty",
         "fuse": ["Legion"],
         "personas": {
-            "Black Ooze": 0,
             "Chernobog": 63,
             "Forneus": 66,
             "Kumbhanda": 0,

--- a/data/SkillDataRoyal.ts
+++ b/data/SkillDataRoyal.ts
@@ -1055,7 +1055,7 @@ const skillMapRoyal: SkillMap = {
         "cost": 800,
         "effect": "Increase susceptibility to all ailments of 1 foe.",
         "element": "almighty",
-        "personas": {"Andras": 0, "Biyarky": 0, "Lamia": 28, "Legion": 39, "White Rider": 43},
+        "personas": {"Andras": 0, "Black Ooze": 0, "Biyarky": 0, "Lamia": 28, "Legion": 39, "White Rider": 43},
         "talk": "Pulsing Mud (Black Ooze)"
     },
     "Freeze Boost": {
@@ -2660,7 +2660,6 @@ const skillMapRoyal: SkillMap = {
         "element": "almighty",
         "fuse": ["Legion"],
         "personas": {
-            "Black Ooze": 0,
             "Chernobog": 63,
             "Forneus": 66,
             "Kumbhanda": 0,


### PR DESCRIPTION
Foul Breath is a lvl 0 skill for Black Ooze in P5 Royal, and Stagnant Air isn't. The opposite is true in the original Persona 5.
This commit should fix the failed check on the current version.