### PR TITLE
Add build instructions to README + compile shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,23 +51,23 @@ This app uses `npm` for dependency management. [You can download npm here.](http
 
 ### Clone the repo
 
-```
+```sh
 $ git clone https://github.com/chinhodado/persona5_calculator.git # Or your fork's URL
 ```
 
 ### Install dependencies
 
-```
+```sh
 $ npm install
 ```
 
 ### Compile source files
 
-```
+```sh
 $ npm run compile
 ```
 
-You will need to re-run this command and refresh the page any time to see changes to any of the Typescript (*.ts) source files.
+You will need to re-run this command and refresh the page any time to see changes to any of the Typescript (`*.ts`) source files.
 
 ### Run the app locally
 

--- a/README.md
+++ b/README.md
@@ -44,3 +44,31 @@ Ideas, logics, data, etc. have been gathered from:
  - https://github.com/arantius/persona-fusion-calculator
  - https://github.com/Heimdall409/persona4-fusion-calculator
  - https://github.com/aqiu384/aqiu384.github.io/tree/master/p5-tool
+
+## Building and Running Locally
+
+This app uses `npm` for dependency management. [You can download npm here.](https://www.npmjs.com/get-npm)
+
+### Clone the repo
+
+```
+$ git clone https://github.com/chinhodado/persona5_calculator.git # Or your fork's URL
+```
+
+### Install dependencies
+
+```
+$ npm install
+```
+
+### Compile source files
+
+```
+$ npm run compile
+```
+
+You will need to re-run this command and refresh the page any time to see changes to any of the Typescript (*.ts) source files.
+
+### Run the app locally
+
+Open the top-level `index.html` or `indexRoyal.html` in your browser. The app loads some dependencies (e.g. Angular.js) as external `<script>`s, so you may need to disable CORS temporarily to allow this if [you run into errors](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS/Errors).

--- a/package.json
+++ b/package.json
@@ -1,10 +1,13 @@
 {
   "dependencies": {
-    "mocha": "5.2.0",
-    "@types/mocha": "5.2.5",
-    "chai": "4.2.0",
     "@types/chai": "4.1.7",
+    "@types/mocha": "5.2.5",
     "@types/node": "10.12.10",
+    "chai": "4.2.0",
+    "mocha": "5.2.0",
     "typescript": "3.1.6"
+  },
+  "scripts": {
+    "compile": "./node_modules/.bin/tsc"
   }
 }


### PR DESCRIPTION
Updates the README with instructions on how to run the app locally. To make things easier, I also added an npm script `npm run compile` for convenience. You can view the proposed update [on my branch](https://github.com/ronaldsmartin/persona5_calculator/blob/add-build-instructions/README.md#building-and-running-locally).

Thanks again for this great resource! 🙏 