### PR TITLE
Fix lastPage index calculation

### DIFF
--- a/src/PersonaController.js
+++ b/src/PersonaController.js
@@ -82,7 +82,8 @@ var PersonaController = /** @class */ (function () {
         else {
             fusionFromTo.recipes = fusionFromTo.allRecipes;
         }
-        fusionFromTo.lastPage = Math.floor(fusionFromTo.recipes.length / this.$scope.perPage);
+        var totalPageCount = Math.ceil(fusionFromTo.recipes.length / this.$scope.perPage);
+        fusionFromTo.lastPage = Math.max(0, totalPageCount - 1);
         fusionFromTo.numRecipes = fusionFromTo.recipes.length;
         fusionFromTo.recipes = fusionFromTo.recipes.slice(fusionFromTo.pageNum * this.$scope.perPage, fusionFromTo.pageNum * this.$scope.perPage + this.$scope.perPage);
     };

--- a/src/PersonaController.ts
+++ b/src/PersonaController.ts
@@ -95,7 +95,8 @@ class PersonaController {
             fusionFromTo.recipes = fusionFromTo.allRecipes;
         }
 
-        fusionFromTo.lastPage = Math.floor(fusionFromTo.recipes.length / this.$scope.perPage);
+        const totalPageCount = Math.ceil(fusionFromTo.recipes.length / this.$scope.perPage);
+        fusionFromTo.lastPage = Math.max(0, totalPageCount - 1);
 
         fusionFromTo.numRecipes = fusionFromTo.recipes.length;
         fusionFromTo.recipes = fusionFromTo.recipes.slice(


### PR DESCRIPTION
Fixes #63.

The computation of the `lastPage` index had an occasional off-by-one error when the page size evenly divided the number of recipes. The existing calculation worked most of the time because we were using `Math.floor()`, which was usually one less than the correct number of pages.

This fixes the calculation by correctly computing the total number of pages with `Math.ceil()` instead, and then making sure `lastPage` is always 0-indexed.