### PR TITLE
Game-accurate Arcana order

### DIFF
--- a/src/PersonaListController.js
+++ b/src/PersonaListController.js
@@ -18,7 +18,6 @@ var PersonaListController = /** @class */ (function () {
             var arcanaValue = arcanaIndex >= 10 ? arcanaIndex.toString() : "0" + arcanaIndex;
             var level = 100 - item.level;
             var levelValue = level >= 10 ? level.toString() : ("0" + level);
-            console.log(item.name + " : " + (arcanaValue + levelValue));
             return arcanaValue + levelValue;
         }
         else {

--- a/src/PersonaListController.js
+++ b/src/PersonaListController.js
@@ -14,7 +14,12 @@ var PersonaListController = /** @class */ (function () {
     PersonaListController.prototype.getSortValue = function (item) {
         var sortBy = this.$scope.sortBy;
         if (sortBy === "arcana") {
-            return item.arcana + (item.level >= 10 ? item.level : ("0" + item.level));
+            var arcanaIndex = Object.keys(rareCombos).indexOf(item.arcana);
+            var arcanaValue = arcanaIndex >= 10 ? arcanaIndex.toString() : "0" + arcanaIndex;
+            var level = 100 - item.level;
+            var levelValue = level >= 10 ? level.toString() : ("0" + level);
+            console.log(item.name + " : " + (arcanaValue + levelValue));
+            return arcanaValue + levelValue;
         }
         else {
             return item[sortBy];

--- a/src/PersonaListController.ts
+++ b/src/PersonaListController.ts
@@ -17,7 +17,13 @@ class PersonaListController {
     private getSortValue(item) {
         let sortBy = this.$scope.sortBy;
         if (sortBy === "arcana") {
-            return item.arcana + (item.level >= 10? item.level : ("0" + item.level));
+            let arcanaIndex = Object.keys(rareCombos).indexOf(item.arcana);
+            let arcanaValue = arcanaIndex >= 10 ? arcanaIndex.toString() : "0" + arcanaIndex;
+
+            let level = 100 - item.level;
+            let levelValue = level >= 10 ? level.toString() : ("0" + level);
+            
+            return arcanaValue + levelValue;
         }
         else {
             return item[sortBy];


### PR DESCRIPTION
Makes the sort by arcana follow the game's logic (Tarot card number, then level in descending order). Makes comparisons to the game's Compendium easier, notably to check missing Personas. Fixes #59.