### PR TITLE
Add Inheritance and Mementos data to index and persona info

### DIFF
--- a/data/Data5.js
+++ b/data/Data5.js
@@ -277,3 +277,19 @@ var specialCombos = [
 var dlcPersona = [["Orpheus", "Orpheus Picaro"], ["Izanagi", "Izanagi Picaro"], ["Thanatos", "Thanatos Picaro"],
     ["Magatsu-Izanagi", "Magatsu-Izanagi Picaro"], ["Kaguya", "Kaguya Picaro"], ["Ariadne", "Ariadne Picaro"],
     ["Asterius", "Asterius Picaro"], ["Tsukiyomi", "Tsukiyomi Picaro"], ["Messiah", "Messiah Picaro"]];
+
+    var inheritanceChart = {
+        //['physical', 'gun', 'fire', 'ice', 'electric', 'wind', 'psychic', 'nuclear', 'bless', 'curse', 'healing','ailment','almighty']
+        "Physical": ["✓","✓","✘","✘","✘","✘","✘","✘","✘","✘","✓","✓"],
+        "Fire":     ["✓","✓","✓","✘","✓","✓","✓","✓","✓","✓","✓","✓"],
+        "Ice":      ["✓","✓","✘","✓","✓","✓","✓","✓","✓","✓","✓","✓"],
+        "Electric": ["✓","✓","✓","✓","✓","✘","✓","✓","✓","✓","✓","✓"],
+        "Wind":     ["✓","✓","✓","✓","✘","✓","✓","✓","✓","✓","✓","✓"],
+        "Psy":      ["✓","✓","✓","✓","✓","✓","✓","✘","✓","✓","✓","✓"],
+        "Nuclear":  ["✓","✓","✓","✓","✓","✓","✘","✓","✓","✓","✓","✓"],
+        "Bless":    ["✘","✘","✓","✓","✓","✓","✓","✓","✓","✘","✓","✘"],
+        "Curse":    ["✘","✘","✓","✓","✓","✓","✓","✓","✘","✓","✘","✓"],
+        "Healing":  ["✘","✘","✓","✓","✓","✓","✓","✓","✓","✘","✓","✓"],
+        "Ailment":  ["✓","✓","✓","✓","✓","✓","✓","✓","✘","✓","✘","✓"],
+        "Almighty": ["✓","✓","✓","✓","✓","✓","✓","✓","✓","✓","✓","✓"]
+    };

--- a/data/Data5.ts
+++ b/data/Data5.ts
@@ -281,3 +281,19 @@ const specialCombos = [
 const dlcPersona = [["Orpheus", "Orpheus Picaro"], ["Izanagi", "Izanagi Picaro"], ["Thanatos", "Thanatos Picaro"],
     ["Magatsu-Izanagi", "Magatsu-Izanagi Picaro"], ["Kaguya", "Kaguya Picaro"], ["Ariadne", "Ariadne Picaro"],
     ["Asterius", "Asterius Picaro"], ["Tsukiyomi", "Tsukiyomi Picaro"], ["Messiah", "Messiah Picaro"]];
+
+const inheritanceChart = {
+    //['physical', 'gun', 'fire', 'ice', 'electric', 'wind', 'psychic', 'nuclear', 'bless', 'curse', 'healing','ailment','almighty']
+    "Physical": ["✓","✓","✘","✘","✘","✘","✘","✘","✘","✘","✓","✓"],
+    "Fire":     ["✓","✓","✓","✘","✓","✓","✓","✓","✓","✓","✓","✓"],
+    "Ice":      ["✓","✓","✘","✓","✓","✓","✓","✓","✓","✓","✓","✓"],
+    "Electric": ["✓","✓","✓","✓","✓","✘","✓","✓","✓","✓","✓","✓"],
+    "Wind":     ["✓","✓","✓","✓","✘","✓","✓","✓","✓","✓","✓","✓"],
+    "Psy":      ["✓","✓","✓","✓","✓","✓","✓","✘","✓","✓","✓","✓"],
+    "Nuclear":  ["✓","✓","✓","✓","✓","✓","✘","✓","✓","✓","✓","✓"],
+    "Bless":    ["✘","✘","✓","✓","✓","✓","✓","✓","✓","✘","✓","✘"],
+    "Curse":    ["✘","✘","✓","✓","✓","✓","✓","✓","✘","✓","✘","✓"],
+    "Healing":  ["✘","✘","✓","✓","✓","✓","✓","✓","✓","✘","✓","✓"],
+    "Ailment":  ["✓","✓","✓","✓","✓","✓","✓","✓","✘","✓","✘","✓"],
+    "Almighty": ["✓","✓","✓","✓","✓","✓","✓","✓","✓","✓","✓","✓"]
+};

--- a/data/Data5Royal.js
+++ b/data/Data5Royal.js
@@ -330,7 +330,7 @@ var specialCombosRoyal = [
     { result: 'Satanael', sources: ["Arsène", "Anzu", "Ishtar", "Satan", "Lucifer", "Michael"] },
     { result: 'Seth', sources: ["Isis", "Anubis", "Thoth", "Horus"] },
     { result: 'Shiva', sources: ["Barong", "Rangda"] },
-    { result: 'Sraosha', sources: ["Mithra", "Mithras", "Melchizedek", "Lilith", "Gabriel"] },
+    { result: 'Sraosha', sources: ["Mitra", "Mithras", "Melchizedek", "Lilith", "Gabriel"] },
     { result: 'Tam Lin', sources: ["Cait Sith", "High Pixie", "Leanan Sidhe"] },
     { result: 'Trumpeter', sources: ["White Rider", "Red Rider", "Black Rider", "Pale Rider"] },
     { result: 'Vasuki', sources: ["Naga", "Ananta", "Raja Naga"] },
@@ -351,3 +351,19 @@ var dlcPersonaRoyal = [
     ["Izanagi-no-Okami", "Izanagi-no-Okami Picaro"],
     ["Raoul"]
 ];
+
+var inheritanceChartRoyal = {
+    //['physical', 'gun', 'fire', 'ice', 'electric', 'wind', 'psychic', 'nuclear', 'bless', 'curse', 'healing','ailment','almighty']
+    "Physical": ["✓","✓","✘","✘","✘","✘","✘","✘","✘","✘","✓","✓"],
+    "Fire":     ["✓","✓","✓","✘","✓","✓","✓","✓","✓","✓","✓","✓"],
+    "Ice":      ["✓","✓","✘","✓","✓","✓","✓","✓","✓","✓","✓","✓"],
+    "Electric": ["✓","✓","✓","✓","✓","✘","✓","✓","✓","✓","✓","✓"],
+    "Wind":     ["✓","✓","✓","✓","✘","✓","✓","✓","✓","✓","✓","✓"],
+    "Psy":      ["✓","✓","✓","✓","✓","✓","✓","✘","✓","✓","✓","✓"],
+    "Nuclear":  ["✓","✓","✓","✓","✓","✓","✘","✓","✓","✓","✓","✓"],
+    "Bless":    ["✘","✘","✓","✓","✓","✓","✓","✓","✓","✘","✓","✘"],
+    "Curse":    ["✘","✘","✓","✓","✓","✓","✓","✓","✘","✓","✘","✓"],
+    "Healing":  ["✘","✘","✓","✓","✓","✓","✓","✓","✓","✘","✓","✓"],
+    "Ailment":  ["✓","✓","✓","✓","✓","✓","✓","✓","✘","✓","✘","✓"],
+    "Almighty": ["✓","✓","✓","✓","✓","✓","✓","✓","✓","✓","✓","✓"]
+};

--- a/data/Data5Royal.ts
+++ b/data/Data5Royal.ts
@@ -333,7 +333,7 @@ const specialCombosRoyal = [
     {result: 'Satanael', sources: ["Arsène", "Anzu", "Ishtar", "Satan", "Lucifer", "Michael"]},
     {result: 'Seth', sources: ["Isis", "Anubis", "Thoth", "Horus"]},
     {result: 'Shiva', sources: ["Barong", "Rangda"]},
-    {result: 'Sraosha', sources: ["Mithra", "Mithras", "Melchizedek", "Lilith", "Gabriel"]},
+    {result: 'Sraosha', sources: ["Mitra", "Mithras", "Melchizedek", "Lilith", "Gabriel"]},
     {result: 'Tam Lin', sources: ["Cait Sith", "High Pixie", "Leanan Sidhe"]},
     {result: 'Trumpeter', sources: ["White Rider", "Red Rider", "Black Rider", "Pale Rider"]},
     {result: 'Vasuki', sources: ["Naga", "Ananta", "Raja Naga"]},
@@ -355,3 +355,19 @@ const dlcPersonaRoyal = [
     ["Izanagi-no-Okami", "Izanagi-no-Okami Picaro"],
     ["Raoul"]
 ];
+
+const inheritanceChartRoyal = {
+    //['physical', 'gun', 'fire', 'ice', 'electric', 'wind', 'psychic', 'nuclear', 'bless', 'curse', 'healing','ailment','almighty']
+    "Physical": ["✓","✓","✘","✘","✘","✘","✘","✘","✘","✘","✓","✓"],
+    "Fire":     ["✓","✓","✓","✘","✓","✓","✓","✓","✓","✓","✓","✓"],
+    "Ice":      ["✓","✓","✘","✓","✓","✓","✓","✓","✓","✓","✓","✓"],
+    "Electric": ["✓","✓","✓","✓","✓","✘","✓","✓","✓","✓","✓","✓"],
+    "Wind":     ["✓","✓","✓","✓","✘","✓","✓","✓","✓","✓","✓","✓"],
+    "Psy":      ["✓","✓","✓","✓","✓","✓","✓","✘","✓","✓","✓","✓"],
+    "Nuclear":  ["✓","✓","✓","✓","✓","✓","✘","✓","✓","✓","✓","✓"],
+    "Bless":    ["✘","✘","✓","✓","✓","✓","✓","✓","✓","✘","✓","✘"],
+    "Curse":    ["✘","✘","✓","✓","✓","✓","✓","✓","✘","✓","✘","✓"],
+    "Healing":  ["✘","✘","✓","✓","✓","✓","✓","✓","✓","✘","✓","✓"],
+    "Ailment":  ["✓","✓","✓","✓","✓","✓","✓","✓","✘","✓","✘","✓"],
+    "Almighty": ["✓","✓","✓","✓","✓","✓","✓","✓","✓","✓","✓","✓"]
+};

--- a/data/ItemData.js
+++ b/data/ItemData.js
@@ -1,38 +1,11 @@
 var itemMap = {
-    "Agidyne": {
-        "skillCard": true,
-    },
-    "Agilao": {
-        "skillCard": true,
-    },
-    "Agneyastra": {
-        "skillCard": true,
-    },
-    "Amrita Drop": {
-        "skillCard": true,
-    },
-    "Angelic Grace": {
-        "skillCard": true,
-    },
     "Archangel Bra": {
         "type": "Protector - Women only",
         "description": "Def 200 / Ev 18 / +Reduce Elec dmg (high)"
     },
-    "Arms Master": {
-        "skillCard": true
-    },
     "Arsène's Cane": {
         "type": "Weapon - Joker only",
         "description": "Atk 130 / Acc 92 / +Random ailment (low)",
-    },
-    "Auto-Mataru": {
-        "skillCard": true
-    },
-    "Bad Beat": {
-        "skillCard": true
-    },
-    "Baisudi": {
-        "skillCard": true
     },
     "Bear Gloves": {
         "type": "Weapon - Makoto only",
@@ -49,53 +22,22 @@ var itemMap = {
     "Black Moon": {
         "type": "Accessory",
         "description": "+Critical rate up (high)"
-        
     },
     "Black Wing Robe": {
         "type": "Protector - Unisex",
         "description": "Def 220 / Ev 20 / +Reduce Nuke dmg (med)"
     },
-    "Bloodbath": {
-        "skillCard": true
-    },
-    "Brain Shake": {
-        "skillCard": true
-    },
     "Brain Shot": {
         "type": "Gun - Ann only",
         "description" : "Atk 140 / Acc 84 / Rounds 12 / +Brainwash (med)"
-    },
-    "Brave Blade": {
-        "skillCard": true
-    },
-    "Bufu": {
-        "skillCard": true
-    },
-    "Burn Boost": {
-        "skillCard": true
     },
     "Catnap": {
         "type": "Gun - Morgana only",
         "description": "Atk 168 / Acc 90 / Rounds 5 / +Sleep (med)" 
     },
-    "Charge": {
-        "skillCard": true
-    },
     "Claiomh Solais - Sable": {
         "type": "Weapon - Morgana only",
         "description": "Atk 280 / Acc 90 / +50 SP"
-    },
-    "Cleave": {
-        "skillCard": true
-    },
-    "Concentrate": {
-        "skillCard": true
-    },
-    "Confuse Boost": {
-        "skillCard": true
-    },
-    "Counter": {
-        "skillCard": true
     },
     "Crystal Skull": {
         "type": "Accessory",
@@ -109,133 +51,21 @@ var itemMap = {
         "type": "Accessory",
         "description": "+Evade Curse (high)"
     },
-    "Dazzler": {
-        "skillCard": true
-    },
-    "Deadly Fury": {
-        "skillCard": true
-    },
     "Death Contract": {
         "type": "Weapon - Haru only",
         "description": "Atk 140 / Acc 86 / +Despair (low)"
-    },
-    "Deathbound": {
-        "skillCard": true
-    },
-    "Debilitate": {
-        "skillCard": true
-    },
-    "Dekaja": {
-        "skillCard": true
-    },
-    "Dekunda": {
-        "skillCard": true
-    },
-    "Despair Boost": {
-        "skillCard": true
-    },
-    "Dia": {
-        "skillCard": true
-    },
-    "Diarahan": {
-        "skillCard": true
-    },
-    "Diarama": {
-        "skillCard": true
-    },
-    "Divine Grace": {
-        "skillCard": true
-    },
-    "Dormin Rush": {
-        "skillCard": true
-    },
-    "Dream Needle": {
-        "skillCard": true
-    },
-    "Eigaon": {
-        "skillCard": true
-    },
-    "Elec Amp": {
-        "skillCard": true
-    },
-    "Elec Boost": {
-        "skillCard": true
     },
     "Emperor's Amulet": {
         "type": "Accessory",
         "description": "En +5 / +Auto-Tarukaja"
     },
-    "Endure": {
-        "skillCard": true
-    },
-    "Enduring Soul": {
-        "skillCard": true
-    },
-    "Energy Drop": {
-        "skillCard": true
-    },
-    "Fast Heal": {
-        "skillCard": true
-    },
-    "Fear Boost": {
-        "skillCard": true
-    },
-    "Fire Amp": {
-        "skillCard": true
-    },
-    "Fire Boost": {
-        "skillCard": true
-    },
-    "Flash Bomb": {
-        "skillCard": true
-    },
     "Fleur du Mal": {
         "type": "Weapon - Haru only",
         "description": "Atk 308 / Acc 86 / Ma +5 / +Dizzy (high)"
-        
-    },
-    "Forget Boost": {
-        "skillCard": true
-    },
-    "Foul Breath": {
-        "skillCard": true
-    },
-    "Freeze Boost": {
-        "skillCard": true
-    },
-    "Freila": {
-        "skillCard": true
     },
     "Frost Hood": {
         "type": "Protector - Morgana only",
         "description": "Def 130 / Ev 20 / +20 SP"
-    },
-    "Garu": {
-        "skillCard": true
-    },
-    "Garudyne": {
-        "skillCard": true
-    },
-    "Garula": {
-        "skillCard": true
-    },
-    "Giant Slice": {
-        "skillCard": true
-    },
-    "Gigantomachia": {
-        "skillCard": true
-    },
-    "God's Hand": {
-        "skillCard": true
-    },
-    "Growth 1": {
-        "skillCard": true
-    },
-    "Growth 2": {
-        "skillCard": true
-    },
-    "Growth 3": {
-        "skillCard": true
     },
     "Hades Harp": {
         "type": "Accessory",
@@ -248,9 +78,6 @@ var itemMap = {
         "type": "Weapon - Morgana only",
         "description": "Atk 128 / Acc 90 / +Critical rate up (low)"
     },
-    "Heat Riser": {
-        "skillCard": true
-    },
     "Heaven's Gate": {
         "type": "Gun - Yusuke only",
         "description": "Atk 378 / Acc 88 / Rounds 12 / Ag +10"
@@ -262,24 +89,6 @@ var itemMap = {
     "Hua Khon": {
         "type": "Accessory",
         "description": "Prevents insta-kill from Bless"
-    },
-    "Ice Boost": {
-        "skillCard": true
-    },
-    "Ice Break": {
-        "skillCard": true
-    },
-    "Insta-Heal": {
-        "skillCard": true
-    },
-    "Invigorate 1": {
-        "skillCard": true
-    },
-    "Invigorate 2": {
-        "skillCard": true
-    },
-    "Invigorate 3": {
-        "skillCard": true
     },
     "Judge of the Dead": {
         "type": "Gun - Makoto only",
@@ -315,118 +124,13 @@ var itemMap = {
         "type": "Protector - Unisex",
         "description": "Def 250 / Ev 10 / +Reduce Magic dmg (high)"
     },
-    "Lucky Punch": {
-        "skillCard": true
-    },
-    "Lullaby": {
-        "skillCard": true
-    },
-    "Mabufu": {
-        "skillCard": true
-    },
-    "Mabufudyne": {
-        "skillCard": true
-    },
-    "Mabufula": {
-        "skillCard": true
-    },
-    "Maeiga": {
-        "skillCard": true
-    },
-    "Maeigaon": {
-        "skillCard": true
-    },
-    "Maeiha": {
-        "skillCard": true
-    },
-    "Mafrei": {
-        "skillCard": true
-    },
-    "Mafreidyne": {
-        "skillCard": true
-    },
-    "Magaru": {
-        "skillCard": true
-    },
-    "Mahamaon": {
-        "skillCard": true
-    },
-    "Makajama": {
-        "skillCard": true
-    },
-    "Makarakarn": {
-        "skillCard": true
-    },
-    "Makouga": {
-        "skillCard": true
-    },
-    "Makougaon": {
-        "skillCard": true
-    },
-    "Makouha": {
-        "skillCard": true
-    },
-    "Mamudoon": {
-        "skillCard": true
-    },
-    "Mapsio": {
-        "skillCard": true
-    },
-    "Maragi": {
-        "skillCard": true
-    },
-    "Maragidyne": {
-        "skillCard": true
-    },
-    "Maragion": {
-        "skillCard": true
-    },
-    "Marakunda": {
-        "skillCard": true
-    },
     "Masquerade Ribbon": {
         "type": "Weapon - Ann only",
         "description": "Atk 172 / Acc 88 / +Dizzy (low)"
     },
-    "Masukukaja": {
-        "skillCard": true
-    },
-    "Masukunda": {
-        "skillCard": true
-    },
-    "Matarukaja": {
-        "skillCard": true
-    },
-    "Mazio": {
-        "skillCard": true
-    },
-    "Mazionga": {
-        "skillCard": true
-    },
-    "Me Patra": {
-        "skillCard": true
-    },
-    "Mediarahan": {
-        "skillCard": true
-    },
-    "Mediarama": {
-        "skillCard": true
-    },
     "Megido Fire": {
         "type": "Gun - Ryuji only",
         "description": "Atk 380 / Acc 98 / Rounds 3 / +Critical rate up (low)"
-    },
-    "Megidola": {
-        "skillCard": true
-    },
-    "Memory Blow": {
-        "skillCard": true
-    },
-    "Mind Slice": {
-        "skillCard": true
-    },
-    "Miracle Punch": {
-        "skillCard": true
     },
     "Mirrirmina": {
         "type": "Gun - Makoto only",
@@ -440,9 +144,6 @@ var itemMap = {
         "type": "Protector - Women only",
         "description": "Def 30 / Ev 30 / +Repel Phys (high)"
     },
-    "Myriad Slashes": {
-        "skillCard": true
-    },
     "Naraka Whip": {
         "type": "Weapon - Ann only",
         "description": "Atk 252 / Acc 90 / +Freeze (high)"
@@ -451,21 +152,9 @@ var itemMap = {
         "type": "Gun - Joker only",
         "description": "Atk 360 / Acc 94 / Rounds 8 / All stats +5"
     },
-    "Nuke Amp": {
-        "skillCard": true
-    },
-    "Nuke Boost": {
-        "skillCard": true
-    },
     "Official's Robe": {
         "type": "Protector - Men only",
         "description": "Def 178 / Ev 18 / +Evade Curse (high)"
-    },
-    "One-shot Kill": {
-        "skillCard": true
-    },
-    "Oni-Kagura": {
-        "skillCard": true
     },
     "Orlov": {
         "type": "Accessory",
@@ -475,9 +164,6 @@ var itemMap = {
         "type": "Weapon - Joker only",
         "description": "Atk 290 / Acc 92 / +Reduce Curse dmg (high)"
     },
-    "Patra": {
-        "skillCard": true
-    },
     "Pawzooka": {
         "type": "Gun - Haru only",
         "description": "Atk 140 / Acc 89 / Rounds 1 / +Confuse (med)"
@@ -485,12 +171,6 @@ var itemMap = {
     "Petra Genetrix": {
         "type": "Accessory",
         "description": "+Null Burn"
-    },
-    "Psiodyne": {
-        "skillCard": true
-    },
-    "Psy Break": {
-        "skillCard": true
     },
     "Pumpkin Bomb": {
         "type": "Gun - Ryuji only",
@@ -500,37 +180,13 @@ var itemMap = {
         "type": "Accessory",
         "description": "All stats +1 / +30 SP"
     },
-    "Rage Boost": {
-        "skillCard": true
-    },
-    "Rakukaja": {
-        "skillCard": true
-    },
-    "Rampage": {
-        "skillCard": true
-    },
-    "Recarm": {
-        "skillCard": true
-    },
     "Red Yarn Ball": {
         "type": "Accessory",
         "description": "Lu +10 / +Auto-Tarukaja"
     },
-    "Regenerate 1": {
-        "skillCard": true
-    },
-    "Regenerate 2": {
-        "skillCard": true
-    },
-    "Regenerate 3": {
-        "skillCard": true
-    },
     "Regent": {
         "type": "Accessory",
         "description": "Str +3 / +Critical rate up (med)"
-    },
-    "Riot Gun": {
-        "skillCard": true
     },
     "Ruyi Jingu Bang": {
         "type": "Weapon - Ryuji only",
@@ -540,12 +196,6 @@ var itemMap = {
         "type": "Weapon - Makoto only",
         "description": "Atk 280 / Acc 90 / +Critical rate up (high)"
     },
-    "Salvation": {
-        "skillCard": true
-    },
-    "Samarecarm": {
-        "skillCard": true
-    },
     "Senryou Yakusha": {
         "type": "Weapon - Yusuke only",
         "description": "Atk 160 / Acc 90 / St +5"
@@ -554,37 +204,13 @@ var itemMap = {
         "type": "Accessory",
         "description": "+Null Rage"
     },
-    "Sharp Student": {
-        "skillCard": true
-    },
-    "Shock Boost": {
-        "skillCard": true
-    },
     "Silk Dress": {
         "type": "Protector - Women only",
         "description": "Def 60 / Ev 10 / +Evade Magic (low)"
     },
-    "Skull Cracker": {
-        "skillCard": true
-    },
-    "Sledgehammer": {
-        "skillCard": true
-    },
-    "Sleep Boost": {
-        "skillCard": true
-    },
     "Snow Queen's Whip": {
         "type": "Weapon - Ann only",
         "description": "Atk 210 / Acc 90 / +Auto-Sukukaja"
-    },
-    "Spell Master": {
-        "skillCard": true
-    },
-    "Spirit Drain": {
-        "skillCard": true
-    },
-    "Stagnant Air": {
-        "skillCard": true
     },
     "Stone of Scone": {
         "type": "Accessory",
@@ -594,9 +220,6 @@ var itemMap = {
         "type": "Gun - Morgana only",
         "description": "Atk 308 / Acc 98 / Rounds 5 / +Random ailment (low)"
     },
-    "Swift Strike": {
-        "skillCard": true
-    },
     "Tantric Oath": {
         "type": "Protector - Men only",
         "description": "Def 272 / Ev 18 / +Reduce Magic dmg (high)"
@@ -604,21 +227,6 @@ var itemMap = {
     "Tapsuan": {
         "type": "Protector - Women only",
         "description": "Def 160 / Ev 12 / +Evade Wind (high)"
-    },
-    "Tarukaja": {
-        "skillCard": true
-    },
-    "Tempest Slash": {
-        "skillCard": true
-    },
-    "Terror Claw": {
-        "skillCard": true
-    },
-    "Tetraja": {
-        "skillCard": true
-    },
-    "Thermopylae": {
-        "skillCard": true
     },
     "Thunder Band": {
         "type": "Accessory",
@@ -628,15 +236,9 @@ var itemMap = {
         "type": "Accessory",
         "description": "En +10 / +Fire attacks"
     },
-    "Triple Down": {
-        "skillCard": true
-    },
     "Tyrant Pistol": {
         "type": "Gun - Joker only",
         "description": "Atk 390 / Acc 98 / Rounds 8 / Ma +10"
-    },
-    "Unshaken Will": {
-        "skillCard": true
     },
     "Usumidori": {
         "type": "Weapon - Yusuke only",
@@ -646,12 +248,6 @@ var itemMap = {
         "type": "Weapon - Makoto only",
         "description": "Atk 272 / Acc 90 / +Random ailment (high)"
     },
-    "Vicious Strike": {
-        "skillCard": true
-    },
-    "Vorpal Blade": {
-        "skillCard": true
-    },
     "White Headband": {
         "type": "Accessory",
         "description": "+50 HP"
@@ -660,26 +256,8 @@ var itemMap = {
         "type": "Gun - Ann only",
         "description": "Atk 386 / Acc 84 / +Despair (med)"
     },
-    "Wind Amp": {
-        "skillCard": true
-    },
-    "Wind Boost": {
-        "skillCard": true
-    },
-    "Wind Wall": {
-        "skillCard": true
-    },
     "Yagrush": {
         "type": "Gun - Haru only",
         "description": "Atk 330 / Acc 80 / Rounds 1 / +Shock (med)"
     },
-    "Zio": {
-        "skillCard": true
-    },
-    "Ziodyne": {
-        "skillCard": true
-    },
-    "Zionga": {
-        "skillCard": true
-    }
 };

--- a/data/ItemData.ts
+++ b/data/ItemData.ts
@@ -6,44 +6,16 @@ interface ItemData {
     name?: string;
     description?: string;
     type?: string;
-    skillCard?: boolean
 }
 
 const itemMap: ItemMap = {
-    "Agidyne": {
-        "skillCard": true,
-    },
-    "Agilao": {
-        "skillCard": true,
-    },
-    "Agneyastra": {
-        "skillCard": true,
-    },
-    "Amrita Drop": {
-        "skillCard": true,
-    },
-    "Angelic Grace": {
-        "skillCard": true,
-    },
     "Archangel Bra": {
         "type": "Protector - Women only",
         "description": "Def 200 / Ev 18 / +Reduce Elec dmg (high)"
     },
-    "Arms Master": {
-        "skillCard": true
-    },
     "Arsène's Cane": {
         "type": "Weapon - Joker only",
         "description": "Atk 130 / Acc 92 / +Random ailment (low)",
-    },
-    "Auto-Mataru": {
-        "skillCard": true
-    },
-    "Bad Beat": {
-        "skillCard": true
-    },
-    "Baisudi": {
-        "skillCard": true
     },
     "Bear Gloves": {
         "type": "Weapon - Makoto only",
@@ -60,53 +32,22 @@ const itemMap: ItemMap = {
     "Black Moon": {
         "type": "Accessory",
         "description": "+Critical rate up (high)"
-        
     },
     "Black Wing Robe": {
         "type": "Protector - Unisex",
         "description": "Def 220 / Ev 20 / +Reduce Nuke dmg (med)"
     },
-    "Bloodbath": {
-        "skillCard": true
-    },
-    "Brain Shake": {
-        "skillCard": true
-    },
     "Brain Shot": {
         "type": "Gun - Ann only",
         "description" : "Atk 140 / Acc 84 / Rounds 12 / +Brainwash (med)"
-    },
-    "Brave Blade": {
-        "skillCard": true
-    },
-    "Bufu": {
-        "skillCard": true
-    },
-    "Burn Boost": {
-        "skillCard": true
     },
     "Catnap": {
         "type": "Gun - Morgana only",
         "description": "Atk 168 / Acc 90 / Rounds 5 / +Sleep (med)" 
     },
-    "Charge": {
-        "skillCard": true
-    },
     "Claiomh Solais - Sable": {
         "type": "Weapon - Morgana only",
         "description": "Atk 280 / Acc 90 / +50 SP"
-    },
-    "Cleave": {
-        "skillCard": true
-    },
-    "Concentrate": {
-        "skillCard": true
-    },
-    "Confuse Boost": {
-        "skillCard": true
-    },
-    "Counter": {
-        "skillCard": true
     },
     "Crystal Skull": {
         "type": "Accessory",
@@ -120,147 +61,29 @@ const itemMap: ItemMap = {
         "type": "Accessory",
         "description": "+Evade Curse (high)"
     },
-    "Dazzler": {
-        "skillCard": true
-    },
-    "Deadly Fury": {
-        "skillCard": true
-    },
     "Death Contract": {
         "type": "Weapon - Haru only",
         "description": "Atk 140 / Acc 86 / +Despair (low)"
-    },
-    "Deathbound": {
-        "skillCard": true
-    },
-    "Debilitate": {
-        "skillCard": true
-    },
-    "Dekaja": {
-        "skillCard": true
-    },
-    "Dekunda": {
-        "skillCard": true
-    },
-    "Despair Boost": {
-        "skillCard": true
-    },
-    "Dia": {
-        "skillCard": true
-    },
-    "Diarahan": {
-        "skillCard": true
-    },
-    "Diarama": {
-        "skillCard": true
-    },
-    "Divine Grace": {
-        "skillCard": true
-    },
-    "Dormin Rush": {
-        "skillCard": true
-    },
-    "Dream Needle": {
-        "skillCard": true
-    },
-    "Eigaon": {
-        "skillCard": true
-    },
-    "Elec Amp": {
-        "skillCard": true
-    },
-    "Elec Boost": {
-        "skillCard": true
     },
     "Emperor's Amulet": {
         "type": "Accessory",
         "description": "En +5 / +Auto-Tarukaja"
     },
-    "Endure": {
-        "skillCard": true
-    },
-    "Enduring Soul": {
-        "skillCard": true
-    },
-    "Energy Drop": {
-        "skillCard": true
-    },
-    "Fast Heal": {
-        "skillCard": true
-    },
-    "Fear Boost": {
-        "skillCard": true
-    },
-    "Fire Amp": {
-        "skillCard": true
-    },
-    "Fire Boost": {
-        "skillCard": true
-    },
-    "Flash Bomb": {
-        "skillCard": true
-    },
     "Fleur du Mal": {
         "type": "Weapon - Haru only",
         "description": "Atk 308 / Acc 86 / Ma +5 / +Dizzy (high)"
-        
-    },
-    "Forget Boost": {
-        "skillCard": true
-    },
-    "Foul Breath": {
-        "skillCard": true
-    },
-    "Freeze Boost": {
-        "skillCard": true
-    },
-    "Freila": {
-        "skillCard": true
     },
     "Frost Hood": {
         "type": "Protector - Morgana only",
         "description": "Def 130 / Ev 20 / +20 SP"
     },
-    "Garu": {
-        "skillCard": true
-    },
-    "Garudyne": {
-        "skillCard": true
-    },
-    "Garula": {
-        "skillCard": true
-    },
-    "Giant Slice": {
-        "skillCard": true
-    },
-    "Gigantomachia": {
-        "skillCard": true
-    },
-    "God's Hand": {
-        "skillCard": true
-    },
-    "Growth 1": {
-        "skillCard": true
-    },
-    "Growth 2": {
-        "skillCard": true
-    },
-    "Growth 3": {
-        "skillCard": true
-    },
     "Hades Harp": {
         "type": "Accessory",
         "description": "Ag +3 / +Null Brainwash"
     },
-    "Headbutt": {
-        "skillCard": true
-    },
     "Headhunter Ladle": {
         "type": "Weapon - Morgana only",
         "description": "Atk 128 / Acc 90 / +Critical rate up (low)"
-    },
-    "Heat Riser": {
-        "skillCard": true
     },
     "Heaven's Gate": {
         "type": "Gun - Yusuke only",
@@ -273,24 +96,6 @@ const itemMap: ItemMap = {
     "Hua Khon": {
         "type": "Accessory",
         "description": "Prevents insta-kill from Bless"
-    },
-    "Ice Boost": {
-        "skillCard": true
-    },
-    "Ice Break": {
-        "skillCard": true
-    },
-    "Insta-Heal": {
-        "skillCard": true
-    },
-    "Invigorate 1": {
-        "skillCard": true
-    },
-    "Invigorate 2": {
-        "skillCard": true
-    },
-    "Invigorate 3": {
-        "skillCard": true
     },
     "Judge of the Dead": {
         "type": "Gun - Makoto only",
@@ -308,9 +113,6 @@ const itemMap: ItemMap = {
         "type": "Accessory",
         "description": "All stats +2 / +Bless"
     },
-    "Kougaon": {
-        "skillCard": true
-    },
     "Kuzuryu Gouhou": {
         "type": "Gun - Yusuke only",
         "description": "Atk 300 / Acc 88 / Rounds 9 / +Random ailment (low)"
@@ -319,125 +121,17 @@ const itemMap: ItemMap = {
         "type": "Accessory",
         "description": "+Null Fear"
     },
-    "Life Aid": {
-        "skillCard": true
-    },
     "Lucifer Guard": {
         "type": "Protector - Unisex",
         "description": "Def 250 / Ev 10 / +Reduce Magic dmg (high)"
-    },
-    "Lucky Punch": {
-        "skillCard": true
-    },
-    "Lullaby": {
-        "skillCard": true
-    },
-    "Mabufu": {
-        "skillCard": true
-    },
-    "Mabufudyne": {
-        "skillCard": true
-    },
-    "Mabufula": {
-        "skillCard": true
-    },
-    "Maeiga": {
-        "skillCard": true
-    },
-    "Maeigaon": {
-        "skillCard": true
-    },
-    "Maeiha": {
-        "skillCard": true
-    },
-    "Mafrei": {
-        "skillCard": true
-    },
-    "Mafreidyne": {
-        "skillCard": true
-    },
-    "Magaru": {
-        "skillCard": true
-    },
-    "Mahamaon": {
-        "skillCard": true
-    },
-    "Makajama": {
-        "skillCard": true
-    },
-    "Makarakarn": {
-        "skillCard": true
-    },
-    "Makouga": {
-        "skillCard": true
-    },
-    "Makougaon": {
-        "skillCard": true
-    },
-    "Makouha": {
-        "skillCard": true
-    },
-    "Mamudoon": {
-        "skillCard": true
-    },
-    "Mapsio": {
-        "skillCard": true
-    },
-    "Maragi": {
-        "skillCard": true
-    },
-    "Maragidyne": {
-        "skillCard": true
-    },
-    "Maragion": {
-        "skillCard": true
-    },
-    "Marakunda": {
-        "skillCard": true
     },
     "Masquerade Ribbon": {
         "type": "Weapon - Ann only",
         "description": "Atk 172 / Acc 88 / +Dizzy (low)"
     },
-    "Masukukaja": {
-        "skillCard": true
-    },
-    "Masukunda": {
-        "skillCard": true
-    },
-    "Matarukaja": {
-        "skillCard": true
-    },
-    "Mazio": {
-        "skillCard": true
-    },
-    "Mazionga": {
-        "skillCard": true
-    },
-    "Me Patra": {
-        "skillCard": true
-    },
-    "Mediarahan": {
-        "skillCard": true
-    },
-    "Mediarama": {
-        "skillCard": true
-    },
     "Megido Fire": {
         "type": "Gun - Ryuji only",
         "description": "Atk 380 / Acc 98 / Rounds 3 / +Critical rate up (low)"
-    },
-    "Megidola": {
-        "skillCard": true
-    },
-    "Memory Blow": {
-        "skillCard": true
-    },
-    "Mind Slice": {
-        "skillCard": true
-    },
-    "Miracle Punch": {
-        "skillCard": true
     },
     "Mirrirmina": {
         "type": "Gun - Makoto only",
@@ -451,9 +145,6 @@ const itemMap: ItemMap = {
         "type": "Protector - Women only",
         "description": "Def 30 / Ev 30 / +Repel Phys (high)"
     },
-    "Myriad Slashes": {
-        "skillCard": true
-    },
     "Naraka Whip": {
         "type": "Weapon - Ann only",
         "description": "Atk 252 / Acc 90 / +Freeze (high)"
@@ -462,21 +153,9 @@ const itemMap: ItemMap = {
         "type": "Gun - Joker only",
         "description": "Atk 360 / Acc 94 / Rounds 8 / All stats +5"
     },
-    "Nuke Amp": {
-        "skillCard": true
-    },
-    "Nuke Boost": {
-        "skillCard": true
-    },
     "Official's Robe": {
         "type": "Protector - Men only",
         "description": "Def 178 / Ev 18 / +Evade Curse (high)"
-    },
-    "One-shot Kill": {
-        "skillCard": true
-    },
-    "Oni-Kagura": {
-        "skillCard": true
     },
     "Orlov": {
         "type": "Accessory",
@@ -486,9 +165,6 @@ const itemMap: ItemMap = {
         "type": "Weapon - Joker only",
         "description": "Atk 290 / Acc 92 / +Reduce Curse dmg (high)"
     },
-    "Patra": {
-        "skillCard": true
-    },
     "Pawzooka": {
         "type": "Gun - Haru only",
         "description": "Atk 140 / Acc 89 / Rounds 1 / +Confuse (med)"
@@ -496,12 +172,6 @@ const itemMap: ItemMap = {
     "Petra Genetrix": {
         "type": "Accessory",
         "description": "+Null Burn"
-    },
-    "Psiodyne": {
-        "skillCard": true
-    },
-    "Psy Break": {
-        "skillCard": true
     },
     "Pumpkin Bomb": {
         "type": "Gun - Ryuji only",
@@ -511,37 +181,13 @@ const itemMap: ItemMap = {
         "type": "Accessory",
         "description": "All stats +1 / +30 SP"
     },
-    "Rage Boost": {
-        "skillCard": true
-    },
-    "Rakukaja": {
-        "skillCard": true
-    },
-    "Rampage": {
-        "skillCard": true
-    },
-    "Recarm": {
-        "skillCard": true
-    },
     "Red Yarn Ball": {
         "type": "Accessory",
         "description": "Lu +10 / +Auto-Tarukaja"
     },
-    "Regenerate 1": {
-        "skillCard": true
-    },
-    "Regenerate 2": {
-        "skillCard": true
-    },
-    "Regenerate 3": {
-        "skillCard": true
-    },
     "Regent": {
         "type": "Accessory",
         "description": "Str +3 / +Critical rate up (med)"
-    },
-    "Riot Gun": {
-        "skillCard": true
     },
     "Ruyi Jingu Bang": {
         "type": "Weapon - Ryuji only",
@@ -551,12 +197,6 @@ const itemMap: ItemMap = {
         "type": "Weapon - Makoto only",
         "description": "Atk 280 / Acc 90 / +Critical rate up (high)"
     },
-    "Salvation": {
-        "skillCard": true
-    },
-    "Samarecarm": {
-        "skillCard": true
-    },
     "Senryou Yakusha": {
         "type": "Weapon - Yusuke only",
         "description": "Atk 160 / Acc 90 / St +5"
@@ -565,37 +205,13 @@ const itemMap: ItemMap = {
         "type": "Accessory",
         "description": "+Null Rage"
     },
-    "Sharp Student": {
-        "skillCard": true
-    },
-    "Shock Boost": {
-        "skillCard": true
-    },
     "Silk Dress": {
         "type": "Protector - Women only",
         "description": "Def 60 / Ev 10 / +Evade Magic (low)"
     },
-    "Skull Cracker": {
-        "skillCard": true
-    },
-    "Sledgehammer": {
-        "skillCard": true
-    },
-    "Sleep Boost": {
-        "skillCard": true
-    },
     "Snow Queen's Whip": {
         "type": "Weapon - Ann only",
         "description": "Atk 210 / Acc 90 / +Auto-Sukukaja"
-    },
-    "Spell Master": {
-        "skillCard": true
-    },
-    "Spirit Drain": {
-        "skillCard": true
-    },
-    "Stagnant Air": {
-        "skillCard": true
     },
     "Stone of Scone": {
         "type": "Accessory",
@@ -605,9 +221,6 @@ const itemMap: ItemMap = {
         "type": "Gun - Morgana only",
         "description": "Atk 308 / Acc 98 / Rounds 5 / +Random ailment (low)"
     },
-    "Swift Strike": {
-        "skillCard": true
-    },
     "Tantric Oath": {
         "type": "Protector - Men only",
         "description": "Def 272 / Ev 18 / +Reduce Magic dmg (high)"
@@ -615,21 +228,6 @@ const itemMap: ItemMap = {
     "Tapsuan": {
         "type": "Protector - Women only",
         "description": "Def 160 / Ev 12 / +Evade Wind (high)"
-    },
-    "Tarukaja": {
-        "skillCard": true
-    },
-    "Tempest Slash": {
-        "skillCard": true
-    },
-    "Terror Claw": {
-        "skillCard": true
-    },
-    "Tetraja": {
-        "skillCard": true
-    },
-    "Thermopylae": {
-        "skillCard": true
     },
     "Thunder Band": {
         "type": "Accessory",
@@ -639,15 +237,9 @@ const itemMap: ItemMap = {
         "type": "Accessory",
         "description": "En +10 / +Fire attacks"
     },
-    "Triple Down": {
-        "skillCard": true
-    },
     "Tyrant Pistol": {
         "type": "Gun - Joker only",
         "description": "Atk 390 / Acc 98 / Rounds 8 / Ma +10"
-    },
-    "Unshaken Will": {
-        "skillCard": true
     },
     "Usumidori": {
         "type": "Weapon - Yusuke only",
@@ -657,12 +249,6 @@ const itemMap: ItemMap = {
         "type": "Weapon - Makoto only",
         "description": "Atk 272 / Acc 90 / +Random ailment (high)"
     },
-    "Vicious Strike": {
-        "skillCard": true
-    },
-    "Vorpal Blade": {
-        "skillCard": true
-    },
     "White Headband": {
         "type": "Accessory",
         "description": "+50 HP"
@@ -671,26 +257,8 @@ const itemMap: ItemMap = {
         "type": "Gun - Ann only",
         "description": "Atk 386 / Acc 84 / +Despair (med)"
     },
-    "Wind Amp": {
-        "skillCard": true
-    },
-    "Wind Boost": {
-        "skillCard": true
-    },
-    "Wind Wall": {
-        "skillCard": true
-    },
     "Yagrush": {
         "type": "Gun - Haru only",
         "description": "Atk 330 / Acc 80 / Rounds 1 / +Shock (med)"
     },
-    "Zio": {
-        "skillCard": true
-    },
-    "Ziodyne": {
-        "skillCard": true
-    },
-    "Zionga": {
-        "skillCard": true
-    }
 };

--- a/data/ItemDataRoyal.js
+++ b/data/ItemDataRoyal.js
@@ -1,19 +1,4 @@
 var itemMapRoyal = {
-    "Abysmal Surge": {
-        "skillCard": true,
-    },
-    "Agi": {
-        "skillCard": true,
-    },
-    "Agidyne": {
-        "skillCard": true,
-    },
-    "Agilao": {
-        "skillCard": true,
-    },
-    "Agneyastra": {
-        "skillCard": true,
-    },
     "Aid Charm": {
         "type": "Accessory",
         "description": "+Dia (Small HP recovery for 1 ally)"
@@ -30,9 +15,6 @@ var itemMapRoyal = {
         "type": "Protector - Women only",
         "description": "Def 300 / Ev 18 / +Reduce Elec dmg (high)"
     },
-    "Arms Master": {
-        "skillCard": true
-    },
     "Arsène's Cane": {
         "type": "Weapon - Joker only",
         "description": "Atk 130 / Acc 92 / +Random ailment (low)",
@@ -41,24 +23,9 @@ var itemMapRoyal = {
         "type": "Accessory",
         "description": "+Assault Dive (Heavy Phys dmg to 1 foe)"
     },
-    "Assault Dive": {
-        "skillCard": true,
-    },
     "Atom Ring": {
         "type": "Accessory",
         "description": "+Frei (Light Nuke dmg to 1 foe)"
-    },
-    "Atomic Flare": {
-        "skillCard": true,
-    },
-    "Auto-Maraku": {
-        "skillCard": true,
-    },
-    "Auto-Masaku": {
-        "skillCard": true,
-    },
-    "Auto-Mataru": {
-        "skillCard": true
     },
     "Bear Gloves": {
         "type": "Weapon - Makoto only",
@@ -101,12 +68,6 @@ var itemMapRoyal = {
         "type": "Accessory",
         "description": "+Fire Amp / En +10"
     },
-    "Bless Amp": {
-        "skillCard": true
-    },
-    "Bless Boost": {
-        "skillCard": true
-    },
     "Blessing Ring": {
         "type": "Accessory",
         "description": "+Kouga (Med. Bless dmg to 1 foe)"
@@ -114,9 +75,6 @@ var itemMapRoyal = {
     "Blizzard Ring": {
         "type": "Accessory",
         "description": "+Bufudyne (Heavy Ice dmg to 1 foe)"
-    },
-    "Bloodbath": {
-        "skillCard": true
     },
     "Blood Red Capote": {
         "type": "Protector - Men only",
@@ -126,9 +84,6 @@ var itemMapRoyal = {
         "type": "Protector - Men only",
         "description": "Def 130 / Ev 20 / Ag +6"
     },
-    "Brain Jack": {
-        "skillCard": true
-    },
     "Brain Shot": {
         "type": "Gun - Ann only",
         "description" : "Atk 140 / Acc 84 / Rounds 12 / +Brainwash (med)"
@@ -137,21 +92,9 @@ var itemMapRoyal = {
         "type": "Accessory",
         "description": "+Brave Blade (Colossal Phys dmg to 1 foe)"
     },
-    "Brave Blade": {
-        "skillCard": true
-    },
     "Breeze Ring": {
         "type": "Accessory",
         "description": "+Garu (Light Wind dmg to 1 foe)"
-    },
-    "Bufu": {
-        "skillCard": true
-    },
-    "Bufudyne": {
-        "skillCard": true
-    },
-    "Bufula": {
-        "skillCard": true
     },
     "Cat Buster": {
         "type": "Gun - Morgana only",
@@ -161,9 +104,6 @@ var itemMapRoyal = {
         "type": "Gun - Morgana only",
         "description": "Atk 150 / Acc 90 / Rounds 5 / +Sleep (med)" 
     },
-    "Charge": {
-        "skillCard": true
-    },
     "Claiomh Solais": {
         "type": "Weapon - Morgana only",
         "description": "Atk 315 / Acc 90 / +50 SP"
@@ -171,21 +111,6 @@ var itemMapRoyal = {
     "Claiomh Solais R": {
         "type": "Weapon - Morgana only",
         "description": "Atk 330 / Acc 90 / +50 SP"
-    },
-    "Cleave": {
-        "skillCard": true
-    },
-    "Concentrate": {
-        "skillCard": true
-    },
-    "Cornered Fang": {
-        "skillCard": true
-    },
-    "Counter": {
-        "skillCard": true
-    },
-    "Counterstrike": {
-        "skillCard": true
     },
     "Crystal Skull": {
         "type": "Accessory",
@@ -227,12 +152,6 @@ var itemMapRoyal = {
         "type": "Accessory",
         "description": "+Evade Curse (high) / Ma +8"
     },
-    "Dazzler": {
-        "skillCard": true
-    },
-    "Deadly Fury": {
-        "skillCard": true
-    },
     "Death Contract": {
         "type": "Weapon - Haru only",
         "description": "Atk 190 / Acc 80 / +Despair (low)"
@@ -241,39 +160,9 @@ var itemMapRoyal = {
         "type": "Weapon - Haru only",
         "description": "Atk 200 / Acc 80 / +Despair (med)"
     },
-    "Death Scythe": {
-        "skillCard": true
-    },
-    "Deathbound": {
-        "skillCard": true
-    },
-    "Debilitate": {
-        "skillCard": true
-    },
-    "Dekaja": {
-        "skillCard": true
-    },
-    "Dekunda": {
-        "skillCard": true
-    },
-    "Demonic Decree": {
-        "skillCard": true
-    },
-    "Diamond Dust": {
-        "skillCard": true
-    },
     "Diamond Dust Lily": {
         "type": "Accessory",
         "description": "+Diamond Dust (Severe Ice dmg to 1 foe)"
-    },
-    "Diarahan": {
-        "skillCard": true
-    },
-    "Diarama": {
-        "skillCard": true
-    },
-    "Divine Judgement": {
-        "skillCard": true
     },
     "Divine Ring": {
         "type": "Accessory",
@@ -283,39 +172,9 @@ var itemMapRoyal = {
         "type": "Gun - Akechi only",
         "description": "Atk 330 / Acc 85 / Rounds 5 / All Stats +5"
     },
-    "Dormin Rush": {
-        "skillCard": true
-    },
-    "Dormina": {
-        "skillCard": true
-    },
-    "Double Fangs": {
-        "skillCard": true
-    },
-    "Double Shot": {
-        "skillCard": true
-    },
     "Dragon's Heart": {
         "type": "Accessory",
         "description": "+Psycho Force (Severe Psy dmg to 1 foe)"
-    },
-    "Drain Curse": {
-        "skillCard": true
-    },
-    "Dream Needle": {
-        "skillCard": true
-    },
-    "Eiga": {
-        "skillCard": true
-    },
-    "Eigaon": {
-        "skillCard": true
-    },
-    "Elec Amp": {
-        "skillCard": true
-    },
-    "Elec Boost": {
-        "skillCard": true
     },
     "Ember Ring": {
         "type": "Accessory",
@@ -329,27 +188,9 @@ var itemMapRoyal = {
         "type": "Accessory",
         "description": "En +8 / +Auto-Mataru"
     },
-    "Endure": {
-        "skillCard": true
-    },
-    "Enduring Soul": {
-        "skillCard": true
-    },
     "Energy Charm": {
         "type": "Accessory",
         "description": "+Energy Drop (Cure Confuse/Fear/Despair/Rage/Brainwash for 1 ally)"
-    },
-    "Energy Drop": {
-        "skillCard": true
-    },
-    "Energy Shower": {
-        "skillCard": true
-    },
-    "Evil Smile": {
-        "skillCard": true
-    },
-    "Evil Touch": {
-        "skillCard": true
     },
     "Fairy Hero Armor": {
         "type": "Protector - Men only",
@@ -375,12 +216,6 @@ var itemMapRoyal = {
         "type": "Accessory",
         "description": "+Atomic Flare (Severe Nuke dmg to 1 foe)"
     },
-    "Firm Stance": {
-        "skillCard": true
-    },
-    "Flash Bomb": {
-        "skillCard": true
-    },
     "Fleurs du Mal": {
         "type": "Weapon - Haru only",
         "description": "Atk 325 / Acc 86 / Ma +5 / +Dizzy (high)"
@@ -389,16 +224,6 @@ var itemMapRoyal = {
     "Fleurs du Mal R": {
         "type": "Weapon - Haru only",
         "description": "Atk 345 / Acc 86 / Ma +5 / +Dizzy (high)"
-        
-    },
-    "Foul Breath": {
-        "skillCard": true
-    },
-    "Frei": {
-        "skillCard": true
-    },
-    "Freidyne": {
-        "skillCard": true
     },
     "Frost Ace Hood": {
         "type": "Protector - Morgana only",
@@ -412,35 +237,17 @@ var itemMapRoyal = {
         "type": "Accessory",
         "description": "+Bufu (Light Ice dmg to all foes)"
     },
-    "Garu": {
-        "skillCard": true
-    },
-    "Garudyne": {
-        "skillCard": true
-    },
-    "Garula": {
-        "skillCard": true
-    },
     "Gatling Belt": {
         "type": "Accessory",
         "description": "+Gatling Blow (Light Phys dmg 3-4 times to 1 foe)"
-    },
-    "Giant Slice": {
-        "skillCard": true
     },
     "Giant Slice Belt": {
         "type": "Accessory",
         "description": "+Giant Slice (Med Phys dmg to 1 foe, powers up after baton pass)"
     },
-    "Gigantomachia": {
-        "skillCard": true
-    },
     "Gigantomachia Belt": {
         "type": "Accessory",
         "description": "+Gigantomachia (Colossal Phys dmg to all foes)"
-    },
-    "God's Hand": {
-        "skillCard": true
     },
     "God's Hand Belt": {
         "type": "Accessory",
@@ -466,25 +273,13 @@ var itemMapRoyal = {
         "type": "Accessory",
         "description": "Null Brainwash / Ma +8"
     },
-    "Growth 2": {
-        "skillCard": true
-    },
-    "Growth 3": {
-        "skillCard": true
-    },
     "Grudge Ring": {
         "type": "Accessory",
         "description": "+Eiha (Light Curse dmg to 1 foe)"
     },
-    "Gun Amp": {
-        "skillCard": true
-    },
     "Gungnir": {
         "type": "Gun - Ann only",
         "description": "Atk 340 / Acc 90 / Rounds 12 / +Despair (med)"
-    },
-    "Gun Boost": {
-        "skillCard": true
     },
     "Hades Harp": {
         "type": "Accessory",
@@ -498,15 +293,6 @@ var itemMapRoyal = {
         "type": "Accessory",
         "description": "+Hamaon (Bless, med chance of insta-killing 1 foe)"
     },
-    "Hama": {
-        "skillCard": true
-    },
-    "Hamaon": {
-        "skillCard": true
-    },
-    "Headbutt": {
-        "skillCard": true
-    },
     "Headhunter Ladle": {
         "type": "Weapon - Morgana only",
         "description": "Atk 150 / Acc 90 / +Critical rate up (low)"
@@ -514,12 +300,6 @@ var itemMapRoyal = {
     "Headhunter Ladle EX": {
         "type": "Weapon - Morgana only",
         "description": "Atk 150 / Acc 90 / +Critical rate up (med)"
-    },
-    "Heat Riser": {
-        "skillCard": true
-    },
-    "Heat Wave": {
-        "skillCard": true
     },
     "Heaven's Gate": {
         "type": "Gun - Yusuke only",
@@ -537,9 +317,6 @@ var itemMapRoyal = {
         "type": "Protector - Women only",
         "description": "Def 325 / Ev 20 / +Reduce Elec dmg (high)"
     },
-    "High Counter": {
-        "skillCard": true
-    },
     "Hinokagutsuchi": {
         "type": "Weapon - Akechi only",
         "description": "Atk 350 / Acc 90 / +Burn (med)"
@@ -556,21 +333,9 @@ var itemMapRoyal = {
         "type": "Accessory",
         "description": "All stats +4 / Regenerate 3"
     },
-    "Hysterical Slap": {
-        "skillCard": true
-    },
-    "Ice Amp": {
-        "skillCard": true
-    },
-    "Ice Boost": {
-        "skillCard": true
-    },
     "Imprisoned Mjolnir": {
         "type": "Weapon - Ryuji only",
         "description": "Atk 324 / Acc 88 / +Elec attacks"
-    },
-    "Inferno": {
-        "skillCard": true
     },
     "Inferno Horns": {
         "type": "Accessory",
@@ -579,9 +344,6 @@ var itemMapRoyal = {
     "Inferno Ring": {
         "type": "Accessory",
         "description": "+Agidyne (Heavy Fire dmg to 1 foe)"
-    },
-    "Insta-Heal": {
-        "skillCard": true
     },
     "Judge End": {
         "type": "Gun - Makoto only",
@@ -603,9 +365,6 @@ var itemMapRoyal = {
         "type": "Accessory",
         "description": "+Psio (Med Psy dmg to 1 foe)"
     },
-    "Kill Rush": {
-        "skillCard": true
-    },
     "King Frost Cape": {
         "type": "Protector - Unisex",
         "description": "Def 260 / Ev 16 / +Reduce Ice dmg (high)"
@@ -622,15 +381,6 @@ var itemMapRoyal = {
         "type": "Accessory",
         "description": "All stats +3 / +Bless Amp"
     },
-    "Kouga": {
-        "skillCard": true
-    },
-    "Kougaon": {
-        "skillCard": true
-    },
-    "Kouha": {
-        "skillCard": true
-    },
     "Kugelbein": {
         "type": "Accessory",
         "description": "+Auto-Maraku"
@@ -643,108 +393,9 @@ var itemMapRoyal = {
         "type": "Gun - Yusuke only",
         "description": "Atk 300 / Acc 75 / Rounds 10 / St +5"
     },
-    "Lucky Punch": {
-        "skillCard": true
-    },
     "Lucky Robe": {
         "type": "Protector - Women only",
         "description": "Def 210 / Ev 18 / Lu +5"
-    },
-    "Lullaby": {
-        "skillCard": true
-    },
-    "Lunge": {
-        "skillCard": true
-    },
-    "Mabufu": {
-        "skillCard": true
-    },
-    "Mabufudyne": {
-        "skillCard": true
-    },
-    "Mabufula": {
-        "skillCard": true
-    },
-    "Maeiga": {
-        "skillCard": true
-    },
-    "Maeigaon": {
-        "skillCard": true
-    },
-    "Maeiha": {
-        "skillCard": true
-    },
-    "Mafrei": {
-        "skillCard": true
-    },
-    "Mafreidyne": {
-        "skillCard": true
-    },
-    "Mafreila": {
-        "skillCard": true
-    },
-    "Magaru": {
-        "skillCard": true
-    },
-    "Magarudyne": {
-        "skillCard": true
-    },
-    "Magarula": {
-        "skillCard": true
-    },
-    "Mahama": {
-        "skillCard": true
-    },
-    "Mahamaon": {
-        "skillCard": true
-    },
-    "Makajama": {
-        "skillCard": true
-    },
-    "Makajamaon": {
-        "skillCard": true
-    },
-    "Makarakarn": {
-        "skillCard": true
-    },
-    "Makouga": {
-        "skillCard": true
-    },
-    "Makougaon": {
-        "skillCard": true
-    },
-    "Makouha": {
-        "skillCard": true
-    },
-    "Mamudo": {
-        "skillCard": true
-    },
-    "Mamudoon": {
-        "skillCard": true
-    },
-    "Mapsi": {
-        "skillCard": true
-    },
-    "Mapsiodyne": {
-        "skillCard": true
-    },
-    "Maragi": {
-        "skillCard": true
-    },
-    "Maragidyne": {
-        "skillCard": true
-    },
-    "Maragion": {
-        "skillCard": true
-    },
-    "Marakukaja": {
-        "skillCard": true
-    },
-    "Marakunda": {
-        "skillCard": true
-    },
-    "Marin Karin": {
-        "skillCard": true
     },
     "Masquerade Ribbon": {
         "type": "Weapon - Ann only",
@@ -754,39 +405,9 @@ var itemMapRoyal = {
         "type": "Weapon - Ann only",
         "description": "Atk 250 / Acc 88 / +Dizzy (low)"
     },
-    "Masukunda": {
-        "skillCard": true
-    },
-    "Matarukaja": {
-        "skillCard": true
-    },
-    "Matarunda": {
-        "skillCard": true
-    },
-    "Mazio": {
-        "skillCard": true
-    },
-    "Maziodyne": {
-        "skillCard": true
-    },
-    "Mazionga": {
-        "skillCard": true
-    },
-    "Media": {
-        "skillCard": true
-    },
-    "Mediarahan": {
-        "skillCard": true
-    },
-    "Mediarama": {
-        "skillCard": true
-    },
     "Megaton Raid Belt": {
         "type": "Accessory",
         "description": "+Megaton Raid (Severe Phys dmg to 1 foe)"
-    },
-    "Megaton Raid": {
-        "skillCard": true
     },
     "Megido Blaster": {
         "type": "Gun - Ryuji only",
@@ -795,21 +416,6 @@ var itemMapRoyal = {
     "Megido Fire": {
         "type": "Gun - Ryuji only",
         "description": "Atk 350 / Acc 85 / Rounds 3 / +Burn (high)"
-    },
-    "Megidola": {
-        "skillCard": true
-    },
-    "Megidolaon": {
-        "skillCard": true
-    },
-    "Memory Blow": {
-        "skillCard": true
-    },
-    "Mind Slice": {
-        "skillCard": true
-    },
-    "Miracle Punch": {
-        "skillCard": true
     },
     "Mirrirmina": {
         "type": "Gun - Makoto only",
@@ -831,18 +437,9 @@ var itemMapRoyal = {
         "type": "Protector - Women only",
         "description": "Def 70 / Ev 30 / +Repel Phys (high)"
     },
-    "Mudo": {
-        "skillCard": true
-    },
-    "Mudoon": {
-        "skillCard": true
-    },
     "Myriad Slash Belt": {
         "type": "Accessory",
         "description": "+Myriad Slashes (Med Phys dmg to 1 foe 2-3 times)"
-    },
-    "Myriad Slashes": {
-        "skillCard": true
     },
     "Mystic Ring": {
         "type": "Accessory",
@@ -860,39 +457,9 @@ var itemMapRoyal = {
         "type": "Gun - Joker only",
         "description": "Atk 350 / Acc 85 / Rounds 8 / All stats +6"
     },
-    "Nocturnal Flash": {
-        "skillCard": true
-    },
     "Nuclear Ring": {
         "type": "Accessory",
         "description": "+Freila (Med. Nuke dmg to 1 foe)"
-    },
-    "Nuke Amp": {
-        "skillCard": true
-    },
-    "Nuke Boost": {
-        "skillCard": true
-    },
-    "Null Bless": {
-        "skillCard": true
-    },
-    "Null Curse": {
-        "skillCard": true
-    },
-    "Null Elec": {
-        "skillCard": true
-    },
-    "Null Fire": {
-        "skillCard": true
-    },
-    "Null Ice": {
-        "skillCard": true
-    },
-    "Null Psy": {
-        "skillCard": true
-    },
-    "Null Wind": {
-        "skillCard": true
     },
     "Official's Robe": {
         "type": "Protector - Men only",
@@ -901,15 +468,6 @@ var itemMapRoyal = {
     "Official's Robe R": {
         "type": "Protector - Men only",
         "description": "Def 295 / Ev 20 / +Evade Curse (high)"
-    },
-    "Ominous Words": {
-        "skillCard": true
-    },
-    "One-shot Kill": {
-        "skillCard": true
-    },
-    "Oni-Kagura": {
-        "skillCard": true
     },
     "Orichalcum": {
         "type": "Accessory",
@@ -926,9 +484,6 @@ var itemMapRoyal = {
     "Orlov R": {
         "type": "Accessory",
         "description": "+High Counter / En +5"
-    },
-    "Panta Rhei": {
-        "skillCard": true
     },
     "Paradise Lost": {
         "type": "Weapon - Joker only",
@@ -958,9 +513,6 @@ var itemMapRoyal = {
         "type": "Gun - Ann only",
         "description": "Atk 135 / Acc 90 / Rounds 12 / +Brainwash (med)"
     },
-    "Power Slash": {
-        "skillCard": true
-    },
     "Prayer Ring": {
         "type": "Accessory",
         "description": "+Kouha (Light Bless dmg to 1 foe)"
@@ -969,18 +521,9 @@ var itemMapRoyal = {
         "type": "Gun - Yusuke only",
         "description": "Atk 350 / Acc 75 / Rounds 10 / Ag +13"
     },
-    "Psio": {
-        "skillCard": true
-    },
-    "Psiodyne": {
-        "skillCard": true
-    },
     "Psy Ring": {
         "type": "Accessory",
         "description": "+Psi (Light Psy dmg to 1 foe)"
-    },
-    "Psycho Force": {
-        "skillCard": true
     },
     "Pumpkin Bomb": {
         "type": "Gun - Ryuji only",
@@ -998,28 +541,13 @@ var itemMapRoyal = {
         "type": "Accessory",
         "description": "Mana Bonus (SP +10%) / All stats +2"
     },
-    "Rakukaja": {
-        "skillCard": true
-    },
-    "Rakunda": {
-        "skillCard": true
-    },
-    "Rampage": {
-        "skillCard": true
-    },
     "Reactor Ring": {
         "type": "Accessory",
         "description": "+Freidyne (Heavy Nuke dmg to 1 foe)"
     },
-    "Rebellion": {
-        "skillCard": true
-    },
     "Rebellion Anklet": {
         "type": "Accessory",
         "description": "+Rebellion (Incr. Critical rate for 1 ally)"
-    },
-    "Recarm": {
-        "skillCard": true
     },
     "Red String R": {
         "type": "Accessory",
@@ -1028,15 +556,6 @@ var itemMapRoyal = {
     "Red String": {
         "type": "Accessory",
         "description": "Lu +10 / +Attack Master (Incr. Attack at start of battle)"
-    },
-    "Regenerate 1": {
-        "skillCard": true
-    },
-    "Regenerate 2": {
-        "skillCard": true
-    },
-    "Regenerate 3": {
-        "skillCard": true
     },
     "Regent": {
         "type": "Accessory",
@@ -1050,43 +569,13 @@ var itemMapRoyal = {
         "type": "Accessory",
         "description": "+Samarecarm (Revive 1 ally with full HP)"
     },
-    "Repel Bless": {
-        "skillCard": true
-    },
-    "Repel Elec": {
-        "skillCard": true
-    },
-    "Repel Ice": {
-        "skillCard": true
-    },
-    "Repel Nuke": {
-        "skillCard": true
-    },
-    "Repel Phys": {
-        "skillCard": true
-    },
-    "Repel Psy": {
-        "skillCard": true
-    },
-    "Repel Wind": {
-        "skillCard": true
-    },
     "Revival Charm": {
         "type": "Accessory",
         "description": "+Recarm (Revive 1 ally with 50% HP)"
     },
-    "Revolution": {
-        "skillCard": true
-    },
     "Revolution Anklet": {
         "type": "Accessory",
         "description": "+Revolution (Increases Critical rate of everyone on field)"
-    },
-    "Riot Gun": {
-        "skillCard": true
-    },
-    "Rising Slash": {
-        "skillCard": true
     },
     "Rising Slash Belt": {
         "type": "Accessory",
@@ -1116,12 +605,6 @@ var itemMapRoyal = {
         "type": "Gun - Kasumi only",
         "description": "Atk 345 / Acc 90 / Rounds 10 / All stats +6"
     },
-    "Salvation": {
-        "skillCard": true
-    },
-    "Samarecarm": {
-        "skillCard": true
-    },
     "Senryou Yakusha": {
         "type": "Weapon - Yusuke only",
         "description": "Atk 130 / Acc 90 / St +5"
@@ -1150,12 +633,6 @@ var itemMapRoyal = {
         "type": "Protector - Unisex",
         "description": "Def 330 / Ev 10 / +Reduce Magic dmg (high)"
     },
-    "Skull Cracker": {
-        "skillCard": true
-    },
-    "Sledgehammer": {
-        "skillCard": true
-    },
     "Snow Queen's Whip": {
         "type": "Weapon - Ann only",
         "description": "Atk 260 / Acc 90 / +Auto-Sukukaja"
@@ -1175,12 +652,6 @@ var itemMapRoyal = {
     "Special Shot Belt": {
         "type": "Accessory",
         "description": "+One-shot Kill (Heavy Gun dmg to area of foes with high Critical)"
-    },
-    "Speed Master": {
-        "skillCard": true
-    },
-    "Spell Master": {
-        "skillCard": true
     },
     "Spiral Aid Charm": {
         "type": "Accessory",
@@ -1302,9 +773,6 @@ var itemMapRoyal = {
         "type": "Accessory",
         "description": "+Magarula (Med. Wind dmg to all foes)"
     },
-    "Stagnant Air": {
-        "skillCard": true
-    },
     "Static Ring": {
         "type": "Accessory",
         "description": "+Zio (Light Elec dmg to 1 foe)"
@@ -1329,22 +797,13 @@ var itemMapRoyal = {
         "type": "Gun - Morgana only",
         "description": "Atk 330 / Acc 90 / Rounds 5 / +Dizzy (high)"
     },
-    "Sukunda": {
-        "skillCard": true
-    },
     "Super Lucky Robe": {
         "type": "Protector - Women only",
         "description": "Def 220 / Ev 18 / Lu +10"
     },
-    "Swift Strike": {
-        "skillCard": true
-    },
     "Swift Strike Belt": {
         "type": "Accessory",
         "description": "+Swift Strike (Miniscule Phys dmg to all foes 2-4 times)"
-    },
-    "Sword Dance": {
-        "skillCard": true
     },
     "Sword Dance Belt": {
         "type": "Accessory",
@@ -1370,37 +829,13 @@ var itemMapRoyal = {
         "type": "Protector - Women only",
         "description": "Def 170 / Ev 12 / +Evade Wind (high)"
     },
-    "Tarukaja": {
-        "skillCard": true
-    },
-    "Tarunda": {
-        "skillCard": true
-    },
-    "Tempest Slash": {
-        "skillCard": true
-    },
-    "Terror Claw": {
-        "skillCard": true
-    },
-    "Tetraja": {
-        "skillCard": true
-    },
-    "Tetrakarn": {
-        "skillCard": true
-    },
     "The Great Thief Stick": {
         "type": "Weapon - Joker only",
         "description": "Atk 150 / Acc 92 / +Random ailment (med)"
     },
-    "Thunder Reign": {
-        "skillCard": true
-    },
     "Thunder Ring": {
         "type": "Accessory",
         "description": "+Ziodyne (Heavy elec dmg to 1 foe)"
-    },
-    "Triple Down": {
-        "skillCard": true
     },
     "Triple Shot Belt": {
         "type": "Accessory",
@@ -1430,15 +865,6 @@ var itemMapRoyal = {
         "type": "Weapon - Makoto only",
         "description": "Atk 305 / Acc 90 / +Random ailment (high)"
     },
-    "Vajra Blast": {
-        "skillCard": true
-    },
-    "Vicious Strike": {
-        "skillCard": true
-    },
-    "Vorpal Blade": {
-        "skillCard": true
-    },
     "Vorpal Blade Belt": {
         "type": "Accessory",
         "description": "+Vorpal Blade (Severe Phys dmg to all foes)"
@@ -1455,12 +881,6 @@ var itemMapRoyal = {
         "type": "Gun - Ann only",
         "description": "Atk 320 / Acc 90 / +Despair (med)"
     },
-    "Wind Amp": {
-        "skillCard": true
-    },
-    "Wind Boost": {
-        "skillCard": true
-    },
     "Wind Ring": {
         "type": "Accessory",
         "description": "+Garula (Med. Wind dmg to 1 foe)"
@@ -1472,14 +892,5 @@ var itemMapRoyal = {
     "Yagrush EX": {
         "type": "Gun - Haru only",
         "description": "Atk 360 / Acc 70 / Rounds 1 / +Shock (high)"
-    },
-    "Zio": {
-        "skillCard": true
-    },
-    "Ziodyne": {
-        "skillCard": true
-    },
-    "Zionga": {
-        "skillCard": true
     }
 };

--- a/data/ItemDataRoyal.ts
+++ b/data/ItemDataRoyal.ts
@@ -1,19 +1,4 @@
 const itemMapRoyal: ItemMap = {
-    "Abysmal Surge": {
-        "skillCard": true,
-    },
-    "Agi": {
-        "skillCard": true,
-    },
-    "Agidyne": {
-        "skillCard": true,
-    },
-    "Agilao": {
-        "skillCard": true,
-    },
-    "Agneyastra": {
-        "skillCard": true,
-    },
     "Aid Charm": {
         "type": "Accessory",
         "description": "+Dia (Small HP recovery for 1 ally)"
@@ -30,9 +15,6 @@ const itemMapRoyal: ItemMap = {
         "type": "Protector - Women only",
         "description": "Def 300 / Ev 18 / +Reduce Elec dmg (high)"
     },
-    "Arms Master": {
-        "skillCard": true
-    },
     "Arsène's Cane": {
         "type": "Weapon - Joker only",
         "description": "Atk 130 / Acc 92 / +Random ailment (low)",
@@ -41,24 +23,9 @@ const itemMapRoyal: ItemMap = {
         "type": "Accessory",
         "description": "+Assault Dive (Heavy Phys dmg to 1 foe)"
     },
-    "Assault Dive": {
-        "skillCard": true,
-    },
     "Atom Ring": {
         "type": "Accessory",
         "description": "+Frei (Light Nuke dmg to 1 foe)"
-    },
-    "Atomic Flare": {
-        "skillCard": true,
-    },
-    "Auto-Maraku": {
-        "skillCard": true,
-    },
-    "Auto-Masaku": {
-        "skillCard": true,
-    },
-    "Auto-Mataru": {
-        "skillCard": true
     },
     "Bear Gloves": {
         "type": "Weapon - Makoto only",
@@ -101,12 +68,6 @@ const itemMapRoyal: ItemMap = {
         "type": "Accessory",
         "description": "+Fire Amp / En +10"
     },
-    "Bless Amp": {
-        "skillCard": true
-    },
-    "Bless Boost": {
-        "skillCard": true
-    },
     "Blessing Ring": {
         "type": "Accessory",
         "description": "+Kouga (Med. Bless dmg to 1 foe)"
@@ -114,9 +75,6 @@ const itemMapRoyal: ItemMap = {
     "Blizzard Ring": {
         "type": "Accessory",
         "description": "+Bufudyne (Heavy Ice dmg to 1 foe)"
-    },
-    "Bloodbath": {
-        "skillCard": true
     },
     "Blood Red Capote": {
         "type": "Protector - Men only",
@@ -126,9 +84,6 @@ const itemMapRoyal: ItemMap = {
         "type": "Protector - Men only",
         "description": "Def 130 / Ev 20 / Ag +6"
     },
-    "Brain Jack": {
-        "skillCard": true
-    },
     "Brain Shot": {
         "type": "Gun - Ann only",
         "description" : "Atk 140 / Acc 84 / Rounds 12 / +Brainwash (med)"
@@ -137,21 +92,9 @@ const itemMapRoyal: ItemMap = {
         "type": "Accessory",
         "description": "+Brave Blade (Colossal Phys dmg to 1 foe)"
     },
-    "Brave Blade": {
-        "skillCard": true
-    },
     "Breeze Ring": {
         "type": "Accessory",
         "description": "+Garu (Light Wind dmg to 1 foe)"
-    },
-    "Bufu": {
-        "skillCard": true
-    },
-    "Bufudyne": {
-        "skillCard": true
-    },
-    "Bufula": {
-        "skillCard": true
     },
     "Cat Buster": {
         "type": "Gun - Morgana only",
@@ -161,9 +104,6 @@ const itemMapRoyal: ItemMap = {
         "type": "Gun - Morgana only",
         "description": "Atk 150 / Acc 90 / Rounds 5 / +Sleep (med)" 
     },
-    "Charge": {
-        "skillCard": true
-    },
     "Claiomh Solais": {
         "type": "Weapon - Morgana only",
         "description": "Atk 315 / Acc 90 / +50 SP"
@@ -171,21 +111,6 @@ const itemMapRoyal: ItemMap = {
     "Claiomh Solais R": {
         "type": "Weapon - Morgana only",
         "description": "Atk 330 / Acc 90 / +50 SP"
-    },
-    "Cleave": {
-        "skillCard": true
-    },
-    "Concentrate": {
-        "skillCard": true
-    },
-    "Cornered Fang": {
-        "skillCard": true
-    },
-    "Counter": {
-        "skillCard": true
-    },
-    "Counterstrike": {
-        "skillCard": true
     },
     "Crystal Skull": {
         "type": "Accessory",
@@ -227,12 +152,6 @@ const itemMapRoyal: ItemMap = {
         "type": "Accessory",
         "description": "+Evade Curse (high) / Ma +8"
     },
-    "Dazzler": {
-        "skillCard": true
-    },
-    "Deadly Fury": {
-        "skillCard": true
-    },
     "Death Contract": {
         "type": "Weapon - Haru only",
         "description": "Atk 190 / Acc 80 / +Despair (low)"
@@ -241,39 +160,9 @@ const itemMapRoyal: ItemMap = {
         "type": "Weapon - Haru only",
         "description": "Atk 200 / Acc 80 / +Despair (med)"
     },
-    "Death Scythe": {
-        "skillCard": true
-    },
-    "Deathbound": {
-        "skillCard": true
-    },
-    "Debilitate": {
-        "skillCard": true
-    },
-    "Dekaja": {
-        "skillCard": true
-    },
-    "Dekunda": {
-        "skillCard": true
-    },
-    "Demonic Decree": {
-        "skillCard": true
-    },
-    "Diamond Dust": {
-        "skillCard": true
-    },
     "Diamond Dust Lily": {
         "type": "Accessory",
         "description": "+Diamond Dust (Severe Ice dmg to 1 foe)"
-    },
-    "Diarahan": {
-        "skillCard": true
-    },
-    "Diarama": {
-        "skillCard": true
-    },
-    "Divine Judgement": {
-        "skillCard": true
     },
     "Divine Ring": {
         "type": "Accessory",
@@ -283,39 +172,9 @@ const itemMapRoyal: ItemMap = {
         "type": "Gun - Akechi only",
         "description": "Atk 330 / Acc 85 / Rounds 5 / All Stats +5"
     },
-    "Dormin Rush": {
-        "skillCard": true
-    },
-    "Dormina": {
-        "skillCard": true
-    },
-    "Double Fangs": {
-        "skillCard": true
-    },
-    "Double Shot": {
-        "skillCard": true
-    },
     "Dragon's Heart": {
         "type": "Accessory",
         "description": "+Psycho Force (Severe Psy dmg to 1 foe)"
-    },
-    "Drain Curse": {
-        "skillCard": true
-    },
-    "Dream Needle": {
-        "skillCard": true
-    },
-    "Eiga": {
-        "skillCard": true
-    },
-    "Eigaon": {
-        "skillCard": true
-    },
-    "Elec Amp": {
-        "skillCard": true
-    },
-    "Elec Boost": {
-        "skillCard": true
     },
     "Ember Ring": {
         "type": "Accessory",
@@ -329,27 +188,9 @@ const itemMapRoyal: ItemMap = {
         "type": "Accessory",
         "description": "En +8 / +Auto-Mataru"
     },
-    "Endure": {
-        "skillCard": true
-    },
-    "Enduring Soul": {
-        "skillCard": true
-    },
     "Energy Charm": {
         "type": "Accessory",
         "description": "+Energy Drop (Cure Confuse/Fear/Despair/Rage/Brainwash for 1 ally)"
-    },
-    "Energy Drop": {
-        "skillCard": true
-    },
-    "Energy Shower": {
-        "skillCard": true
-    },
-    "Evil Smile": {
-        "skillCard": true
-    },
-    "Evil Touch": {
-        "skillCard": true
     },
     "Fairy Hero Armor": {
         "type": "Protector - Men only",
@@ -375,29 +216,13 @@ const itemMapRoyal: ItemMap = {
         "type": "Accessory",
         "description": "+Atomic Flare (Severe Nuke dmg to 1 foe)"
     },
-    "Firm Stance": {
-        "skillCard": true
-    },
-    "Flash Bomb": {
-        "skillCard": true
-    },
     "Fleurs du Mal": {
         "type": "Weapon - Haru only",
         "description": "Atk 325 / Acc 86 / Ma +5 / +Dizzy (high)"
-        
     },
     "Fleurs du Mal R": {
         "type": "Weapon - Haru only",
         "description": "Atk 345 / Acc 86 / Ma +5 / +Dizzy (high)"
-    },
-    "Foul Breath": {
-        "skillCard": true
-    },
-    "Frei": {
-        "skillCard": true
-    },
-    "Freidyne": {
-        "skillCard": true
     },
     "Frost Ace Hood": {
         "type": "Protector - Morgana only",
@@ -411,35 +236,17 @@ const itemMapRoyal: ItemMap = {
         "type": "Accessory",
         "description": "+Bufu (Light Ice dmg to all foes)"
     },
-    "Garu": {
-        "skillCard": true
-    },
-    "Garudyne": {
-        "skillCard": true
-    },
-    "Garula": {
-        "skillCard": true
-    },
     "Gatling Belt": {
         "type": "Accessory",
         "description": "+Gatling Blow (Light Phys dmg 3-4 times to 1 foe)"
-    },
-    "Giant Slice": {
-        "skillCard": true
     },
     "Giant Slice Belt": {
         "type": "Accessory",
         "description": "+Giant Slice (Med Phys dmg to 1 foe, powers up after baton pass)"
     },
-    "Gigantomachia": {
-        "skillCard": true
-    },
     "Gigantomachia Belt": {
         "type": "Accessory",
         "description": "+Gigantomachia (Colossal Phys dmg to all foes)"
-    },
-    "God's Hand": {
-        "skillCard": true
     },
     "God's Hand Belt": {
         "type": "Accessory",
@@ -465,25 +272,13 @@ const itemMapRoyal: ItemMap = {
         "type": "Accessory",
         "description": "Null Brainwash / Ma +8"
     },
-    "Growth 2": {
-        "skillCard": true
-    },
-    "Growth 3": {
-        "skillCard": true
-    },
     "Grudge Ring": {
         "type": "Accessory",
         "description": "+Eiha (Light Curse dmg to 1 foe)"
     },
-    "Gun Amp": {
-        "skillCard": true
-    },
     "Gungnir": {
         "type": "Gun - Ann only",
         "description": "Atk 340 / Acc 90 / Rounds 12 / +Despair (med)"
-    },
-    "Gun Boost": {
-        "skillCard": true
     },
     "Hades Harp": {
         "type": "Accessory",
@@ -497,15 +292,6 @@ const itemMapRoyal: ItemMap = {
         "type": "Accessory",
         "description": "+Hamaon (Bless, med chance of insta-killing 1 foe)"
     },
-    "Hama": {
-        "skillCard": true
-    },
-    "Hamaon": {
-        "skillCard": true
-    },
-    "Headbutt": {
-        "skillCard": true
-    },
     "Headhunter Ladle": {
         "type": "Weapon - Morgana only",
         "description": "Atk 150 / Acc 90 / +Critical rate up (low)"
@@ -513,12 +299,6 @@ const itemMapRoyal: ItemMap = {
     "Headhunter Ladle EX": {
         "type": "Weapon - Morgana only",
         "description": "Atk 150 / Acc 90 / +Critical rate up (med)"
-    },
-    "Heat Riser": {
-        "skillCard": true
-    },
-    "Heat Wave": {
-        "skillCard": true
     },
     "Heaven's Gate": {
         "type": "Gun - Yusuke only",
@@ -536,9 +316,6 @@ const itemMapRoyal: ItemMap = {
         "type": "Protector - Women only",
         "description": "Def 325 / Ev 20 / +Reduce Elec dmg (high)"
     },
-    "High Counter": {
-        "skillCard": true
-    },
     "Hinokagutsuchi": {
         "type": "Weapon - Akechi only",
         "description": "Atk 350 / Acc 90 / +Burn (med)"
@@ -555,21 +332,9 @@ const itemMapRoyal: ItemMap = {
         "type": "Accessory",
         "description": "All stats +4 / Regenerate 3"
     },
-    "Hysterical Slap": {
-        "skillCard": true
-    },
-    "Ice Amp": {
-        "skillCard": true
-    },
-    "Ice Boost": {
-        "skillCard": true
-    },
     "Imprisoned Mjolnir": {
         "type": "Weapon - Ryuji only",
         "description": "Atk 324 / Acc 88 / +Elec attacks"
-    },
-    "Inferno": {
-        "skillCard": true
     },
     "Inferno Horns": {
         "type": "Accessory",
@@ -578,9 +343,6 @@ const itemMapRoyal: ItemMap = {
     "Inferno Ring": {
         "type": "Accessory",
         "description": "+Agidyne (Heavy Fire dmg to 1 foe)"
-    },
-    "Insta-Heal": {
-        "skillCard": true
     },
     "Judge End": {
         "type": "Gun - Makoto only",
@@ -602,9 +364,6 @@ const itemMapRoyal: ItemMap = {
         "type": "Accessory",
         "description": "+Psio (Med Psy dmg to 1 foe)"
     },
-    "Kill Rush": {
-        "skillCard": true
-    },
     "King Frost Cape": {
         "type": "Protector - Unisex",
         "description": "Def 260 / Ev 16 / +Reduce Ice dmg (high)"
@@ -621,15 +380,6 @@ const itemMapRoyal: ItemMap = {
         "type": "Accessory",
         "description": "All stats +3 / +Bless Amp"
     },
-    "Kouga": {
-        "skillCard": true
-    },
-    "Kougaon": {
-        "skillCard": true
-    },
-    "Kouha": {
-        "skillCard": true
-    },
     "Kugelbein": {
         "type": "Accessory",
         "description": "+Auto-Maraku"
@@ -642,108 +392,9 @@ const itemMapRoyal: ItemMap = {
         "type": "Gun - Yusuke only",
         "description": "Atk 300 / Acc 75 / Rounds 10 / St +5"
     },
-    "Lucky Punch": {
-        "skillCard": true
-    },
     "Lucky Robe": {
         "type": "Protector - Women only",
         "description": "Def 210 / Ev 18 / Lu +5"
-    },
-    "Lullaby": {
-        "skillCard": true
-    },
-    "Lunge": {
-        "skillCard": true
-    },
-    "Mabufu": {
-        "skillCard": true
-    },
-    "Mabufudyne": {
-        "skillCard": true
-    },
-    "Mabufula": {
-        "skillCard": true
-    },
-    "Maeiga": {
-        "skillCard": true
-    },
-    "Maeigaon": {
-        "skillCard": true
-    },
-    "Maeiha": {
-        "skillCard": true
-    },
-    "Mafrei": {
-        "skillCard": true
-    },
-    "Mafreidyne": {
-        "skillCard": true
-    },
-    "Mafreila": {
-        "skillCard": true
-    },
-    "Magaru": {
-        "skillCard": true
-    },
-    "Magarudyne": {
-        "skillCard": true
-    },
-    "Magarula": {
-        "skillCard": true
-    },
-    "Mahama": {
-        "skillCard": true
-    },
-    "Mahamaon": {
-        "skillCard": true
-    },
-    "Makajama": {
-        "skillCard": true
-    },
-    "Makajamaon": {
-        "skillCard": true
-    },
-    "Makarakarn": {
-        "skillCard": true
-    },
-    "Makouga": {
-        "skillCard": true
-    },
-    "Makougaon": {
-        "skillCard": true
-    },
-    "Makouha": {
-        "skillCard": true
-    },
-    "Mamudo": {
-        "skillCard": true
-    },
-    "Mamudoon": {
-        "skillCard": true
-    },
-    "Mapsi": {
-        "skillCard": true
-    },
-    "Mapsiodyne": {
-        "skillCard": true
-    },
-    "Maragi": {
-        "skillCard": true
-    },
-    "Maragidyne": {
-        "skillCard": true
-    },
-    "Maragion": {
-        "skillCard": true
-    },
-    "Marakukaja": {
-        "skillCard": true
-    },
-    "Marakunda": {
-        "skillCard": true
-    },
-    "Marin Karin": {
-        "skillCard": true
     },
     "Masquerade Ribbon": {
         "type": "Weapon - Ann only",
@@ -753,39 +404,9 @@ const itemMapRoyal: ItemMap = {
         "type": "Weapon - Ann only",
         "description": "Atk 250 / Acc 88 / +Dizzy (low)"
     },
-    "Masukunda": {
-        "skillCard": true
-    },
-    "Matarukaja": {
-        "skillCard": true
-    },
-    "Matarunda": {
-        "skillCard": true
-    },
-    "Mazio": {
-        "skillCard": true
-    },
-    "Maziodyne": {
-        "skillCard": true
-    },
-    "Mazionga": {
-        "skillCard": true
-    },
-    "Media": {
-        "skillCard": true
-    },
-    "Mediarahan": {
-        "skillCard": true
-    },
-    "Mediarama": {
-        "skillCard": true
-    },
     "Megaton Raid Belt": {
         "type": "Accessory",
         "description": "+Megaton Raid (Severe Phys dmg to 1 foe)"
-    },
-    "Megaton Raid": {
-        "skillCard": true
     },
     "Megido Blaster": {
         "type": "Gun - Ryuji only",
@@ -794,21 +415,6 @@ const itemMapRoyal: ItemMap = {
     "Megido Fire": {
         "type": "Gun - Ryuji only",
         "description": "Atk 350 / Acc 85 / Rounds 3 / +Burn (high)"
-    },
-    "Megidola": {
-        "skillCard": true
-    },
-    "Megidolaon": {
-        "skillCard": true
-    },
-    "Memory Blow": {
-        "skillCard": true
-    },
-    "Mind Slice": {
-        "skillCard": true
-    },
-    "Miracle Punch": {
-        "skillCard": true
     },
     "Mirrirmina": {
         "type": "Gun - Makoto only",
@@ -830,18 +436,9 @@ const itemMapRoyal: ItemMap = {
         "type": "Protector - Women only",
         "description": "Def 70 / Ev 30 / +Repel Phys (high)"
     },
-    "Mudo": {
-        "skillCard": true
-    },
-    "Mudoon": {
-        "skillCard": true
-    },
     "Myriad Slash Belt": {
         "type": "Accessory",
         "description": "+Myriad Slashes (Med Phys dmg to 1 foe 2-3 times)"
-    },
-    "Myriad Slashes": {
-        "skillCard": true
     },
     "Mystic Ring": {
         "type": "Accessory",
@@ -859,39 +456,9 @@ const itemMapRoyal: ItemMap = {
         "type": "Gun - Joker only",
         "description": "Atk 350 / Acc 85 / Rounds 8 / All stats +6"
     },
-    "Nocturnal Flash": {
-        "skillCard": true
-    },
     "Nuclear Ring": {
         "type": "Accessory",
         "description": "+Freila (Med. Nuke dmg to 1 foe)"
-    },
-    "Nuke Amp": {
-        "skillCard": true
-    },
-    "Nuke Boost": {
-        "skillCard": true
-    },
-    "Null Bless": {
-        "skillCard": true
-    },
-    "Null Curse": {
-        "skillCard": true
-    },
-    "Null Elec": {
-        "skillCard": true
-    },
-    "Null Fire": {
-        "skillCard": true
-    },
-    "Null Ice": {
-        "skillCard": true
-    },
-    "Null Psy": {
-        "skillCard": true
-    },
-    "Null Wind": {
-        "skillCard": true
     },
     "Official's Robe": {
         "type": "Protector - Men only",
@@ -900,15 +467,6 @@ const itemMapRoyal: ItemMap = {
     "Official's Robe R": {
         "type": "Protector - Men only",
         "description": "Def 295 / Ev 20 / +Evade Curse (high)"
-    },
-    "Ominous Words": {
-        "skillCard": true
-    },
-    "One-shot Kill": {
-        "skillCard": true
-    },
-    "Oni-Kagura": {
-        "skillCard": true
     },
     "Orichalcum": {
         "type": "Accessory",
@@ -925,9 +483,6 @@ const itemMapRoyal: ItemMap = {
     "Orlov R": {
         "type": "Accessory",
         "description": "+High Counter / En +5"
-    },
-    "Panta Rhei": {
-        "skillCard": true
     },
     "Paradise Lost": {
         "type": "Weapon - Joker only",
@@ -957,9 +512,6 @@ const itemMapRoyal: ItemMap = {
         "type": "Gun - Ann only",
         "description": "Atk 135 / Acc 90 / Rounds 12 / +Brainwash (med)"
     },
-    "Power Slash": {
-        "skillCard": true
-    },
     "Prayer Ring": {
         "type": "Accessory",
         "description": "+Kouha (Light Bless dmg to 1 foe)"
@@ -968,18 +520,9 @@ const itemMapRoyal: ItemMap = {
         "type": "Gun - Yusuke only",
         "description": "Atk 350 / Acc 75 / Rounds 10 / Ag +13"
     },
-    "Psio": {
-        "skillCard": true
-    },
-    "Psiodyne": {
-        "skillCard": true
-    },
     "Psy Ring": {
         "type": "Accessory",
         "description": "+Psi (Light Psy dmg to 1 foe)"
-    },
-    "Psycho Force": {
-        "skillCard": true
     },
     "Pumpkin Bomb": {
         "type": "Gun - Ryuji only",
@@ -997,28 +540,13 @@ const itemMapRoyal: ItemMap = {
         "type": "Accessory",
         "description": "Mana Bonus (SP +10%) / All stats +2"
     },
-    "Rakukaja": {
-        "skillCard": true
-    },
-    "Rakunda": {
-        "skillCard": true
-    },
-    "Rampage": {
-        "skillCard": true
-    },
     "Reactor Ring": {
         "type": "Accessory",
         "description": "+Freidyne (Heavy Nuke dmg to 1 foe)"
     },
-    "Rebellion": {
-        "skillCard": true
-    },
     "Rebellion Anklet": {
         "type": "Accessory",
         "description": "+Rebellion (Incr. Critical rate for 1 ally)"
-    },
-    "Recarm": {
-        "skillCard": true
     },
     "Red String R": {
         "type": "Accessory",
@@ -1027,15 +555,6 @@ const itemMapRoyal: ItemMap = {
     "Red String": {
         "type": "Accessory",
         "description": "Lu +10 / +Attack Master (Incr. Attack at start of battle)"
-    },
-    "Regenerate 1": {
-        "skillCard": true
-    },
-    "Regenerate 2": {
-        "skillCard": true
-    },
-    "Regenerate 3": {
-        "skillCard": true
     },
     "Regent": {
         "type": "Accessory",
@@ -1049,43 +568,13 @@ const itemMapRoyal: ItemMap = {
         "type": "Accessory",
         "description": "+Samarecarm (Revive 1 ally with full HP)"
     },
-    "Repel Bless": {
-        "skillCard": true
-    },
-    "Repel Elec": {
-        "skillCard": true
-    },
-    "Repel Ice": {
-        "skillCard": true
-    },
-    "Repel Nuke": {
-        "skillCard": true
-    },
-    "Repel Phys": {
-        "skillCard": true
-    },
-    "Repel Psy": {
-        "skillCard": true
-    },
-    "Repel Wind": {
-        "skillCard": true
-    },
     "Revival Charm": {
         "type": "Accessory",
         "description": "+Recarm (Revive 1 ally with 50% HP)"
     },
-    "Revolution": {
-        "skillCard": true
-    },
     "Revolution Anklet": {
         "type": "Accessory",
         "description": "+Revolution (Increases Critical rate of everyone on field)"
-    },
-    "Riot Gun": {
-        "skillCard": true
-    },
-    "Rising Slash": {
-        "skillCard": true
     },
     "Rising Slash Belt": {
         "type": "Accessory",
@@ -1115,12 +604,6 @@ const itemMapRoyal: ItemMap = {
         "type": "Gun - Kasumi only",
         "description": "Atk 345 / Acc 90 / Rounds 10 / All stats +6"
     },
-    "Salvation": {
-        "skillCard": true
-    },
-    "Samarecarm": {
-        "skillCard": true
-    },
     "Senryou Yakusha": {
         "type": "Weapon - Yusuke only",
         "description": "Atk 130 / Acc 90 / St +5"
@@ -1149,12 +632,6 @@ const itemMapRoyal: ItemMap = {
         "type": "Protector - Unisex",
         "description": "Def 330 / Ev 10 / +Reduce Magic dmg (high)"
     },
-    "Skull Cracker": {
-        "skillCard": true
-    },
-    "Sledgehammer": {
-        "skillCard": true
-    },
     "Snow Queen's Whip": {
         "type": "Weapon - Ann only",
         "description": "Atk 260 / Acc 90 / +Auto-Sukukaja"
@@ -1174,12 +651,6 @@ const itemMapRoyal: ItemMap = {
     "Special Shot Belt": {
         "type": "Accessory",
         "description": "+One-shot Kill (Heavy Gun dmg to area of foes with high Critical)"
-    },
-    "Speed Master": {
-        "skillCard": true
-    },
-    "Spell Master": {
-        "skillCard": true
     },
     "Spiral Aid Charm": {
         "type": "Accessory",
@@ -1301,9 +772,6 @@ const itemMapRoyal: ItemMap = {
         "type": "Accessory",
         "description": "+Magarula (Med. Wind dmg to all foes)"
     },
-    "Stagnant Air": {
-        "skillCard": true
-    },
     "Static Ring": {
         "type": "Accessory",
         "description": "+Zio (Light Elec dmg to 1 foe)"
@@ -1328,22 +796,13 @@ const itemMapRoyal: ItemMap = {
         "type": "Gun - Morgana only",
         "description": "Atk 330 / Acc 90 / Rounds 5 / +Dizzy (high)"
     },
-    "Sukunda": {
-        "skillCard": true
-    },
     "Super Lucky Robe": {
         "type": "Protector - Women only",
         "description": "Def 220 / Ev 18 / Lu +10"
     },
-    "Swift Strike": {
-        "skillCard": true
-    },
     "Swift Strike Belt": {
         "type": "Accessory",
         "description": "+Swift Strike (Miniscule Phys dmg to all foes 2-4 times)"
-    },
-    "Sword Dance": {
-        "skillCard": true
     },
     "Sword Dance Belt": {
         "type": "Accessory",
@@ -1369,37 +828,13 @@ const itemMapRoyal: ItemMap = {
         "type": "Protector - Women only",
         "description": "Def 170 / Ev 12 / +Evade Wind (high)"
     },
-    "Tarukaja": {
-        "skillCard": true
-    },
-    "Tarunda": {
-        "skillCard": true
-    },
-    "Tempest Slash": {
-        "skillCard": true
-    },
-    "Terror Claw": {
-        "skillCard": true
-    },
-    "Tetraja": {
-        "skillCard": true
-    },
-    "Tetrakarn": {
-        "skillCard": true
-    },
     "The Great Thief Stick": {
         "type": "Weapon - Joker only",
         "description": "Atk 150 / Acc 92 / +Random ailment (med)"
     },
-    "Thunder Reign": {
-        "skillCard": true
-    },
     "Thunder Ring": {
         "type": "Accessory",
         "description": "+Ziodyne (Heavy elec dmg to 1 foe)"
-    },
-    "Triple Down": {
-        "skillCard": true
     },
     "Triple Shot Belt": {
         "type": "Accessory",
@@ -1429,15 +864,6 @@ const itemMapRoyal: ItemMap = {
         "type": "Weapon - Makoto only",
         "description": "Atk 305 / Acc 90 / +Random ailment (high)"
     },
-    "Vajra Blast": {
-        "skillCard": true
-    },
-    "Vicious Strike": {
-        "skillCard": true
-    },
-    "Vorpal Blade": {
-        "skillCard": true
-    },
     "Vorpal Blade Belt": {
         "type": "Accessory",
         "description": "+Vorpal Blade (Severe Phys dmg to all foes)"
@@ -1454,12 +880,6 @@ const itemMapRoyal: ItemMap = {
         "type": "Gun - Ann only",
         "description": "Atk 320 / Acc 90 / +Despair (med)"
     },
-    "Wind Amp": {
-        "skillCard": true
-    },
-    "Wind Boost": {
-        "skillCard": true
-    },
     "Wind Ring": {
         "type": "Accessory",
         "description": "+Garula (Med. Wind dmg to 1 foe)"
@@ -1471,14 +891,5 @@ const itemMapRoyal: ItemMap = {
     "Yagrush EX": {
         "type": "Gun - Haru only",
         "description": "Atk 360 / Acc 70 / Rounds 1 / +Shock (high)"
-    },
-    "Zio": {
-        "skillCard": true
-    },
-    "Ziodyne": {
-        "skillCard": true
-    },
-    "Zionga": {
-        "skillCard": true
     }
 };

--- a/data/PersonaData.js
+++ b/data/PersonaData.js
@@ -1,6 +1,7 @@
 // derived partly from https://github.com/aqiu384/aqiu384.github.io/blob/master/p5-tool/js/full_compendium.js
 var personaMap = {
     "Abaddon": {
+        "inherits": "Curse",
         "item": "Makarakarn",
         "skillCard": true,
         "arcana": "Judgement",
@@ -17,6 +18,7 @@ var personaMap = {
         }
     },
     "Agathion": {
+        "inherits": "Electric",
         "item": "Zio",
         "skillCard": true,
         "arcana": "Chariot",
@@ -24,9 +26,12 @@ var personaMap = {
         "stats": [3, 4, 5, 7, 3],
         "elems": ["-", "rs", "-", "-", "rs", "wk", "-", "-", "-", "-"],
         "skills": {"Baisudi": 0, "Dia": 0, "Dodge Elec": 8, "Lunge": 4, "Rakukaja": 6, "Zio": 0},
-        "personality": "Timid"
+        "personality": "Timid",
+        "area": "Aiyatsbus",
+        "floor": "L1"
     },
     "Alice": {
+        "inherits": "Curse",
         "item": "Mamudoon",
         "skillCard": true,
         "arcana": "Death",
@@ -46,14 +51,18 @@ var personaMap = {
         "max": true
     },
     "Ame-no-Uzume": {
+        "inherits": "Almighty",
         "item": "Senryou Yakusha",
         "arcana": "Lovers",
         "level": 29,
         "stats": [15, 22, 19, 20, 18],
         "elems": ["-", "-", "ab", "-", "-", "-", "wk", "-", "-", "-"],
-        "skills": {"Bufula": 0, "Diarama": 0, "Divine Grace": 32, "Mazio": 0, "Shock Boost": 34, "Tentarafoo": 31}
+        "skills": {"Bufula": 0, "Diarama": 0, "Divine Grace": 32, "Mazio": 0, "Shock Boost": 34, "Tentarafoo": 31},
+        "area": "Chemdah",
+        "floor": "L6 & 7"
     },
     "Ananta": {
+        "inherits": "Nuclear",
         "item": "Hua Khon",
         "arcana": "Star",
         "level": 43,
@@ -71,6 +80,7 @@ var personaMap = {
         }
     },
     "Andras": {
+        "inherits": "Ice",
         "item": "Ice Break",
         "skillCard": true,
         "arcana": "Devil",
@@ -78,9 +88,12 @@ var personaMap = {
         "stats": [5, 9, 7, 10, 6],
         "elems": ["-", "wk", "wk", "rs", "-", "-", "-", "-", "-", "-"],
         "skills": {"Apt Pupil": 13, "Bufu": 0, "Ice Break": 15, "Mabufu": 14, "Rakunda": 0, "Tarukaja": 11},
-        "personality": "Timid"
+        "personality": "Timid",
+        "area": "Aiyatsbus",
+        "floor": "L5 & 6"
     },
     "Angel": {
+        "inherits": "Bless",
         "item": "Baisudi",
         "skillCard": true,
         "arcana": "Justice",
@@ -88,9 +101,12 @@ var personaMap = {
         "stats": [7, 9, 9, 9, 9],
         "elems": ["-", "-", "-", "-", "rs", "-", "-", "-", "nu", "wk"],
         "skills": {"Baisudi": 14, "Dazzler": 0, "Dekunda": 17, "Dia": 0, "Dodge Curse": 15, "Hama": 0, "Kouha": 13},
-        "personality": "Irritable"
+        "personality": "Irritable",
+        "area": "Aiyatsbus / Kaitul",
+        "floor": "L5 & 6 / L1-4"
     },
     "Anubis": {
+        "inherits": "Almighty",
         "item": "Makouha",
         "skillCard": true,
         "arcana": "Judgement",
@@ -106,9 +122,12 @@ var personaMap = {
             "Null Fear": 39,
             "Resist Bless": 41
         },
-        "personality": "Gloomy"
+        "personality": "Gloomy",
+        "area": "Akzeriyyuth",
+        "floor": "L10 & 11"
     },
     "Anzu": {
+        "inherits": "Wind",
         "item": "Dekaja",
         "skillCard": true,
         "arcana": "Hierophant",
@@ -116,9 +135,12 @@ var personaMap = {
         "stats": [14, 18, 15, 21, 14],
         "elems": ["-", "wk", "-", "-", "rs", "rp", "-", "wk", "-", "-"],
         "skills": {"Assault Dive": 27, "Dekaja": 28, "Garula": 0, "Masukukaja": 0, "Null Forget": 29, "Wind Break": 0},
-        "personality": "Irritable"
+        "personality": "Irritable",
+        "area": "Akzeriyyuth",
+        "floor": "L1-3, 5-7, 9-11"
     },
     "Apsaras": {
+        "inherits": "Ice",
         "item": "Freeze Boost",
         "skillCard": true,
         "arcana": "Priestess",
@@ -126,9 +148,12 @@ var personaMap = {
         "stats": [7, 11, 6, 10, 6],
         "elems": ["-", "-", "-", "rs", "wk", "-", "-", "-", "-", "-"],
         "skills": {"Bufu": 0, "Elec Wall": 14, "Ice Wall": 0, "Media": 13, "Rebellion": 0, "Wind Wall": 16},
-        "personality": "Upbeat"
+        "personality": "Upbeat",
+        "area": "Chemdah",
+        "floor": "L1-4"
     },
     "Ara Mitama": {
+        "inherits": "Nuclear",
         "item": "Freila",
         "skillCard": true,
         "arcana": "Chariot",
@@ -138,6 +163,7 @@ var personaMap = {
         "skills": {"Freila": 0, "Marakunda": 33, "Miracle Punch": 0, "Taunt": 0, "Rage Boost": 35, "Rebellion": 32}
     },
     "Arahabaki": {
+        "inherits": "Ailment",
         "item": "Tapsuan",
         "arcana": "Hermit",
         "level": 35,
@@ -151,9 +177,12 @@ var personaMap = {
             "Null Brainwash": 0,
             "Spirit Drain": 37
         },
-        "personality": "Gloomy"
+        "personality": "Gloomy",
+        "area": "Adyeshach",
+        "floor": "L1-4, 6-8, 10"
     },
     "Archangel": {
+        "inherits": "Bless",
         "item": "Dazzler",
         "skillCard": true,
         "arcana": "Justice",
@@ -161,9 +190,12 @@ var personaMap = {
         "stats": [13, 10, 13, 12, 7],
         "elems": ["-", "-", "-", "-", "wk", "-", "-", "-", "nu", "wk"],
         "skills": {"Dazzler": 0, "Hama": 0, "Vajra Blast": 21, "Makouha": 19, "Psi": 0, "Rebellion": 18},
-        "personality": "Irritable"
+        "personality": "Irritable",
+        "area": "Aiyatsbus",
+        "floor": "L5 & 6"
     },
     "Ardha": {
+        "inherits": "Almighty",
         "item": "Agneyastra",
         "skillCard": true,
         "arcana": "Temperance",
@@ -183,6 +215,7 @@ var personaMap = {
         "max": true
     },
     "Ariadne": {
+        "inherits": "Almighty",
         "item": "Red Yarn Ball",
         "arcana": "Fortune",
         "level": 30,
@@ -200,6 +233,7 @@ var personaMap = {
         "dlc": true
     },
     "Ariadne Picaro": {
+        "inherits": "Almighty",
         "item": "Auto-Mataru",
         "skillCard": true,
         "arcana": "Fortune",
@@ -218,6 +252,7 @@ var personaMap = {
         "dlc": true
     },
     "Arsène": {
+        "inherits": "Curse",
         "item": "Arsène's Cane",
         "arcana": "Fool",
         "level": 1,
@@ -226,6 +261,7 @@ var personaMap = {
         "skills": {"Cleave": 2, "Adverse Resolve": 7, "Dream Needle": 5, "Eiha": 1, "Sukunda": 4}
     },
     "Asterius": {
+        "inherits": "Almighty",
         "item": "Thunder Horns",
         "arcana": "Fortune",
         "level": 56,
@@ -243,6 +279,7 @@ var personaMap = {
         "dlc": true
     },
     "Asterius Picaro": {
+        "inherits": "Almighty",
         "item": "Gigantomachia",
         "skillCard": true,
         "arcana": "Fortune",
@@ -261,6 +298,7 @@ var personaMap = {
         "dlc": true
     },
     "Asura-Ou": {
+        "inherits": "Nuclear",
         "item": "Vajra",
         "arcana": "Sun",
         "level": 76,
@@ -279,6 +317,7 @@ var personaMap = {
         "max": true
     },
     "Atropos": {
+        "inherits": "Electric",
         "item": "Mazionga",
         "skillCard": true,
         "arcana": "Fortune",
@@ -296,6 +335,7 @@ var personaMap = {
         }
     },
     "Attis": {
+        "inherits": "Fire",
         "item": "Enduring Soul",
         "skillCard": true,
         "arcana": "Hanged Man",
@@ -314,6 +354,7 @@ var personaMap = {
         "max": true
     },
     "Baal": {
+        "inherits": "Wind",
         "item": "Yagrush",
         "arcana": "Emperor",
         "level": 75,
@@ -330,6 +371,7 @@ var personaMap = {
         }
     },
     "Baphomet": {
+        "inherits": "Almighty",
         "item": "Shock Boost",
         "skillCard": true,
         "arcana": "Devil",
@@ -344,9 +386,12 @@ var personaMap = {
             "Freeze Boost": 63,
             "Shock Boost": 62,
             "Ziodyne": 61
-        }
+        },
+        "area": "Sheriruth",
+        "floor": "L13 (after Palace 7)"
     },
     "Barong": {
+        "inherits": "Electric",
         "item": "Invigorate 2",
         "skillCard": true,
         "arcana": "Emperor",
@@ -360,9 +405,12 @@ var personaMap = {
             "Null Elec": 55,
             "Wage War": 0,
             "Ziodyne": 0
-        }
+        },
+        "area": "Sheriruth",
+        "floor": "L11 & 12 (after Palace 7)"
     },
     "Beelzebub": {
+        "inherits": "Curse",
         "item": "Fleur du Mal",
         "arcana": "Devil",
         "level": 84,
@@ -381,6 +429,7 @@ var personaMap = {
         "max": true
     },
     "Belial": {
+        "inherits": "Curse",
         "item": "Maragion",
         "skillCard": true,
         "arcana": "Devil",
@@ -398,6 +447,7 @@ var personaMap = {
         }
     },
     "Belphegor": {
+        "inherits": "Ice",
         "item": "Mabufula",
         "skillCard": true,
         "arcana": "Tower",
@@ -405,9 +455,12 @@ var personaMap = {
         "stats": [25, 27, 24, 23, 19],
         "elems": ["-", "-", "wk", "rs", "rs", "-", "-", "rs", "-", "rp"],
         "skills": {"Bufula": 0, "Dodge Fire": 0, "Ice Break": 39, "Mabufula": 41, "Concentrate": 44, "Null Rage": 38},
-        "personality": "Irritable"
+        "personality": "Irritable",
+        "area": "Adyeshach",
+        "floor": "L6-8, 10"
     },
     "Berith": {
+        "inherits": "Physical",
         "item": "Cleave",
         "skillCard": true,
         "arcana": "Hierophant",
@@ -415,9 +468,12 @@ var personaMap = {
         "stats": [8, 6, 7, 8, 5],
         "elems": ["-", "nu", "rs", "wk", "-", "-", "-", "-", "-", "-"],
         "skills": {"Cleave": 0, "Dodge Fire": 11, "Double Fangs": 10, "Rakukaja": 0, "Sledgehammer": 13},
-        "personality": "Irritable"
+        "personality": "Irritable",
+        "area": "Aiyatsbus",
+        "floor": "L5 & 6"
     },
     "Bicorn": {
+        "inherits": "Wind",
         "item": "Garu",
         "skillCard": true,
         "arcana": "Hermit",
@@ -425,9 +481,12 @@ var personaMap = {
         "stats": [5, 3, 3, 5, 3],
         "elems": ["-", "-", "-", "-", "wk", "-", "-", "-", "-", "rs"],
         "skills": {"Apt Pupil": 8, "Garu": 6, "Ice Wall": 7, "Lunge": 0, "Tarunda": 0},
-        "personality": "Irritable"
+        "personality": "Irritable",
+        "area": "Aiyatsbus",
+        "floor": "L1 & 2"
     },
     "Bishamonten": {
+        "inherits": "Nuclear",
         "item": "Mafreidyne",
         "skillCard": true,
         "arcana": "Hierophant",
@@ -445,6 +504,7 @@ var personaMap = {
         }
     },
     "Black Frost": {
+        "inherits": "Almighty",
         "item": "Naraka Whip",
         "arcana": "Fool",
         "level": 67,
@@ -462,6 +522,7 @@ var personaMap = {
         "note": "Request \"One Who Bullies Bullies\" must be cleared"
     },
     "Black Ooze": {
+        "inherits": "Curse",
         "item": "Stagnant Air",
         "skillCard": true,
         "arcana": "Moon",
@@ -477,9 +538,12 @@ var personaMap = {
             "Matarunda": 0,
             "Stagnant Air": 0
         },
-        "personality": "Irritable"
+        "personality": "Irritable",
+        "area": "Adyeshach",
+        "floor": "L1-4, 6"
     },
     "Black Rider": {
+        "inherits": "Curse",
         "item": "Bad Beat",
         "skillCard": true,
         "arcana": "Tower",
@@ -497,6 +561,7 @@ var personaMap = {
         }
     },
     "Bugs": {
+        "inherits": "Almighty",
         "item": "Bear Gloves",
         "arcana": "Fool",
         "level": 49,
@@ -515,6 +580,7 @@ var personaMap = {
         "note": "Request \"The Lovesick Cyberstalking Girl\" must be cleared"
     },
     "Byakko": {
+        "inherits": "Ice",
         "item": "Swift Strike",
         "skillCard": true,
         "arcana": "Temperance",
@@ -532,6 +598,7 @@ var personaMap = {
         }
     },
     "Cerberus": {
+        "inherits": "Fire",
         "item": "Agidyne",
         "skillCard": true,
         "arcana": "Chariot",
@@ -546,9 +613,12 @@ var personaMap = {
             "Rebellion": 56,
             "Regenerate 2": 58
         },
-        "personality": "Unknown"
+        "personality": "Unknown",
+        "area": "Sheriruth",
+        "floor": "L7-9 (after Palace 7)"
     },
     "Chernobog": {
+        "inherits": "Ailment",
         "item": "Deadly Fury",
         "skillCard": true,
         "arcana": "Death",
@@ -566,6 +636,7 @@ var personaMap = {
         }
     },
     "Chi You": {
+        "inherits": "Psy",
         "item": "Arms Master",
         "skillCard": true,
         "arcana": "Chariot",
@@ -585,6 +656,7 @@ var personaMap = {
         "max": true
     },
     "Choronzon": {
+        "inherits": "Curse",
         "item": "Maeiha",
         "skillCard": true,
         "arcana": "Magician",
@@ -601,9 +673,12 @@ var personaMap = {
             "Rainy Play": 33,
             "Rampage": 0
         },
-        "personality": "Timid"
+        "personality": "Timid",
+        "area": "Kaitul",
+        "floor": "L1-4"
     },
     "Clotho": {
+        "inherits": "Healing",
         "item": "Invigorate 1",
         "skillCard": true,
         "arcana": "Fortune",
@@ -636,9 +711,12 @@ var personaMap = {
             "Maragidyne": 0,
             "Maziodyne": 0
         },
-        "rare": true
+        "rare": true,
+        "area": "Sheriruth",
+        "floor": "L7-9. 11-13 (after Palace 7)"
     },
     "Cu Chulainn": {
+        "inherits": "Almighty",
         "item": "Charge",
         "skillCard": true,
         "arcana": "Star",
@@ -656,6 +734,7 @@ var personaMap = {
         }
     },
     "Cybele": {
+        "inherits": "Healing",
         "item": "Sabazios",
         "arcana": "Priestess",
         "level": 73,
@@ -673,6 +752,7 @@ var personaMap = {
         "max": true
     },
     "Daisoujou": {
+        "inherits": "Bless",
         "item": "Makouga",
         "skillCard": true,
         "arcana": "Hierophant",
@@ -690,6 +770,7 @@ var personaMap = {
         }
     },
     "Dakini": {
+        "inherits": "Physical",
         "item": "Deathbound",
         "skillCard": true,
         "arcana": "Empress",
@@ -705,9 +786,12 @@ var personaMap = {
             "Rising Slash": 0,
             "Rebellion": 54
         },
-        "personality": "Unknown"
+        "personality": "Unknown",
+        "area": "Sheriruth",
+        "floor": "L7-9 (after Palace 7)"
     },
     "Decarabia": {
+        "inherits": "Fire",
         "item": "Fire Boost",
         "skillCard": true,
         "arcana": "Fool",
@@ -723,9 +807,12 @@ var personaMap = {
             "Tetrakarn": 38,
             "Ominous Words": 0
         },
-        "personality": "Gloomy"
+        "personality": "Gloomy",
+        "area": "Adyeshach",
+        "floor": "L3, 4, 6-8"
     },
     "Dionysus": {
+        "inherits": "Psy",
         "item": "Thermopylae",
         "skillCard": true,
         "arcana": "Fool",
@@ -743,6 +830,7 @@ var personaMap = {
         }
     },
     "Dominion": {
+        "inherits": "Bless",
         "item": "Makougaon",
         "skillCard": true,
         "arcana": "Justice",
@@ -761,6 +849,7 @@ var personaMap = {
         "personality": "Unknown"
     },
     "Eligor": {
+        "inherits": "Fire",
         "item": "Tarukaja",
         "skillCard": true,
         "arcana": "Emperor",
@@ -775,7 +864,9 @@ var personaMap = {
             "Sukunda": 19,
             "Tarukaja": 0
         },
-        "personality": "Unknown"
+        "personality": "Unknown",
+        "area": "Chemdah",
+        "floor": "L3 & 4"
     },
     "Emperor's Amulet": {
         "item": "Emperor's Amulet",
@@ -793,9 +884,12 @@ var personaMap = {
             "Psiodyne": 0,
             "Ziodyne": 0
         },
-        "rare": true
+        "rare": true,
+        "area": "Sheriruth",
+        "floor": "L7-9, 11-13 (after Palace 7)"
     },
     "Phoenix": {
+        "inherits": "Nuclear",
         "item": "Nuke Boost",
         "skillCard": true,
         "arcana": "Hierophant",
@@ -805,6 +899,7 @@ var personaMap = {
         "skills": {"Diarama": 23, "Dream Needle": 0, "Freila": 0, "Nuke Boost": 27, "Recarm": 25}
     },
     "Flauros": {
+        "inherits": "Ailment",
         "item": "Shackles",
         "arcana": "Devil",
         "level": 25,
@@ -823,6 +918,7 @@ var personaMap = {
         "note": "Needs Strength cooperation rank 1 to be fused"
     },
     "Forneus": {
+        "inherits": "Psy",
         "item": "Masukunda",
         "skillCard": true,
         "arcana": "Hierophant",
@@ -838,9 +934,12 @@ var personaMap = {
             "Stagnant Air": 66,
             "Survival Trick": 65
         },
-        "personality": "Unknown"
+        "personality": "Unknown",
+        "area": "Sheriruth",
+        "floor": "L12 & 13 (after Palace 7)"
     },
     "Fortuna": {
+        "inherits": "Wind",
         "item": "Fast Heal",
         "skillCard": true,
         "arcana": "Fortune",
@@ -858,6 +957,7 @@ var personaMap = {
         }
     },
     "Futsunushi": {
+        "inherits": "Physical",
         "item": "Brave Blade",
         "skillCard": true,
         "arcana": "Magician",
@@ -877,6 +977,7 @@ var personaMap = {
         "max": true
     },
     "Fuu-Ki": {
+        "inherits": "Wind",
         "item": "Wind Boost",
         "skillCard": true,
         "arcana": "Star",
@@ -884,9 +985,12 @@ var personaMap = {
         "stats": [14, 17, 16, 15, 14],
         "elems": ["-", "-", "-", "-", "wk", "ab", "-", "-", "-", "-"],
         "skills": {"Dodge Wind": 26, "Garula": 0, "Resist Psy": 27, "Tarukaja": 0, "Tetra Break": 0, "Wind Boost": 25},
-        "personality": "Unknown"
+        "personality": "Unknown",
+        "area": "Kaitul",
+        "floor": "L8 & 9"
     },
     "Gabriel": {
+        "inherits": "Almighty",
         "item": "Mabufudyne",
         "skillCard": true,
         "arcana": "Temperance",
@@ -905,6 +1009,7 @@ var personaMap = {
         }
     },
     "Ganesha": {
+        "inherits": "Ailment",
         "item": "Miracle Punch",
         "skillCard": true,
         "arcana": "Sun",
@@ -920,9 +1025,12 @@ var personaMap = {
             "Rebellion": 0,
             "Tetraja": 55
         },
-        "personality": "Unknown"
+        "personality": "Unknown",
+        "area": "Sheriruth",
+        "floor": "L5, 7-9 (before Palace 7) / L3 & 4 (after Palace 7)"
     },
     "Garuda": {
+        "inherits": "Wind",
         "item": "Wind Amp",
         "skillCard": true,
         "arcana": "Star",
@@ -938,9 +1046,12 @@ var personaMap = {
             "Masukukaja": 54,
             "Wind Amp": 59
         },
-        "personality": "Unknown"
+        "personality": "Unknown",
+        "area": "Sheriruth",
+        "floor": "L12 (after Palace 7)"
     },
     "Genbu": {
+        "inherits": "Ice",
         "item": "Patra",
         "skillCard": true,
         "arcana": "Temperance",
@@ -950,6 +1061,7 @@ var personaMap = {
         "skills": {"Bufu": 0, "Defense Master": 12, "Mabufu": 10, "Patra": 8, "Rakunda": 0, "Resist Forget": 11}
     },
     "Girimehkala": {
+        "inherits": "Ailment",
         "item": "Marakunda",
         "skillCard": true,
         "arcana": "Moon",
@@ -957,9 +1069,12 @@ var personaMap = {
         "stats": [36, 24, 32, 32, 15],
         "elems": ["rp", "rp", "rs", "-", "-", "-", "-", "-", "wk", "nu"],
         "skills": {"Foul Breath": 46, "Marakunda": 0, "Mudoon": 0, "Repel Phys": 51, "Swift Strike": 0, "Wage War": 48},
-        "personality": "Gloomy"
+        "personality": "Gloomy",
+        "area": "Adyeshach",
+        "floor": "L4, 6-8, 10"
     },
     "Hanuman": {
+        "inherits": "Physical",
         "item": "Ruyi Jingu Bang",
         "arcana": "Star",
         "level": 64,
@@ -973,9 +1088,12 @@ var personaMap = {
             "Tempest Slash": 0,
             "Tetra Break": 67
         },
-        "personality": "Unknown"
+        "personality": "Unknown",
+        "area": "Sheriruth",
+        "floor": "L12 & 13 (after Palace 7)"
     },
     "Hariti": {
+        "inherits": "Electric",
         "item": "Spirit Drain",
         "skillCard": true,
         "arcana": "Empress",
@@ -995,6 +1113,7 @@ var personaMap = {
         "personality": "Unknown"
     },
     "Hecatoncheires": {
+        "inherits": "Psy",
         "item": "Endure",
         "skillCard": true,
         "arcana": "Hanged Man",
@@ -1012,6 +1131,7 @@ var personaMap = {
         }
     },
     "Hell Biker": {
+        "inherits": "Fire",
         "item": "Black Jacket",
         "arcana": "Death",
         "level": 39,
@@ -1029,6 +1149,7 @@ var personaMap = {
         }
     },
     "High Pixie": {
+        "inherits": "Healing",
         "item": "Diarama",
         "skillCard": true,
         "arcana": "Fool",
@@ -1036,7 +1157,9 @@ var personaMap = {
         "stats": [8, 14, 10, 13, 10],
         "elems": ["-", "wk", "-", "-", "rs", "rs", "-", "wk", "-", "-"],
         "skills": {"Diarama": 18, "Dormina": 0, "Garu": 0, "Magaru": 20, "Media": 0, "Taunt": 19},
-        "personality": "Irritable"
+        "personality": "Irritable",
+        "area": "Kaitul",
+        "floor": "L1-3"
     },
     "Hope Diamond": {
         "item": "Hope Diamond",
@@ -1054,9 +1177,12 @@ var personaMap = {
             "Invigorate 2": 0,
             "Regenerate 2": 0
         },
-        "rare": true
+        "rare": true,
+        "area": "Sheriruth",
+        "floor": "L7-9. 11-13 (after Palace 7)"
     },
     "Horus": {
+        "inherits": "Almighty",
         "item": "Kougaon",
         "skillCard": true,
         "arcana": "Sun",
@@ -1074,6 +1200,7 @@ var personaMap = {
         }
     },
     "Hua Po": {
+        "inherits": "Fire",
         "item": "Agilao",
         "skillCard": true,
         "arcana": "Hanged Man",
@@ -1081,9 +1208,12 @@ var personaMap = {
         "stats": [4, 10, 4, 8, 8],
         "elems": ["-", "wk", "rp", "wk", "-", "-", "-", "-", "-", "-"],
         "skills": {"Agi": 0, "Burn Boost": 15, "Dormina": 0, "Maragi": 13, "Resist Forget": 12, "Tarunda": 11},
-        "personality": "Upbeat"
+        "personality": "Upbeat",
+        "area": "Chemdah",
+        "floor": "L1-3"
     },
     "Incubus": {
+        "inherits": "Ailment",
         "item": "Dream Needle",
         "skillCard": true,
         "arcana": "Devil",
@@ -1091,9 +1221,12 @@ var personaMap = {
         "stats": [4, 6, 4, 5, 3],
         "elems": ["-", "wk", "-", "-", "rs", "-", "-", "-", "wk", "-"],
         "skills": {"Life Drain": 0, "Evil Touch": 0, "Dodge Curse": 9, "Eiha": 7, "Tarunda": 8},
-        "personality": "Timid"
+        "personality": "Timid",
+        "area": "Aiyatsbus",
+        "floor": "L2, 3 & 6"
     },
     "Inugami": {
+        "inherits": "Fire",
         "item": "Brain Shake",
         "skillCard": true,
         "arcana": "Hanged Man",
@@ -1109,9 +1242,12 @@ var personaMap = {
             "Pulinpa": 0,
             "Tarukaja": 0
         },
-        "personality": "Timid"
+        "personality": "Timid",
+        "area": "Chemdah",
+        "floor": "L4, 6 & 7"
     },
     "Ippon-Datara": {
+        "inherits": "Physical",
         "item": "Sledgehammer",
         "skillCard": true,
         "arcana": "Hermit",
@@ -1126,9 +1262,12 @@ var personaMap = {
             "Sledgehammer": 0,
             "Tarukaja": 0
         },
-        "personality": "Unknown"
+        "personality": "Unknown",
+        "area": "Chemdah",
+        "floor": "L1-4"
     },
     "Ishtar": {
+        "inherits": "Healing",
         "item": "Salvation",
         "skillCard": true,
         "arcana": "Lovers",
@@ -1147,6 +1286,7 @@ var personaMap = {
         "max": true
     },
     "Isis": {
+        "inherits": "Healing",
         "item": "Zionga",
         "skillCard": true,
         "arcana": "Priestess",
@@ -1162,9 +1302,12 @@ var personaMap = {
             "Sukukaja": 0,
             "Zionga": 29
         },
-        "personality": "Timid"
+        "personality": "Timid",
+        "area": "Akzeriyyuth",
+        "floor": "L5-7, 9-11"
     },
     "Izanagi": {
+        "inherits": "Almighty",
         "item": "White Headband",
         "arcana": "Fool",
         "level": 20,
@@ -1182,6 +1325,7 @@ var personaMap = {
         "dlc": true
     },
     "Izanagi Picaro": {
+        "inherits": "Almighty",
         "item": "Growth 3",
         "skillCard": true,
         "arcana": "Fool",
@@ -1200,24 +1344,31 @@ var personaMap = {
         "dlc": true
     },
     "Jack Frost": {
+        "inherits": "Ice",
         "item": "Frost Hood",
         "arcana": "Magician",
         "level": 11,
         "stats": [8, 9, 7, 9, 7],
         "elems": ["-", "-", "wk", "nu", "-", "-", "-", "-", "-", "-"],
         "skills": {"Baisudi": 0, "Bufu": 0, "Freeze Boost": 15, "Ice Break": 0, "Mabufu": 12, "Rakunda": 13},
-        "personality": "Timid"
+        "personality": "Timid",
+        "area": "Chemdah",
+        "floor": "L4 & 6"
     },
     "Jack-o'-Lantern": {
+        "inherits": "Fire",
         "item": "Pumpkin Bomb",
         "arcana": "Magician",
         "level": 2,
         "stats": [2, 3, 3, 3, 2],
         "elems": ["-", "wk", "ab", "wk", "-", "wk", "-", "-", "-", "-"],
         "skills": {"Agi": 0, "Dazzler": 5, "Sharp Student": 4, "Rakunda": 0, "Resist Sleep": 7},
-        "personality": "Gloomy"
+        "personality": "Gloomy",
+        "area": "Qimranut / Aiyatsbus",
+        "floor": "All / L1"
     },
     "Jatayu": {
+        "inherits": "Wind",
         "item": "Flash Bomb",
         "skillCard": true,
         "arcana": "Tower",
@@ -1235,6 +1386,7 @@ var personaMap = {
         }
     },
     "Jikokuten": {
+        "inherits": "Physical",
         "item": "Memory Blow",
         "skillCard": true,
         "arcana": "Temperance",
@@ -1252,6 +1404,7 @@ var personaMap = {
         }
     },
     "Kaguya": {
+        "inherits": "Almighty",
         "item": "Moonlight Robe",
         "arcana": "Moon",
         "level": 16,
@@ -1269,6 +1422,7 @@ var personaMap = {
         "dlc": true
     },
     "Kaguya Picaro": {
+        "inherits": "Almighty",
         "item": "Diarahan",
         "skillCard": true,
         "arcana": "Moon",
@@ -1287,6 +1441,7 @@ var personaMap = {
         "dlc": true
     },
     "Kaiwan": {
+        "inherits": "Almighty",
         "item": "Mapsio",
         "skillCard": true,
         "arcana": "Star",
@@ -1302,9 +1457,12 @@ var personaMap = {
             "Psio": 0,
             "Speed Master": 38
         },
-        "personality": "Timid"
+        "personality": "Timid",
+        "area": "Adyeshach",
+        "floor": "L10-12"
     },
     "Kali": {
+        "inherits": "Fire",
         "item": "Khamrai Tao",
         "arcana": "Empress",
         "level": 77,
@@ -1321,6 +1479,7 @@ var personaMap = {
         }
     },
     "Kelpie": {
+        "inherits": "Wind",
         "item": "Terror Claw",
         "skillCard": true,
         "arcana": "Strength",
@@ -1328,9 +1487,12 @@ var personaMap = {
         "stats": [5, 5, 5, 6, 4],
         "elems": ["-", "-", "-", "rs", "wk", "-", "-", "-", "-", "-"],
         "skills": {"Garu": 0, "Lunge": 0, "Resist Brainwash": 8, "Sukukaja": 9, "Terror Claw": 10},
-        "personality": "Upbeat"
+        "personality": "Upbeat",
+        "area": "Aiyatsbus",
+        "floor": "L3"
     },
     "Kikuri-Hime": {
+        "inherits": "Healing",
         "item": "Divine Grace",
         "skillCard": true,
         "arcana": "Priestess",
@@ -1338,9 +1500,12 @@ var personaMap = {
         "stats": [22, 31, 24, 28, 22],
         "elems": ["-", "-", "wk", "-", "-", "nu", "-", "-", "rs", "-"],
         "skills": {"Divine Grace": 45, "Energy Drop": 0, "Lullaby": 0, "Marakukaja": 0, "Mediarama": 41, "Tetraja": 43},
-        "personality": "Unknown"
+        "personality": "Unknown",
+        "area": "Sheriruth",
+        "floor": "L3-5 (before Palace 7) / L2 & 3 (after Palace 7)"
     },
     "Kin-Ki": {
+        "inherits": "Physical",
         "item": "Regenerate 1",
         "skillCard": true,
         "arcana": "Chariot",
@@ -1356,9 +1521,12 @@ var personaMap = {
             "Regenerate 1": 0,
             "Sledgehammer": 28
         },
-        "personality": "Gloomy"
+        "personality": "Gloomy",
+        "area": "Kaitul",
+        "floor": "L4, 5, 7-9"
     },
     "King Frost": {
+        "inherits": "Ice",
         "item": "King Frost Cape",
         "arcana": "Emperor",
         "level": 61,
@@ -1373,9 +1541,12 @@ var personaMap = {
             "Megaton Raid": 0,
             "Null Despair": 65
         },
-        "personality": "Unknown"
+        "personality": "Unknown",
+        "area": "Sheriruth",
+        "floor": "L8, 11, 12, 13 (after Palace 7)"
     },
     "Kodama": {
+        "inherits": "Ailment",
         "item": "Fear Boost",
         "skillCard": true,
         "arcana": "Star",
@@ -1391,7 +1562,9 @@ var personaMap = {
             "Resist Fear": 17,
             "Tarukaja": 14
         },
-        "personality": "Upbeat"
+        "personality": "Upbeat",
+        "area": "Aiyatsbus",
+        "floor": "L1-3"
     },
     "Koh-i-Noor": {
         "item": "Koh-i-Noor",
@@ -1409,9 +1582,12 @@ var personaMap = {
             "Dodge Psy": 0,
             "Dodge Wind": 0
         },
-        "rare": true
+        "rare": true,
+        "area": "Adyeshach",
+        "floor": "L1-4, 6-8, 10-12"
     },
     "Kohryu": {
+        "inherits": "Psy",
         "item": "Sudarshana",
         "arcana": "Hierophant",
         "level": 76,
@@ -1430,6 +1606,7 @@ var personaMap = {
         "max": true
     },
     "Koppa Tengu": {
+        "inherits": "Wind",
         "item": "Growth 1",
         "skillCard": true,
         "arcana": "Temperance",
@@ -1437,9 +1614,12 @@ var personaMap = {
         "stats": [7, 8, 8, 11, 6],
         "elems": ["-", "-", "-", "wk", "-", "rs", "-", "-", "wk", "-"],
         "skills": {"Snap": 0, "Garu": 0, "Growth 1": 12, "Taunt": 13, "Rage Boost": 14, "Wage War": 15},
-        "personality": "Upbeat"
+        "personality": "Upbeat",
+        "area": "Chemdah",
+        "floor": "L6 & 7"
     },
     "Koropokguru": {
+        "inherits": "Ice",
         "item": "Bufu",
         "skillCard": true,
         "arcana": "Hermit",
@@ -1447,9 +1627,12 @@ var personaMap = {
         "stats": [5, 8, 6, 9, 6],
         "elems": ["-", "rs", "wk", "rs", "-", "rs", "-", "-", "-", "-"],
         "skills": {"Bufu": 0, "Dodge Ice": 11, "Fire Wall": 13, "Mabufu": 14, "Makajam": 0, "Rakunda": 12},
-        "personality": "Timid"
+        "personality": "Timid",
+        "area": "Chemdah",
+        "floor": "L2 & 3"
     },
     "Koumokuten": {
+        "inherits": "Physical",
         "item": "Regenerate 2",
         "skillCard": true,
         "arcana": "Hermit",
@@ -1468,6 +1651,7 @@ var personaMap = {
         }
     },
     "Kumbhanda": {
+        "inherits": "Ailment",
         "item": "Rage Boost",
         "skillCard": true,
         "arcana": "Hermit",
@@ -1482,18 +1666,24 @@ var personaMap = {
             "Stagnant Air": 0,
             "Tempest Slash": 43,
             "Wage War": 0
-        }
+        },
+        "area": "Sheriruth",
+        "floor": "L8, 9, 11-13 (before Palace 7) / L4 & 5 (after Palace 7)"
     },
     "Kurama Tengu": {
+        "inherits": "Wind",
         "item": "Garudyne",
         "skillCard": true,
         "arcana": "Hermit",
         "level": 56,
         "stats": [34, 38, 34, 42, 27],
         "elems": ["-", "-", "-", "wk", "-", "rp", "-", "-", "rs", "rs"],
-        "skills": {"Brain Buster": 0, "Garudyne": 57, "Growth 3": 58, "Heat Wave": 0, "Magarudyne": 60, "Masukunda": 0}
+        "skills": {"Brain Buster": 0, "Garudyne": 57, "Growth 3": 58, "Heat Wave": 0, "Magarudyne": 60, "Masukunda": 0},
+        "area": "Sheriruth",
+        "floor": "L11 (after Palace 7)"
     },
     "Kushinada": {
+        "inherits": "Healing",
         "item": "Wind Wall",
         "skillCard": true,
         "arcana": "Lovers",
@@ -1508,9 +1698,12 @@ var personaMap = {
             "Mediarama": 0,
             "Null Sleep": 45,
             "Wind Wall": 46
-        }
+        },
+        "area": "Sheriruth",
+        "floor": "L5, 7-9 (before Palace 7) / L3 & 4 (after Palace 7)"
     },
     "Kushi Mitama": {
+        "inherits": "Healing",
         "item": "Forget Boost",
         "skillCard": true,
         "arcana": "Strength",
@@ -1528,6 +1721,7 @@ var personaMap = {
         }
     },
     "Lachesis": {
+        "inherits": "Ice",
         "item": "Ice Boost",
         "skillCard": true,
         "arcana": "Fortune",
@@ -1545,6 +1739,7 @@ var personaMap = {
         }
     },
     "Lakshmi": {
+        "inherits": "Healing",
         "item": "Life Aid",
         "skillCard": true,
         "arcana": "Fortune",
@@ -1563,6 +1758,7 @@ var personaMap = {
         "max": true
     },
     "Lamia": {
+        "inherits": "Fire",
         "item": "Despair Boost",
         "skillCard": true,
         "arcana": "Empress",
@@ -1578,9 +1774,12 @@ var personaMap = {
             "Rakukaja": 0,
             "Ominous Words": 27
         },
-        "personality": "Gloomy"
+        "personality": "Gloomy",
+        "area": "Akzeriyyuth",
+        "floor": "L3, 5-7, 9-11"
     },
     "Leanan Sidhe": {
+        "inherits": "Almighty",
         "item": "Recarm",
         "skillCard": true,
         "arcana": "Lovers",
@@ -1588,18 +1787,24 @@ var personaMap = {
         "stats": [9, 17, 12, 16, 10],
         "elems": ["-", "-", "wk", "-", "-", "rs", "rs", "-", "-", "-"],
         "skills": {"Eiga": 23, "Mamudo": 21, "Mapsi": 22, "Marin Karin": 20, "Psio": 0, "Rakunda": 0},
-        "personality": "Irritable"
+        "personality": "Irritable",
+        "area": "Kaitul",
+        "floor": "L3-5"
     },
     "Legion": {
+        "inherits": "Psy",
         "item": "Legion's Jail",
         "arcana": "Fool",
         "level": 38,
         "stats": [24, 24, 30, 23, 20],
         "elems": ["rs", "rs", "rs", "-", "-", "-", "rs", "-", "wk", "nu"],
         "skills": {"Life Drain": 0, "Negative Pile": 0, "Null Dizzy": 42, "Psio": 39, "Rampage": 0, "Tetra Break": 40},
-        "personality": "Unknown"
+        "personality": "Unknown",
+        "area": "Adyeshach",
+        "floor": "L1-4"
     },
     "Lilim": {
+        "inherits": "Ice",
         "item": "Lullaby",
         "skillCard": true,
         "arcana": "Devil",
@@ -1615,9 +1820,12 @@ var personaMap = {
             "Masukunda": 0,
             "Spirit Drain": 36
         },
-        "personality": "Gloomy"
+        "personality": "Gloomy",
+        "area": "Adyeshach",
+        "floor": "L6-8, 10-12"
     },
     "Lilith": {
+        "inherits": "Almighty",
         "item": "Mabufudyne",
         "skillCard": true,
         "arcana": "Moon",
@@ -1635,6 +1843,7 @@ var personaMap = {
         }
     },
     "Lucifer": {
+        "inherits": "Almighty",
         "item": "Tyrant Pistol",
         "arcana": "Star",
         "level": 93,
@@ -1654,6 +1863,7 @@ var personaMap = {
         "max": true
     },
     "Mada": {
+        "inherits": "Fire",
         "item": "Unshaken Will",
         "skillCard": true,
         "arcana": "Tower",
@@ -1673,6 +1883,7 @@ var personaMap = {
         "max": true
     },
     "Magatsu-Izanagi": {
+        "inherits": "Almighty",
         "item": "Black Headband",
         "arcana": "Tower",
         "level": 44,
@@ -1690,6 +1901,7 @@ var personaMap = {
         "dlc": true
     },
     "Magatsu-Izanagi Picaro": {
+        "inherits": "Almighty",
         "item": "Heat Riser",
         "skillCard": true,
         "arcana": "Tower",
@@ -1708,6 +1920,7 @@ var personaMap = {
         "dlc": true
     },
     "Makami": {
+        "inherits": "Nuclear",
         "item": "Makajam",
         "skillCard": true,
         "arcana": "Temperance",
@@ -1723,9 +1936,12 @@ var personaMap = {
             "Makajam": 18,
             "Resist Despair": 19
         },
-        "personality": "Upbeat"
+        "personality": "Upbeat",
+        "area": "Chemdah",
+        "floor": "L6 & 7"
     },
     "Mandrake": {
+        "inherits": "Electric",
         "item": "Energy Drop",
         "skillCard": true,
         "arcana": "Death",
@@ -1733,9 +1949,12 @@ var personaMap = {
         "stats": [2, 3, 3, 4, 4],
         "elems": ["-", "-", "wk", "-", "rs", "-", "-", "-", "-", "-"],
         "skills": {"Energy Drop": 0, "Lunge": 4, "Pulinpa": 0, "Skull Cracker": 7, "Sukunda": 5},
-        "personality": "Upbeat"
+        "personality": "Upbeat",
+        "area": "Qimranut / Aiyatsbus",
+        "floor": "All / L1"
     },
     "Mara": {
+        "inherits": "Fire",
         "item": "Maragidyne",
         "skillCard": true,
         "arcana": "Tower",
@@ -1753,6 +1972,7 @@ var personaMap = {
         }
     },
     "Matador": {
+        "inherits": "Psy",
         "item": "Garula",
         "skillCard": true,
         "arcana": "Death",
@@ -1762,6 +1982,7 @@ var personaMap = {
         "skills": {"Garula": 23, "Null Dizzy": 0, "Psi": 0, "Sukukaja": 0, "Swift Strike": 20, "Trigger Happy": 22}
     },
     "Melchizedek": {
+        "inherits": "Bless",
         "item": "Mahamaon",
         "skillCard": true,
         "arcana": "Justice",
@@ -1779,6 +2000,7 @@ var personaMap = {
         }
     },
     "Messiah": {
+        "inherits": "Almighty",
         "item": "Lucifer Guard",
         "arcana": "Judgement",
         "level": 81,
@@ -1797,6 +2019,7 @@ var personaMap = {
         "dlc": true
     },
     "Messiah Picaro": {
+        "inherits": "Almighty",
         "item": "Insta-Heal",
         "skillCard": true,
         "arcana": "Judgement",
@@ -1816,6 +2039,7 @@ var personaMap = {
         "dlc": true
     },
     "Metatron": {
+        "inherits": "Bless",
         "item": "Nataraja",
         "arcana": "Justice",
         "level": 89,
@@ -1835,6 +2059,7 @@ var personaMap = {
         "max": true
     },
     "Michael": {
+        "inherits": "Almighty",
         "item": "Judge of the Dead",
         "arcana": "Judgement",
         "level": 87,
@@ -1853,6 +2078,7 @@ var personaMap = {
         "note": "Needs Strength cooperation rank 5 to be fused"
     },
     "Mitra": {
+        "inherits": "Bless",
         "item": "Death Contract",
         "arcana": "Temperance",
         "level": 33,
@@ -1869,6 +2095,7 @@ var personaMap = {
         }
     },
     "Mithras": {
+        "inherits": "Nuclear",
         "item": "Petra Genetrix",
         "arcana": "Sun",
         "level": 39,
@@ -1882,9 +2109,12 @@ var personaMap = {
             "Tentarafoo": 0,
             "Tetra Break": 41
         },
-        "personality": "Gloomy"
+        "personality": "Gloomy",
+        "area": "Adyeshach",
+        "floor": "L11 & 12"
     },
     "Mokoi": {
+        "inherits": "Ailment",
         "item": "Dekunda",
         "skillCard": true,
         "arcana": "Death",
@@ -1899,9 +2129,12 @@ var personaMap = {
             "Skull Cracker": 0,
             "Tarukaja": 0
         },
-        "personality": "Gloomy"
+        "personality": "Gloomy",
+        "area": "Chemdah",
+        "floor": "L1-4"
     },
     "Moloch": {
+        "inherits": "Psy",
         "item": "Nuke Amp",
         "skillCard": true,
         "arcana": "Hanged Man",
@@ -1919,6 +2152,7 @@ var personaMap = {
         }
     },
     "Mot": {
+        "inherits": "Ailment",
         "item": "Concentrate",
         "skillCard": true,
         "arcana": "Death",
@@ -1935,6 +2169,7 @@ var personaMap = {
         }
     },
     "Mother Harlot": {
+        "inherits": "Ice",
         "item": "Claiomh Solais - Sable",
         "arcana": "Empress",
         "level": 80,
@@ -1952,6 +2187,7 @@ var personaMap = {
         "max": true
     },
     "Mothman": {
+        "inherits": "Electric",
         "item": "Foul Breath",
         "skillCard": true,
         "arcana": "Moon",
@@ -1966,9 +2202,12 @@ var personaMap = {
             "Skull Cracker": 0,
             "Tentarafoo": 35
         },
-        "personality": "Timid"
+        "personality": "Timid",
+        "area": "Adyeshach",
+        "floor": "L3, 4, 7, 8, 10"
     },
     "Naga": {
+        "inherits": "Electric",
         "item": "Elec Boost",
         "skillCard": true,
         "arcana": "Hermit",
@@ -1984,9 +2223,12 @@ var personaMap = {
             "Mazionga": 28,
             "Zionga": 0
         },
-        "personality": "Gloomy"
+        "personality": "Gloomy",
+        "area": "Akzeriyyuth",
+        "floor": "L2, 3, 5-7, 9"
     },
     "Narcissus": {
+        "inherits": "Ailment",
         "item": "Daffodils",
         "arcana": "Lovers",
         "level": 50,
@@ -2000,9 +2242,12 @@ var personaMap = {
             "Growth 3": 52,
             "Magarula": 0,
             "Mediarama": 54
-        }
+        },
+        "area": "Sheriruth",
+        "floor": "L7 & 8 (after Palace 7)"
     },
     "Nebiros": {
+        "inherits": "Curse",
         "item": "Eigaon",
         "skillCard": true,
         "arcana": "Devil",
@@ -2020,6 +2265,7 @@ var personaMap = {
         }
     },
     "Neko Shogun": {
+        "inherits": "Almighty",
         "item": "Catnap",
         "arcana": "Star",
         "level": 30,
@@ -2038,6 +2284,7 @@ var personaMap = {
         "note": "Needs Strength cooperation rank 1 to be fused"
     },
     "Nekomata": {
+        "inherits": "Ailment",
         "item": "Pawzooka",
         "arcana": "Magician",
         "level": 17,
@@ -2052,9 +2299,12 @@ var personaMap = {
             "Terror Claw": 0,
             "Wind Break": 20
         },
-        "personality": "Upbeat"
+        "personality": "Upbeat",
+        "area": "Kaitul",
+        "floor": "L2-4"
     },
     "Nigi Mitama": {
+        "inherits": "Healing",
         "item": "Me Patra",
         "skillCard": true,
         "arcana": "Temperance",
@@ -2064,6 +2314,7 @@ var personaMap = {
         "skills": {"Baisudi": 0, "Divine Grace": 22, "Makouha": 0, "Me Patra": 23, "Media": 0, "Rainy Play": 24}
     },
     "Norn": {
+        "inherits": "Almighty",
         "item": "Diarahan",
         "skillCard": true,
         "arcana": "Fortune",
@@ -2078,9 +2329,12 @@ var personaMap = {
             "Samarecarm": 57,
             "Tetraja": 56,
             "Ziodyne": 0
-        }
+        },
+        "area": "Sheriruth",
+        "floor": "L11-13 (before Palace 7) / L5 (after Palace 7)"
     },
     "Nue": {
+        "inherits": "Curse",
         "item": "Skull Cracker",
         "skillCard": true,
         "arcana": "Moon",
@@ -2096,9 +2350,12 @@ var personaMap = {
             "Pulinpa": 22,
             "Skull Cracker": 0
         },
-        "personality": "Irritable"
+        "personality": "Irritable",
+        "area": "Chemdah",
+        "floor": "L4"
     },
     "Obariyon": {
+        "inherits": "Physical",
         "item": "Lucky Punch",
         "skillCard": true,
         "arcana": "Fool",
@@ -2106,9 +2363,12 @@ var personaMap = {
         "stats": [7, 3, 9, 8, 4],
         "elems": ["rs", "-", "-", "-", "wk", "-", "-", "-", "-", "-"],
         "skills": {"Dekaja": 12, "Snap": 0, "Lucky Punch": 9, "Resist Fear": 10, "Sukunda": 0},
-        "personality": "Unknown"
+        "personality": "Unknown",
+        "area": "Aiyatsbus",
+        "floor": "L3, 5 & 6"
     },
     "Oberon": {
+        "inherits": "Electric",
         "item": "Elec Amp",
         "skillCard": true,
         "arcana": "Emperor",
@@ -2125,9 +2385,12 @@ var personaMap = {
             "Samarecarm": 71,
             "Ziodyne": 0
         },
-        "personality": "Unknown"
+        "personality": "Unknown",
+        "area": "Sheriruth",
+        "floor": "L13 (after Palace 7)"
     },
     "Odin": {
+        "inherits": "Electric",
         "item": "Wild Hunt",
         "arcana": "Emperor",
         "level": 82,
@@ -2145,6 +2408,7 @@ var personaMap = {
         "max": true
     },
     "Okuninushi": {
+        "inherits": "Psy",
         "item": "Official's Robe",
         "arcana": "Emperor",
         "level": 44,
@@ -2161,6 +2425,7 @@ var personaMap = {
         }
     },
     "Ongyo-Ki": {
+        "inherits": "Physical",
         "item": "Myriad Slashes",
         "skillCard": true,
         "arcana": "Hermit",
@@ -2180,6 +2445,7 @@ var personaMap = {
         "max": true
     },
     "Oni": {
+        "inherits": "Physical",
         "item": "Rampage",
         "skillCard": true,
         "arcana": "Strength",
@@ -2187,9 +2453,12 @@ var personaMap = {
         "stats": [17, 8, 16, 13, 10],
         "elems": ["rs", "rs", "-", "-", "-", "-", "-", "-", "-", "-"],
         "skills": {"Memory Blow": 23, "Sharp Student": 22, "Counter": 0, "Snap": 0, "Giant Slice": 21, "Rampage": 0},
-        "personality": "Upbeat"
+        "personality": "Upbeat",
+        "area": "Kaitul",
+        "floor": "L3-5, 8, 9"
     },
     "Onmoraki": {
+        "inherits": "Curse",
         "item": "Confuse Boost",
         "skillCard": true,
         "arcana": "Moon",
@@ -2197,7 +2466,9 @@ var personaMap = {
         "stats": [9, 12, 7, 10, 5],
         "elems": ["-", "wk", "rs", "-", "-", "-", "-", "-", "wk", "nu"],
         "skills": {"Agi": 13, "Ice Wall": 0, "Mudo": 0, "Confuse Boost": 15, "Pulinpa": 14, "Resist Fear": 17},
-        "personality": "Gloomy"
+        "personality": "Gloomy",
+        "area": "Chemdah",
+        "floor": "L3 & 4"
     },
     "Orlov": {
         "item": "Orlov",
@@ -2215,9 +2486,12 @@ var personaMap = {
             "Maragion": 0,
             "Mazionga": 0
         },
-        "rare": true
+        "rare": true,
+        "area": "Sheriruth",
+        "floor": "All (before Palace 7) / L1-5 (after Palace 7)"
     },
     "Orobas": {
+        "inherits": "Fire",
         "item": "Maragi",
         "skillCard": true,
         "arcana": "Hierophant",
@@ -2225,9 +2499,12 @@ var personaMap = {
         "stats": [11, 14, 15, 12, 6],
         "elems": ["-", "-", "-", "-", "-", "rs", "-", "-", "wk", "rs"],
         "skills": {"Dekaja": 0, "Fire Break": 20, "Makajamon": 21, "Maragi": 0, "Marakunda": 19, "Sukukaja": 0},
-        "personality": "Timid"
+        "personality": "Timid",
+        "area": "Kaitul",
+        "floor": "L1-3"
     },
     "Orpheus": {
+        "inherits": "Almighty",
         "item": "Hades Harp",
         "arcana": "Fool",
         "level": 26,
@@ -2245,6 +2522,7 @@ var personaMap = {
         "dlc": true
     },
     "Orpheus Picaro": {
+        "inherits": "Almighty",
         "item": "Agidyne",
         "skillCard": true,
         "arcana": "Fool",
@@ -2263,6 +2541,7 @@ var personaMap = {
         "dlc": true
     },
     "Orthrus": {
+        "inherits": "Fire",
         "item": "Burn Boost",
         "skillCard": true,
         "arcana": "Hanged Man",
@@ -2270,9 +2549,12 @@ var personaMap = {
         "stats": [16, 14, 14, 19, 7],
         "elems": ["-", "-", "ab", "wk", "-", "-", "-", "rs", "-", "-"],
         "skills": {"Agilao": 0, "Burn Boost": 22, "Dodge Ice": 0, "Double Fangs": 0, "Matarukaja": 26, "Rat Fang": 24},
-        "personality": "Irritable"
+        "personality": "Irritable",
+        "area": "Kaitul",
+        "floor": "L4, 5, 7-9"
     },
     "Ose": {
+        "inherits": "Ailment",
         "item": "Matarukaja",
         "skillCard": true,
         "arcana": "Fool",
@@ -2280,9 +2562,12 @@ var personaMap = {
         "stats": [32, 24, 25, 31, 21],
         "elems": ["-", "-", "rs", "-", "-", "-", "-", "-", "wk", "nu"],
         "skills": {"Counterstrike": 0, "Heat Wave": 47, "Matarukaja": 45, "Oni Kagura": 0, "Tempest Slash": 43},
-        "personality": "Unknown"
+        "personality": "Unknown",
+        "area": "Sheriruth",
+        "floor": "L1-5, 9 (before Palace 7) / L1-4 (after Palace 7)"
     },
     "Pale Rider": {
+        "inherits": "Curse",
         "item": "Megidola",
         "skillCard": true,
         "arcana": "Death",
@@ -2300,6 +2585,7 @@ var personaMap = {
         }
     },
     "Parvati": {
+        "inherits": "Psy",
         "item": "Psiodyne",
         "skillCard": true,
         "arcana": "Lovers",
@@ -2315,9 +2601,12 @@ var personaMap = {
             "Mapsiodyne": 59,
             "Psiodyne": 0
         },
-        "personality": "Unknown"
+        "personality": "Unknown",
+        "area": "Sheriruth",
+        "floor": "L9, 11, 12 (after Palace 7)"
     },
     "Pazuzu": {
+        "inherits": "Curse",
         "item": "Maeiga",
         "skillCard": true,
         "arcana": "Devil",
@@ -2335,6 +2624,7 @@ var personaMap = {
         }
     },
     "Pisaca": {
+        "inherits": "Curse",
         "item": "Headhunter Ladle",
         "arcana": "Death",
         "level": 29,
@@ -2349,9 +2639,12 @@ var personaMap = {
             "Rampage": 0,
             "Stagnant Air": 0
         },
-        "personality": "Unknown"
+        "personality": "Unknown",
+        "area": "Akzeriyyuth",
+        "floor": "L5-7, 9-11"
     },
     "Pixie": {
+        "inherits": "Electric",
         "item": "Dia",
         "skillCard": true,
         "arcana": "Lovers",
@@ -2359,9 +2652,12 @@ var personaMap = {
         "stats": [1, 3, 3, 4, 2],
         "elems": ["-", "wk", "-", "wk", "rs", "-", "-", "-", "rs", "wk"],
         "skills": {"Dia": 0, "Patra": 3, "Resist Confuse": 6, "Tarukaja": 5, "Zio": 0},
-        "personality": "Timid"
+        "personality": "Timid",
+        "area": "Qimranut / Aiyatsbus",
+        "floor": "All / L1 & 3"
     },
     "Power": {
+        "inherits": "Bless",
         "item": "Masukukaja",
         "skillCard": true,
         "arcana": "Justice",
@@ -2377,9 +2673,12 @@ var personaMap = {
             "Sukukaja": 0,
             "Swift Strike": 42
         },
-        "personality": "Unknown"
+        "personality": "Unknown",
+        "area": "Sheriruth",
+        "floor": "L1-5, 7 (before Palace 7) / L1-3 (after Palace 7)"
     },
     "Principality": {
+        "inherits": "Bless",
         "item": "Tetraja",
         "skillCard": true,
         "arcana": "Justice",
@@ -2389,15 +2688,19 @@ var personaMap = {
         "skills": {"Bless Boost": 34, "Mabaisudi": 32, "Makajamon": 0, "Makouga": 0, "Mediarama": 31, "Tetraja": 0}
     },
     "Queen Mab": {
+        "inherits": "Almighty",
         "item": "Masquerade Ribbon",
         "arcana": "Magician",
         "level": 43,
         "stats": [23, 35, 26, 30, 22],
         "elems": ["-", "-", "nu", "-", "rs", "wk", "-", "-", "-", "-"],
         "skills": {"Agidyne": 48, "Makajamon": 0, "Makara Break": 46, "Matarunda": 44, "Mazionga": 0, "Wind Wall": 0},
-        "personality": "Unknown"
+        "personality": "Unknown",
+        "area": "Sheriruth",
+        "floor": "L5, 7-9 (before Palace 7) / L3 & 4 (after Palace 7)"
     },
     "Quetzalcoatl": {
+        "inherits": "Wind",
         "item": "Regenerate 3",
         "skillCard": true,
         "arcana": "Sun",
@@ -2415,6 +2718,7 @@ var personaMap = {
         }
     },
     "Raja Naga": {
+        "inherits": "Electric",
         "item": "Ziodyne",
         "skillCard": true,
         "arcana": "Temperance",
@@ -2432,6 +2736,7 @@ var personaMap = {
         }
     },
     "Rakshasa": {
+        "inherits": "Physical",
         "item": "Mind Slice",
         "skillCard": true,
         "arcana": "Strength",
@@ -2447,9 +2752,12 @@ var personaMap = {
             "Tarukaja": 0,
             "Wind Wall": 0
         },
-        "personality": "Irritable"
+        "personality": "Irritable",
+        "area": "Kaitul",
+        "floor": "L5, 7-9"
     },
     "Rangda": {
+        "inherits": "Curse",
         "item": "Bloodbath",
         "skillCard": true,
         "arcana": "Magician",
@@ -2457,9 +2765,12 @@ var personaMap = {
         "stats": [28, 34, 30, 33, 26],
         "elems": ["rp", "rp", "nu", "-", "wk", "-", "-", "-", "wk", "nu"],
         "skills": {"Bloodbath": 0, "Counterstrike": 0, "Eigaon": 49, "Matarunda": 51, "Mudoon": 53, "Swift Strike": 0},
-        "personality": "Unknown"
+        "personality": "Unknown",
+        "area": "Sheriruth",
+        "floor": "L11-13 (before Palace 7) / L5 (after Palace 7)"
     },
     "Raphael": {
+        "inherits": "Almighty",
         "item": "Heat Riser",
         "skillCard": true,
         "arcana": "Lovers",
@@ -2477,6 +2788,7 @@ var personaMap = {
         }
     },
     "Red Rider": {
+        "inherits": "Psy",
         "item": "Psy Break",
         "skillCard": true,
         "arcana": "Tower",
@@ -2509,9 +2821,12 @@ var personaMap = {
             "Maragi": 0,
             "Mazio": 0
         },
-        "rare": true
+        "rare": true,
+        "area": "Qimranut / Aiyatsbus / Chemdah",
+        "floor": "All / L1-3, 5 & 6 / L1-4, 6 & 7"
     },
     "Saki Mitama": {
+        "inherits": "Healing",
         "item": "Rakukaja",
         "skillCard": true,
         "arcana": "Lovers",
@@ -2521,6 +2836,7 @@ var personaMap = {
         "skills": {"Bufu": 0, "Energy Drop": 0, "Growth 1": 7, "Rakukaja": 8, "Resist Dizzy": 10, "Wind Wall": 0}
     },
     "Sandalphon": {
+        "inherits": "Bless",
         "item": "Angelic Grace",
         "skillCard": true,
         "arcana": "Moon",
@@ -2538,6 +2854,7 @@ var personaMap = {
         "max": true
     },
     "Sandman": {
+        "inherits": "Wind",
         "item": "Sleep Boost",
         "skillCard": true,
         "arcana": "Magician",
@@ -2553,9 +2870,12 @@ var personaMap = {
             "Sleep Boost": 29,
             "Sukunda": 25
         },
-        "personality": "Irritable"
+        "personality": "Irritable",
+        "area": "Akzeriyyuth",
+        "floor": "L1-3"
     },
     "Sarasvati": {
+        "inherits": "Healing",
         "item": "Mediarama",
         "skillCard": true,
         "arcana": "Priestess",
@@ -2570,9 +2890,12 @@ var personaMap = {
             "Mediarama": 0,
             "Null Sleep": 51,
             "Tentarafoo": 0
-        }
+        },
+        "area": "Sheriruth",
+        "floor": "L7-9. 12 (after Palace 7)"
     },
     "Satan": {
+        "inherits": "Ice",
         "item": "Tantric Oath",
         "arcana": "Judgement",
         "level": 92,
@@ -2591,6 +2914,7 @@ var personaMap = {
         "max": true
     },
     "Satanael": {
+        "inherits": "Almighty",
         "item": "Paradise Lost",
         "arcana": "Fool",
         "level": 95,
@@ -2610,6 +2934,7 @@ var personaMap = {
         "note": "Only available on NG+"
     },
     "Scathach": {
+        "inherits": "Wind",
         "item": "Tempest Slash",
         "skillCard": true,
         "arcana": "Priestess",
@@ -2625,9 +2950,12 @@ var personaMap = {
             "Matarukaja": 48,
             "Tempest Slash": 0
         },
-        "personality": "Upbeat"
+        "personality": "Upbeat",
+        "area": "Adyeshach",
+        "floor": "L10-12"
     },
     "Seiryu": {
+        "inherits": "Ice",
         "item": "Amrita Drop",
         "skillCard": true,
         "arcana": "Temperance",
@@ -2645,6 +2973,7 @@ var personaMap = {
         }
     },
     "Setanta": {
+        "inherits": "Physical",
         "item": "Counter",
         "skillCard": true,
         "arcana": "Emperor",
@@ -2661,6 +2990,7 @@ var personaMap = {
         }
     },
     "Seth": {
+        "inherits": "Fire",
         "item": "One-shot Kill",
         "skillCard": true,
         "arcana": "Tower",
@@ -2679,6 +3009,7 @@ var personaMap = {
         "note": "Needs Strength cooperation rank 1 to be fused"
     },
     "Shiisaa": {
+        "inherits": "Electric",
         "item": "Mazio",
         "skillCard": true,
         "arcana": "Chariot",
@@ -2695,6 +3026,7 @@ var personaMap = {
         }
     },
     "Shiki-Ouji": {
+        "inherits": "Psy",
         "item": "Dormin Rush",
         "skillCard": true,
         "arcana": "Chariot",
@@ -2702,9 +3034,12 @@ var personaMap = {
         "stats": [16, 14, 15, 14, 11],
         "elems": ["nu", "nu", "-", "-", "-", "-", "-", "wk", "-", "nu"],
         "skills": {"Dekaja": 24, "Snap": 0, "Mapsi": 22, "Oni Kagura": 27, "Taunt": 0, "Psio": 26, "Tarukaja": 0},
-        "personality": "Irritable"
+        "personality": "Irritable",
+        "area": "Chemdah",
+        "floor": "L6 & 7"
     },
     "Shiva": {
+        "inherits": "Psy",
         "item": "Megido Fire",
         "arcana": "Judgement",
         "level": 82,
@@ -2722,6 +3057,7 @@ var personaMap = {
         "special": true
     },
     "Siegfried": {
+        "inherits": "Physical",
         "item": "Vorpal Blade",
         "skillCard": true,
         "arcana": "Strength",
@@ -2738,15 +3074,19 @@ var personaMap = {
         }
     },
     "Silky": {
+        "inherits": "Healing",
         "item": "Silk Dress",
         "arcana": "Priestess",
         "level": 6,
         "stats": [4, 7, 4, 5, 5],
         "elems": ["-", "-", "wk", "rs", "wk", "-", "-", "-", "-", "-"],
         "skills": {"Bufu": 0, "Sharp Student": 10, "Dia": 7, "Dormina": 0, "Patra": 9},
-        "personality": "Gloomy"
+        "personality": "Gloomy",
+        "area": "Aiyatsbus",
+        "floor": "L2, 3, 5 & 6"
     },
     "Skadi": {
+        "inherits": "Ice",
         "item": "Snow Queen's Whip",
         "arcana": "Priestess",
         "level": 55,
@@ -2760,9 +3100,12 @@ var personaMap = {
             "Null Despair": 0,
             "Repel Ice": 60,
             "Spirit Drain": 59
-        }
+        },
+        "area": "Sheriruth",
+        "floor": "L12 & 13 (before Palace 7) / L5 (after Palace 7)"
     },
     "Slime": {
+        "inherits": "Curse",
         "item": "Headbutt",
         "skillCard": true,
         "arcana": "Chariot",
@@ -2770,9 +3113,12 @@ var personaMap = {
         "stats": [9, 6, 11, 6, 5],
         "elems": ["rs", "-", "wk", "-", "-", "wk", "-", "-", "-", "-"],
         "skills": {"Evil Touch": 0, "Eiha": 11, "Fire Wall": 13, "Headbutt": 14, "Lunge": 0},
-        "personality": "Timid"
+        "personality": "Timid",
+        "area": "Qimranut / Aiyatsbus",
+        "floor": "All / L1, 2, 3, 6"
     },
     "Sraosha": {
+        "inherits": "Bless",
         "item": "Archangel Bra",
         "arcana": "Star",
         "level": 80,
@@ -2797,18 +3143,24 @@ var personaMap = {
         "stats": [20, 20, 20, 20, 20],
         "elems": ["nu", "nu", "nu", "nu", "nu", "nu", "nu", "nu", "nu", "wk"],
         "skills": {"Agilao": 0, "Bufula": 0, "Eiga": 0, "Freila": 0, "Garula": 0, "Kouga": 0, "Psio": 0, "Zionga": 0},
-        "rare": true
+        "rare": true,
+        "area": "Akzeriyyuth",
+        "floor": "L1-3, 5-7, 9-11"
     },
     "Succubus": {
+        "inherits": "Curse",
         "item": "Brain Shot",
         "arcana": "Moon",
         "level": 7,
         "stats": [4, 7, 5, 8, 4],
         "elems": ["-", "wk", "rs", "-", "-", "-", "-", "-", "wk", "nu"],
         "skills": {"Agi": 8, "Brainwash Boost": 11, "Dekaja": 10, "Marin Karin": 0, "Mudo": 12, "Rebellion": 0},
-        "personality": "Irritable"
+        "personality": "Irritable",
+        "area": "Aiyatsbus",
+        "floor": "L5 & 6"
     },
     "Sudama": {
+        "inherits": "Wind",
         "item": "Magaru",
         "skillCard": true,
         "arcana": "Hermit",
@@ -2823,9 +3175,12 @@ var personaMap = {
             "Lucky Punch": 0,
             "Magaru": 0,
             "Wind Wall": 21
-        }
+        },
+        "area": "Chemdah",
+        "floor": "L6 & 7"
     },
     "Sui-Ki": {
+        "inherits": "Ice",
         "item": "Mabufu",
         "skillCard": true,
         "arcana": "Moon",
@@ -2841,9 +3196,12 @@ var personaMap = {
             "Null Nuke": 26,
             "Wage War": 27
         },
-        "personality": "Unknown"
+        "personality": "Unknown",
+        "area": "Kaitul",
+        "floor": "L7-9"
     },
     "Surt": {
+        "inherits": "Fire",
         "item": "Fire Amp",
         "skillCard": true,
         "arcana": "Magician",
@@ -2860,6 +3218,7 @@ var personaMap = {
         }
     },
     "Suzaku": {
+        "inherits": "Nuclear",
         "item": "Mafrei",
         "skillCard": true,
         "arcana": "Sun",
@@ -2877,6 +3236,7 @@ var personaMap = {
         }
     },
     "Take-Minakata": {
+        "inherits": "Electric",
         "item": "Thunder Band",
         "arcana": "Hanged Man",
         "level": 29,
@@ -2890,9 +3250,12 @@ var personaMap = {
             "Mazionga": 30,
             "Zionga": 0
         },
-        "personality": "Gloomy"
+        "personality": "Gloomy",
+        "area": "Kaitul",
+        "floor": "L7-9"
     },
     "Thanatos": {
+        "inherits": "Almighty",
         "item": "Darkness Ring",
         "arcana": "Death",
         "level": 65,
@@ -2910,6 +3273,7 @@ var personaMap = {
         "dlc": true
     },
     "Thanatos Picaro": {
+        "inherits": "Almighty",
         "item": "Maeigaon",
         "skillCard": true,
         "arcana": "Death",
@@ -2943,9 +3307,12 @@ var personaMap = {
             "Tarukaja": 0,
             "Tarunda": 0
         },
-        "rare": true
+        "rare": true,
+        "area": "Kaitul",
+        "floor": "L1-5, 7-9"
     },
     "Thor": {
+        "inherits": "Electric",
         "item": "Mjolnir",
         "arcana": "Chariot",
         "level": 64,
@@ -2962,6 +3329,7 @@ var personaMap = {
         }
     },
     "Thoth": {
+        "inherits": "Nuclear",
         "item": "Growth 2",
         "skillCard": true,
         "arcana": "Emperor",
@@ -2977,9 +3345,12 @@ var personaMap = {
             "Taunt": 0,
             "Psy Wall": 39
         },
-        "personality": "Gloomy"
+        "personality": "Gloomy",
+        "area": "Akzeriyyuth",
+        "floor": "L6, 7, 9-11"
     },
     "Throne": {
+        "inherits": "Bless",
         "item": "Invigorate 3",
         "skillCard": true,
         "arcana": "Justice",
@@ -2999,6 +3370,7 @@ var personaMap = {
         "note": "Needs Strength cooperation rank 5 to be fused"
     },
     "Titania": {
+        "inherits": "Nuclear",
         "item": "Mediarahan",
         "skillCard": true,
         "arcana": "Empress",
@@ -3012,9 +3384,12 @@ var personaMap = {
             "Makara Break": 0,
             "Mediarahan": 61,
             "Nuke Amp": 60
-        }
+        },
+        "area": "Sheriruth",
+        "floor": "L8, 9, 11-13 (after Palace 7)"
     },
     "Trumpeter": {
+        "inherits": "Almighty",
         "item": "Debilitate",
         "skillCard": true,
         "arcana": "Judgement",
@@ -3034,6 +3409,7 @@ var personaMap = {
         "note": "Needs Strength cooperation rank 5 to be fused"
     },
     "Tsukiyomi": {
+        "inherits": "Almighty",
         "item": "Black Moon",
         "arcana": "Moon",
         "level": 50,
@@ -3051,6 +3427,7 @@ var personaMap = {
         "dlc": true
     },
     "Tsukiyomi Picaro": {
+        "inherits": "Almighty",
         "item": "Spell Master",
         "skillCard": true,
         "arcana": "Moon",
@@ -3069,6 +3446,7 @@ var personaMap = {
         "dlc": true
     },
     "Unicorn": {
+        "inherits": "Bless",
         "item": "Samarecarm",
         "skillCard": true,
         "arcana": "Hierophant",
@@ -3084,9 +3462,12 @@ var personaMap = {
             "Samarecarm": 41,
             "Swift Strike": 42
         },
-        "personality": "Unknown"
+        "personality": "Unknown",
+        "area": "Sheriruth",
+        "floor": "L1-4 (before Palace 7) / L1 & 2 (after Palace 7)"
     },
     "Uriel": {
+        "inherits": "Almighty",
         "item": "Heaven's Gate",
         "arcana": "Justice",
         "level": 81,
@@ -3103,6 +3484,7 @@ var personaMap = {
         }
     },
     "Valkyrie": {
+        "inherits": "Physical",
         "item": "Giant Slice",
         "skillCard": true,
         "arcana": "Strength",
@@ -3116,9 +3498,12 @@ var personaMap = {
             "Dodge Physical": 49,
             "Matarukaja": 47,
             "Rising Slash": 0
-        }
+        },
+        "area": "Sheriruth",
+        "floor": "L3-5, 7-9 (before Palace 7) / L2-4 (after Palace 7)"
     },
     "Vasuki": {
+        "inherits": "Ailment",
         "item": "Kuzuryu Gouhou",
         "arcana": "Hanged Man",
         "level": 68,
@@ -3137,6 +3522,7 @@ var personaMap = {
         "note": "Needs Strength cooperation rank 1 to be fused"
     },
     "Vishnu": {
+        "inherits": "Almighty",
         "item": "Riot Gun",
         "skillCard": true,
         "arcana": "Fool",
@@ -3156,6 +3542,7 @@ var personaMap = {
         "max": true
     },
     "White Rider": {
+        "inherits": "Curse",
         "item": "Triple Down",
         "skillCard": true,
         "arcana": "Chariot",
@@ -3174,6 +3561,7 @@ var personaMap = {
         }
     },
     "Yaksini": {
+        "inherits": "Ice",
         "item": "Vicious Strike",
         "skillCard": true,
         "arcana": "Empress",
@@ -3188,9 +3576,12 @@ var personaMap = {
             "Vicious Strike": 24,
             "Wage War": 0
         },
-        "personality": "Irritable"
+        "personality": "Irritable",
+        "area": "Kaitul",
+        "floor": "L3-5, 7"
     },
     "Yamata-no-Orochi": {
+        "inherits": "Ice",
         "item": "Oni Kagura",
         "skillCard": true,
         "arcana": "Judgement",
@@ -3207,6 +3598,7 @@ var personaMap = {
         }
     },
     "Yatagarasu": {
+        "inherits": "Fire",
         "item": "Black Wing Robe",
         "arcana": "Sun",
         "level": 57,
@@ -3223,6 +3615,7 @@ var personaMap = {
         }
     },
     "Yoshitsune": {
+        "inherits": "Physical",
         "item": "Usumidori",
         "arcana": "Tower",
         "level": 79,
@@ -3241,6 +3634,7 @@ var personaMap = {
         "note": "Needs Strength cooperation rank 5 to be fused"
     },
     "Yurlungur": {
+        "inherits": "Electric",
         "item": "Mirrirmina",
         "arcana": "Sun",
         "level": 42,
@@ -3257,6 +3651,7 @@ var personaMap = {
         }
     },
     "Zaou-Gongen": {
+        "inherits": "Fire",
         "item": "God's Hand",
         "skillCard": true,
         "arcana": "Strength",
@@ -3275,6 +3670,7 @@ var personaMap = {
         "max": true
     },
     "Zouchouten": {
+        "inherits": "Electric",
         "item": "Sharp Student",
         "skillCard": true,
         "arcana": "Strength",

--- a/data/PersonaData.ts
+++ b/data/PersonaData.ts
@@ -24,7 +24,7 @@ interface PersonaData {
     inherits?: string;
     item?: string;
     itemr?: string;
-    skillCard?: boolean;
+    skillCard?: boolean; //determines if this persona's itemization results in a skill card
     trait?: string;
 
     // only for when converted to list
@@ -56,10 +56,15 @@ interface PersonaData {
     nuclearValue?: number;
     blessValue?: number;
     curseValue?: number;
+
+    //mementos location data
+    area?: string; //path name
+    floor?: string; //path level
 }
 
 const personaMap : PersonaMap = {
     "Abaddon": {
+        "inherits": "Curse",
         "item": "Makarakarn",
         "skillCard": true,
         "arcana": "Judgement",
@@ -76,6 +81,7 @@ const personaMap : PersonaMap = {
         }
     },
     "Agathion": {
+        "inherits": "Electric",
         "item": "Zio",
         "skillCard": true,
         "arcana": "Chariot",
@@ -83,9 +89,12 @@ const personaMap : PersonaMap = {
         "stats": [3, 4, 5, 7, 3],
         "elems": ["-", "rs", "-", "-", "rs", "wk", "-", "-", "-", "-"],
         "skills": {"Baisudi": 0, "Dia": 0, "Dodge Elec": 8, "Lunge": 4, "Rakukaja": 6, "Zio": 0},
-        "personality": "Timid"
+        "personality": "Timid",
+        "area": "Aiyatsbus",
+        "floor": "L1"
     },
     "Alice": {
+        "inherits": "Curse",
         "item": "Mamudoon",
         "skillCard": true,
         "arcana": "Death",
@@ -105,14 +114,18 @@ const personaMap : PersonaMap = {
         "max": true
     },
     "Ame-no-Uzume": {
+        "inherits": "Almighty",
         "item": "Senryou Yakusha",
         "arcana": "Lovers",
         "level": 29,
         "stats": [15, 22, 19, 20, 18],
         "elems": ["-", "-", "ab", "-", "-", "-", "wk", "-", "-", "-"],
-        "skills": {"Bufula": 0, "Diarama": 0, "Divine Grace": 32, "Mazio": 0, "Shock Boost": 34, "Tentarafoo": 31}
+        "skills": {"Bufula": 0, "Diarama": 0, "Divine Grace": 32, "Mazio": 0, "Shock Boost": 34, "Tentarafoo": 31},
+        "area": "Chemdah",
+        "floor": "L6 & 7"
     },
     "Ananta": {
+        "inherits": "Nuclear",
         "item": "Hua Khon",
         "arcana": "Star",
         "level": 43,
@@ -130,6 +143,7 @@ const personaMap : PersonaMap = {
         }
     },
     "Andras": {
+        "inherits": "Ice",
         "item": "Ice Break",
         "skillCard": true,
         "arcana": "Devil",
@@ -137,9 +151,12 @@ const personaMap : PersonaMap = {
         "stats": [5, 9, 7, 10, 6],
         "elems": ["-", "wk", "wk", "rs", "-", "-", "-", "-", "-", "-"],
         "skills": {"Apt Pupil": 13, "Bufu": 0, "Ice Break": 15, "Mabufu": 14, "Rakunda": 0, "Tarukaja": 11},
-        "personality": "Timid"
+        "personality": "Timid",
+        "area": "Aiyatsbus",
+        "floor": "L5 & 6"
     },
     "Angel": {
+        "inherits": "Bless",
         "item": "Baisudi",
         "skillCard": true,
         "arcana": "Justice",
@@ -147,9 +164,12 @@ const personaMap : PersonaMap = {
         "stats": [7, 9, 9, 9, 9],
         "elems": ["-", "-", "-", "-", "rs", "-", "-", "-", "nu", "wk"],
         "skills": {"Baisudi": 14, "Dazzler": 0, "Dekunda": 17, "Dia": 0, "Dodge Curse": 15, "Hama": 0, "Kouha": 13},
-        "personality": "Irritable"
+        "personality": "Irritable",
+        "area": "Aiyatsbus / Kaitul",
+        "floor": "L5 & 6 / L1-4"
     },
     "Anubis": {
+        "inherits": "Almighty",
         "item": "Makouha",
         "skillCard": true,
         "arcana": "Judgement",
@@ -165,9 +185,12 @@ const personaMap : PersonaMap = {
             "Null Fear": 39,
             "Resist Bless": 41
         },
-        "personality": "Gloomy"
+        "personality": "Gloomy",
+        "area": "Akzeriyyuth",
+        "floor": "L10 & 11"
     },
     "Anzu": {
+        "inherits": "Wind",
         "item": "Dekaja",
         "skillCard": true,
         "arcana": "Hierophant",
@@ -175,9 +198,12 @@ const personaMap : PersonaMap = {
         "stats": [14, 18, 15, 21, 14],
         "elems": ["-", "wk", "-", "-", "rs", "rp", "-", "wk", "-", "-"],
         "skills": {"Assault Dive": 27, "Dekaja": 28, "Garula": 0, "Masukukaja": 0, "Null Forget": 29, "Wind Break": 0},
-        "personality": "Irritable"
+        "personality": "Irritable",
+        "area": "Akzeriyyuth",
+        "floor": "L1-3, 5-7, 9-11"
     },
     "Apsaras": {
+        "inherits": "Ice",
         "item": "Freeze Boost",
         "skillCard": true,
         "arcana": "Priestess",
@@ -185,9 +211,12 @@ const personaMap : PersonaMap = {
         "stats": [7, 11, 6, 10, 6],
         "elems": ["-", "-", "-", "rs", "wk", "-", "-", "-", "-", "-"],
         "skills": {"Bufu": 0, "Elec Wall": 14, "Ice Wall": 0, "Media": 13, "Rebellion": 0, "Wind Wall": 16},
-        "personality": "Upbeat"
+        "personality": "Upbeat",
+        "area": "Chemdah",
+        "floor": "L1-4"
     },
     "Ara Mitama": {
+        "inherits": "Nuclear",
         "item": "Freila",
         "skillCard": true,
         "arcana": "Chariot",
@@ -197,6 +226,7 @@ const personaMap : PersonaMap = {
         "skills": {"Freila": 0, "Marakunda": 33, "Miracle Punch": 0, "Taunt": 0, "Rage Boost": 35, "Rebellion": 32}
     },
     "Arahabaki": {
+        "inherits": "Ailment",
         "item": "Tapsuan",
         "arcana": "Hermit",
         "level": 35,
@@ -210,9 +240,12 @@ const personaMap : PersonaMap = {
             "Null Brainwash": 0,
             "Spirit Drain": 37
         },
-        "personality": "Gloomy"
+        "personality": "Gloomy",
+        "area": "Adyeshach",
+        "floor": "L1-4, 6-8, 10"
     },
     "Archangel": {
+        "inherits": "Bless",
         "item": "Dazzler",
         "skillCard": true,
         "arcana": "Justice",
@@ -220,9 +253,12 @@ const personaMap : PersonaMap = {
         "stats": [13, 10, 13, 12, 7],
         "elems": ["-", "-", "-", "-", "wk", "-", "-", "-", "nu", "wk"],
         "skills": {"Dazzler": 0, "Hama": 0, "Vajra Blast": 21, "Makouha": 19, "Psi": 0, "Rebellion": 18},
-        "personality": "Irritable"
+        "personality": "Irritable",
+        "area": "Aiyatsbus",
+        "floor": "L5 & 6"
     },
     "Ardha": {
+        "inherits": "Almighty",
         "item": "Agneyastra",
         "skillCard": true,
         "arcana": "Temperance",
@@ -242,6 +278,7 @@ const personaMap : PersonaMap = {
         "max": true
     },
     "Ariadne": {
+        "inherits": "Almighty",
         "item": "Red Yarn Ball",
         "arcana": "Fortune",
         "level": 30,
@@ -259,6 +296,7 @@ const personaMap : PersonaMap = {
         "dlc": true
     },
     "Ariadne Picaro": {
+        "inherits": "Almighty",
         "item": "Auto-Mataru",
         "skillCard": true,
         "arcana": "Fortune",
@@ -277,6 +315,7 @@ const personaMap : PersonaMap = {
         "dlc": true
     },
     "Arsène": {
+        "inherits": "Curse",
         "item": "Arsène's Cane",
         "arcana": "Fool",
         "level": 1,
@@ -285,6 +324,7 @@ const personaMap : PersonaMap = {
         "skills": {"Cleave": 2, "Adverse Resolve": 7, "Dream Needle": 5, "Eiha": 1, "Sukunda": 4}
     },
     "Asterius": {
+        "inherits": "Almighty",
         "item": "Thunder Horns",
         "arcana": "Fortune",
         "level": 56,
@@ -302,6 +342,7 @@ const personaMap : PersonaMap = {
         "dlc": true
     },
     "Asterius Picaro": {
+        "inherits": "Almighty",
         "item": "Gigantomachia",
         "skillCard": true,
         "arcana": "Fortune",
@@ -320,6 +361,7 @@ const personaMap : PersonaMap = {
         "dlc": true
     },
     "Asura-Ou": {
+        "inherits": "Nuclear",
         "item": "Vajra",
         "arcana": "Sun",
         "level": 76,
@@ -338,6 +380,7 @@ const personaMap : PersonaMap = {
         "max": true
     },
     "Atropos": {
+        "inherits": "Electric",
         "item": "Mazionga",
         "skillCard": true,
         "arcana": "Fortune",
@@ -355,6 +398,7 @@ const personaMap : PersonaMap = {
         }
     },
     "Attis": {
+        "inherits": "Fire",
         "item": "Enduring Soul",
         "skillCard": true,
         "arcana": "Hanged Man",
@@ -373,6 +417,7 @@ const personaMap : PersonaMap = {
         "max": true
     },
     "Baal": {
+        "inherits": "Wind",
         "item": "Yagrush",
         "arcana": "Emperor",
         "level": 75,
@@ -389,6 +434,7 @@ const personaMap : PersonaMap = {
         }
     },
     "Baphomet": {
+        "inherits": "Almighty",
         "item": "Shock Boost",
         "skillCard": true,
         "arcana": "Devil",
@@ -403,9 +449,12 @@ const personaMap : PersonaMap = {
             "Freeze Boost": 63,
             "Shock Boost": 62,
             "Ziodyne": 61
-        }
+        },
+        "area": "Sheriruth",
+        "floor": "L13 (after Palace 7)"
     },
     "Barong": {
+        "inherits": "Electric",
         "item": "Invigorate 2",
         "skillCard": true,
         "arcana": "Emperor",
@@ -419,9 +468,12 @@ const personaMap : PersonaMap = {
             "Null Elec": 55,
             "Wage War": 0,
             "Ziodyne": 0
-        }
+        },
+        "area": "Sheriruth",
+        "floor": "L11 & 12 (after Palace 7)"
     },
     "Beelzebub": {
+        "inherits": "Curse",
         "item": "Fleur du Mal",
         "arcana": "Devil",
         "level": 84,
@@ -440,6 +492,7 @@ const personaMap : PersonaMap = {
         "max": true
     },
     "Belial": {
+        "inherits": "Curse",
         "item": "Maragion",
         "skillCard": true,
         "arcana": "Devil",
@@ -457,6 +510,7 @@ const personaMap : PersonaMap = {
         }
     },
     "Belphegor": {
+        "inherits": "Ice",
         "item": "Mabufula",
         "skillCard": true,
         "arcana": "Tower",
@@ -464,9 +518,12 @@ const personaMap : PersonaMap = {
         "stats": [25, 27, 24, 23, 19],
         "elems": ["-", "-", "wk", "rs", "rs", "-", "-", "rs", "-", "rp"],
         "skills": {"Bufula": 0, "Dodge Fire": 0, "Ice Break": 39, "Mabufula": 41, "Concentrate": 44, "Null Rage": 38},
-        "personality": "Irritable"
+        "personality": "Irritable",
+        "area": "Adyeshach",
+        "floor": "L6-8, 10"
     },
     "Berith": {
+        "inherits": "Physical",
         "item": "Cleave",
         "skillCard": true,
         "arcana": "Hierophant",
@@ -474,9 +531,12 @@ const personaMap : PersonaMap = {
         "stats": [8, 6, 7, 8, 5],
         "elems": ["-", "nu", "rs", "wk", "-", "-", "-", "-", "-", "-"],
         "skills": {"Cleave": 0, "Dodge Fire": 11, "Double Fangs": 10, "Rakukaja": 0, "Sledgehammer": 13},
-        "personality": "Irritable"
+        "personality": "Irritable",
+        "area": "Aiyatsbus",
+        "floor": "L5 & 6"
     },
     "Bicorn": {
+        "inherits": "Wind",
         "item": "Garu",
         "skillCard": true,
         "arcana": "Hermit",
@@ -484,9 +544,12 @@ const personaMap : PersonaMap = {
         "stats": [5, 3, 3, 5, 3],
         "elems": ["-", "-", "-", "-", "wk", "-", "-", "-", "-", "rs"],
         "skills": {"Apt Pupil": 8, "Garu": 6, "Ice Wall": 7, "Lunge": 0, "Tarunda": 0},
-        "personality": "Irritable"
+        "personality": "Irritable",
+        "area": "Aiyatsbus",
+        "floor": "L1 & 2"
     },
     "Bishamonten": {
+        "inherits": "Nuclear",
         "item": "Mafreidyne",
         "skillCard": true,
         "arcana": "Hierophant",
@@ -504,6 +567,7 @@ const personaMap : PersonaMap = {
         }
     },
     "Black Frost": {
+        "inherits": "Almighty",
         "item": "Naraka Whip",
         "arcana": "Fool",
         "level": 67,
@@ -521,6 +585,7 @@ const personaMap : PersonaMap = {
         "note": "Request \"One Who Bullies Bullies\" must be cleared"
     },
     "Black Ooze": {
+        "inherits": "Curse",
         "item": "Stagnant Air",
         "skillCard": true,
         "arcana": "Moon",
@@ -536,9 +601,12 @@ const personaMap : PersonaMap = {
             "Matarunda": 0,
             "Stagnant Air": 0
         },
-        "personality": "Irritable"
+        "personality": "Irritable",
+        "area": "Adyeshach",
+        "floor": "L1-4, 6"
     },
     "Black Rider": {
+        "inherits": "Curse",
         "item": "Bad Beat",
         "skillCard": true,
         "arcana": "Tower",
@@ -556,6 +624,7 @@ const personaMap : PersonaMap = {
         }
     },
     "Bugs": {
+        "inherits": "Almighty",
         "item": "Bear Gloves",
         "arcana": "Fool",
         "level": 49,
@@ -574,6 +643,7 @@ const personaMap : PersonaMap = {
         "note": "Request \"The Lovesick Cyberstalking Girl\" must be cleared"
     },
     "Byakko": {
+        "inherits": "Ice",
         "item": "Swift Strike",
         "skillCard": true,
         "arcana": "Temperance",
@@ -591,6 +661,7 @@ const personaMap : PersonaMap = {
         }
     },
     "Cerberus": {
+        "inherits": "Fire",
         "item": "Agidyne",
         "skillCard": true,
         "arcana": "Chariot",
@@ -605,9 +676,12 @@ const personaMap : PersonaMap = {
             "Rebellion": 56,
             "Regenerate 2": 58
         },
-        "personality": "Unknown"
+        "personality": "Unknown",
+        "area": "Sheriruth",
+        "floor": "L7-9 (after Palace 7)"
     },
     "Chernobog": {
+        "inherits": "Ailment",
         "item": "Deadly Fury",
         "skillCard": true,
         "arcana": "Death",
@@ -625,6 +699,7 @@ const personaMap : PersonaMap = {
         }
     },
     "Chi You": {
+        "inherits": "Psy",
         "item": "Arms Master",
         "skillCard": true,
         "arcana": "Chariot",
@@ -644,6 +719,7 @@ const personaMap : PersonaMap = {
         "max": true
     },
     "Choronzon": {
+        "inherits": "Curse",
         "item": "Maeiha",
         "skillCard": true,
         "arcana": "Magician",
@@ -660,9 +736,12 @@ const personaMap : PersonaMap = {
             "Rainy Play": 33,
             "Rampage": 0
         },
-        "personality": "Timid"
+        "personality": "Timid",
+        "area": "Kaitul",
+        "floor": "L1-4"
     },
     "Clotho": {
+        "inherits": "Healing",
         "item": "Invigorate 1",
         "skillCard": true,
         "arcana": "Fortune",
@@ -695,9 +774,12 @@ const personaMap : PersonaMap = {
             "Maragidyne": 0,
             "Maziodyne": 0
         },
-        "rare": true
+        "rare": true,
+        "area": "Sheriruth",
+        "floor": "L7-9. 11-13 (after Palace 7)"
     },
     "Cu Chulainn": {
+        "inherits": "Almighty",
         "item": "Charge",
         "skillCard": true,
         "arcana": "Star",
@@ -715,6 +797,7 @@ const personaMap : PersonaMap = {
         }
     },
     "Cybele": {
+        "inherits": "Healing",
         "item": "Sabazios",
         "arcana": "Priestess",
         "level": 73,
@@ -732,6 +815,7 @@ const personaMap : PersonaMap = {
         "max": true
     },
     "Daisoujou": {
+        "inherits": "Bless",
         "item": "Makouga",
         "skillCard": true,
         "arcana": "Hierophant",
@@ -749,6 +833,7 @@ const personaMap : PersonaMap = {
         }
     },
     "Dakini": {
+        "inherits": "Physical",
         "item": "Deathbound",
         "skillCard": true,
         "arcana": "Empress",
@@ -764,9 +849,12 @@ const personaMap : PersonaMap = {
             "Rising Slash": 0,
             "Rebellion": 54
         },
-        "personality": "Unknown"
+        "personality": "Unknown",
+        "area": "Sheriruth",
+        "floor": "L7-9 (after Palace 7)"
     },
     "Decarabia": {
+        "inherits": "Fire",
         "item": "Fire Boost",
         "skillCard": true,
         "arcana": "Fool",
@@ -782,9 +870,12 @@ const personaMap : PersonaMap = {
             "Tetrakarn": 38,
             "Ominous Words": 0
         },
-        "personality": "Gloomy"
+        "personality": "Gloomy",
+        "area": "Adyeshach",
+        "floor": "L3, 4, 6-8"
     },
     "Dionysus": {
+        "inherits": "Psy",
         "item": "Thermopylae",
         "skillCard": true,
         "arcana": "Fool",
@@ -802,6 +893,7 @@ const personaMap : PersonaMap = {
         }
     },
     "Dominion": {
+        "inherits": "Bless",
         "item": "Makougaon",
         "skillCard": true,
         "arcana": "Justice",
@@ -820,6 +912,7 @@ const personaMap : PersonaMap = {
         "personality": "Unknown"
     },
     "Eligor": {
+        "inherits": "Fire",
         "item": "Tarukaja",
         "skillCard": true,
         "arcana": "Emperor",
@@ -834,7 +927,9 @@ const personaMap : PersonaMap = {
             "Sukunda": 19,
             "Tarukaja": 0
         },
-        "personality": "Unknown"
+        "personality": "Unknown",
+        "area": "Chemdah",
+        "floor": "L3 & 4"
     },
     "Emperor's Amulet": {
         "item": "Emperor's Amulet",
@@ -852,9 +947,12 @@ const personaMap : PersonaMap = {
             "Psiodyne": 0,
             "Ziodyne": 0
         },
-        "rare": true
+        "rare": true,
+        "area": "Sheriruth",
+        "floor": "L7-9, 11-13 (after Palace 7)"
     },
     "Phoenix": {
+        "inherits": "Nuclear",
         "item": "Nuke Boost",
         "skillCard": true,
         "arcana": "Hierophant",
@@ -864,6 +962,7 @@ const personaMap : PersonaMap = {
         "skills": {"Diarama": 23, "Dream Needle": 0, "Freila": 0, "Nuke Boost": 27, "Recarm": 25}
     },
     "Flauros": {
+        "inherits": "Ailment",
         "item": "Shackles",
         "arcana": "Devil",
         "level": 25,
@@ -882,6 +981,7 @@ const personaMap : PersonaMap = {
         "note": "Needs Strength cooperation rank 1 to be fused"
     },
     "Forneus": {
+        "inherits": "Psy",
         "item": "Masukunda",
         "skillCard": true,
         "arcana": "Hierophant",
@@ -897,9 +997,12 @@ const personaMap : PersonaMap = {
             "Stagnant Air": 66,
             "Survival Trick": 65
         },
-        "personality": "Unknown"
+        "personality": "Unknown",
+        "area": "Sheriruth",
+        "floor": "L12 & 13 (after Palace 7)"
     },
     "Fortuna": {
+        "inherits": "Wind",
         "item": "Fast Heal",
         "skillCard": true,
         "arcana": "Fortune",
@@ -917,6 +1020,7 @@ const personaMap : PersonaMap = {
         }
     },
     "Futsunushi": {
+        "inherits": "Physical",
         "item": "Brave Blade",
         "skillCard": true,
         "arcana": "Magician",
@@ -936,6 +1040,7 @@ const personaMap : PersonaMap = {
         "max": true
     },
     "Fuu-Ki": {
+        "inherits": "Wind",
         "item": "Wind Boost",
         "skillCard": true,
         "arcana": "Star",
@@ -943,9 +1048,12 @@ const personaMap : PersonaMap = {
         "stats": [14, 17, 16, 15, 14],
         "elems": ["-", "-", "-", "-", "wk", "ab", "-", "-", "-", "-"],
         "skills": {"Dodge Wind": 26, "Garula": 0, "Resist Psy": 27, "Tarukaja": 0, "Tetra Break": 0, "Wind Boost": 25},
-        "personality": "Unknown"
+        "personality": "Unknown",
+        "area": "Kaitul",
+        "floor": "L8 & 9"
     },
     "Gabriel": {
+        "inherits": "Almighty",
         "item": "Mabufudyne",
         "skillCard": true,
         "arcana": "Temperance",
@@ -964,6 +1072,7 @@ const personaMap : PersonaMap = {
         }
     },
     "Ganesha": {
+        "inherits": "Ailment",
         "item": "Miracle Punch",
         "skillCard": true,
         "arcana": "Sun",
@@ -979,9 +1088,12 @@ const personaMap : PersonaMap = {
             "Rebellion": 0,
             "Tetraja": 55
         },
-        "personality": "Unknown"
+        "personality": "Unknown",
+        "area": "Sheriruth",
+        "floor": "L5, 7-9 (before Palace 7) / L3 & 4 (after Palace 7)"
     },
     "Garuda": {
+        "inherits": "Wind",
         "item": "Wind Amp",
         "skillCard": true,
         "arcana": "Star",
@@ -997,9 +1109,12 @@ const personaMap : PersonaMap = {
             "Masukukaja": 54,
             "Wind Amp": 59
         },
-        "personality": "Unknown"
+        "personality": "Unknown",
+        "area": "Sheriruth",
+        "floor": "L12 (after Palace 7)"
     },
     "Genbu": {
+        "inherits": "Ice",
         "item": "Patra",
         "skillCard": true,
         "arcana": "Temperance",
@@ -1009,6 +1124,7 @@ const personaMap : PersonaMap = {
         "skills": {"Bufu": 0, "Defense Master": 12, "Mabufu": 10, "Patra": 8, "Rakunda": 0, "Resist Forget": 11}
     },
     "Girimehkala": {
+        "inherits": "Ailment",
         "item": "Marakunda",
         "skillCard": true,
         "arcana": "Moon",
@@ -1016,9 +1132,12 @@ const personaMap : PersonaMap = {
         "stats": [36, 24, 32, 32, 15],
         "elems": ["rp", "rp", "rs", "-", "-", "-", "-", "-", "wk", "nu"],
         "skills": {"Foul Breath": 46, "Marakunda": 0, "Mudoon": 0, "Repel Phys": 51, "Swift Strike": 0, "Wage War": 48},
-        "personality": "Gloomy"
+        "personality": "Gloomy",
+        "area": "Adyeshach",
+        "floor": "L4, 6-8, 10"
     },
     "Hanuman": {
+        "inherits": "Physical",
         "item": "Ruyi Jingu Bang",
         "arcana": "Star",
         "level": 64,
@@ -1032,9 +1151,12 @@ const personaMap : PersonaMap = {
             "Tempest Slash": 0,
             "Tetra Break": 67
         },
-        "personality": "Unknown"
+        "personality": "Unknown",
+        "area": "Sheriruth",
+        "floor": "L12 & 13 (after Palace 7)"
     },
     "Hariti": {
+        "inherits": "Electric",
         "item": "Spirit Drain",
         "skillCard": true,
         "arcana": "Empress",
@@ -1054,6 +1176,7 @@ const personaMap : PersonaMap = {
         "personality": "Unknown"
     },
     "Hecatoncheires": {
+        "inherits": "Psy",
         "item": "Endure",
         "skillCard": true,
         "arcana": "Hanged Man",
@@ -1071,6 +1194,7 @@ const personaMap : PersonaMap = {
         }
     },
     "Hell Biker": {
+        "inherits": "Fire",
         "item": "Black Jacket",
         "arcana": "Death",
         "level": 39,
@@ -1088,6 +1212,7 @@ const personaMap : PersonaMap = {
         }
     },
     "High Pixie": {
+        "inherits": "Healing",
         "item": "Diarama",
         "skillCard": true,
         "arcana": "Fool",
@@ -1095,7 +1220,9 @@ const personaMap : PersonaMap = {
         "stats": [8, 14, 10, 13, 10],
         "elems": ["-", "wk", "-", "-", "rs", "rs", "-", "wk", "-", "-"],
         "skills": {"Diarama": 18, "Dormina": 0, "Garu": 0, "Magaru": 20, "Media": 0, "Taunt": 19},
-        "personality": "Irritable"
+        "personality": "Irritable",
+        "area": "Kaitul",
+        "floor": "L1-3"
     },
     "Hope Diamond": {
         "item": "Hope Diamond",
@@ -1113,9 +1240,12 @@ const personaMap : PersonaMap = {
             "Invigorate 2": 0,
             "Regenerate 2": 0
         },
-        "rare": true
+        "rare": true,
+        "area": "Sheriruth",
+        "floor": "L7-9. 11-13 (after Palace 7)"
     },
     "Horus": {
+        "inherits": "Almighty",
         "item": "Kougaon",
         "skillCard": true,
         "arcana": "Sun",
@@ -1133,6 +1263,7 @@ const personaMap : PersonaMap = {
         }
     },
     "Hua Po": {
+        "inherits": "Fire",
         "item": "Agilao",
         "skillCard": true,
         "arcana": "Hanged Man",
@@ -1140,9 +1271,12 @@ const personaMap : PersonaMap = {
         "stats": [4, 10, 4, 8, 8],
         "elems": ["-", "wk", "rp", "wk", "-", "-", "-", "-", "-", "-"],
         "skills": {"Agi": 0, "Burn Boost": 15, "Dormina": 0, "Maragi": 13, "Resist Forget": 12, "Tarunda": 11},
-        "personality": "Upbeat"
+        "personality": "Upbeat",
+        "area": "Chemdah",
+        "floor": "L1-3"
     },
     "Incubus": {
+        "inherits": "Ailment",
         "item": "Dream Needle",
         "skillCard": true,
         "arcana": "Devil",
@@ -1150,9 +1284,12 @@ const personaMap : PersonaMap = {
         "stats": [4, 6, 4, 5, 3],
         "elems": ["-", "wk", "-", "-", "rs", "-", "-", "-", "wk", "-"],
         "skills": {"Life Drain": 0, "Evil Touch": 0, "Dodge Curse": 9, "Eiha": 7, "Tarunda": 8},
-        "personality": "Timid"
+        "personality": "Timid",
+        "area": "Aiyatsbus",
+        "floor": "L2, 3 & 6"
     },
     "Inugami": {
+        "inherits": "Fire",
         "item": "Brain Shake",
         "skillCard": true,
         "arcana": "Hanged Man",
@@ -1168,9 +1305,12 @@ const personaMap : PersonaMap = {
             "Pulinpa": 0,
             "Tarukaja": 0
         },
-        "personality": "Timid"
+        "personality": "Timid",
+        "area": "Chemdah",
+        "floor": "L4, 6 & 7"
     },
     "Ippon-Datara": {
+        "inherits": "Physical",
         "item": "Sledgehammer",
         "skillCard": true,
         "arcana": "Hermit",
@@ -1185,9 +1325,12 @@ const personaMap : PersonaMap = {
             "Sledgehammer": 0,
             "Tarukaja": 0
         },
-        "personality": "Unknown"
+        "personality": "Unknown",
+        "area": "Chemdah",
+        "floor": "L1-4"
     },
     "Ishtar": {
+        "inherits": "Healing",
         "item": "Salvation",
         "skillCard": true,
         "arcana": "Lovers",
@@ -1206,6 +1349,7 @@ const personaMap : PersonaMap = {
         "max": true
     },
     "Isis": {
+        "inherits": "Healing",
         "item": "Zionga",
         "skillCard": true,
         "arcana": "Priestess",
@@ -1221,9 +1365,12 @@ const personaMap : PersonaMap = {
             "Sukukaja": 0,
             "Zionga": 29
         },
-        "personality": "Timid"
+        "personality": "Timid",
+        "area": "Akzeriyyuth",
+        "floor": "L5-7, 9-11"
     },
     "Izanagi": {
+        "inherits": "Almighty",
         "item": "White Headband",
         "arcana": "Fool",
         "level": 20,
@@ -1241,6 +1388,7 @@ const personaMap : PersonaMap = {
         "dlc": true
     },
     "Izanagi Picaro": {
+        "inherits": "Almighty",
         "item": "Growth 3",
         "skillCard": true,
         "arcana": "Fool",
@@ -1259,24 +1407,31 @@ const personaMap : PersonaMap = {
         "dlc": true
     },
     "Jack Frost": {
+        "inherits": "Ice",
         "item": "Frost Hood",
         "arcana": "Magician",
         "level": 11,
         "stats": [8, 9, 7, 9, 7],
         "elems": ["-", "-", "wk", "nu", "-", "-", "-", "-", "-", "-"],
         "skills": {"Baisudi": 0, "Bufu": 0, "Freeze Boost": 15, "Ice Break": 0, "Mabufu": 12, "Rakunda": 13},
-        "personality": "Timid"
+        "personality": "Timid",
+        "area": "Chemdah",
+        "floor": "L4 & 6"
     },
     "Jack-o'-Lantern": {
+        "inherits": "Fire",
         "item": "Pumpkin Bomb",
         "arcana": "Magician",
         "level": 2,
         "stats": [2, 3, 3, 3, 2],
         "elems": ["-", "wk", "ab", "wk", "-", "wk", "-", "-", "-", "-"],
         "skills": {"Agi": 0, "Dazzler": 5, "Sharp Student": 4, "Rakunda": 0, "Resist Sleep": 7},
-        "personality": "Gloomy"
+        "personality": "Gloomy",
+        "area": "Qimranut / Aiyatsbus",
+        "floor": "All / L1"
     },
     "Jatayu": {
+        "inherits": "Wind",
         "item": "Flash Bomb",
         "skillCard": true,
         "arcana": "Tower",
@@ -1294,6 +1449,7 @@ const personaMap : PersonaMap = {
         }
     },
     "Jikokuten": {
+        "inherits": "Physical",
         "item": "Memory Blow",
         "skillCard": true,
         "arcana": "Temperance",
@@ -1311,6 +1467,7 @@ const personaMap : PersonaMap = {
         }
     },
     "Kaguya": {
+        "inherits": "Almighty",
         "item": "Moonlight Robe",
         "arcana": "Moon",
         "level": 16,
@@ -1328,6 +1485,7 @@ const personaMap : PersonaMap = {
         "dlc": true
     },
     "Kaguya Picaro": {
+        "inherits": "Almighty",
         "item": "Diarahan",
         "skillCard": true,
         "arcana": "Moon",
@@ -1346,6 +1504,7 @@ const personaMap : PersonaMap = {
         "dlc": true
     },
     "Kaiwan": {
+        "inherits": "Almighty",
         "item": "Mapsio",
         "skillCard": true,
         "arcana": "Star",
@@ -1361,9 +1520,12 @@ const personaMap : PersonaMap = {
             "Psio": 0,
             "Speed Master": 38
         },
-        "personality": "Timid"
+        "personality": "Timid",
+        "area": "Adyeshach",
+        "floor": "L10-12"
     },
     "Kali": {
+        "inherits": "Fire",
         "item": "Khamrai Tao",
         "arcana": "Empress",
         "level": 77,
@@ -1380,6 +1542,7 @@ const personaMap : PersonaMap = {
         }
     },
     "Kelpie": {
+        "inherits": "Wind",
         "item": "Terror Claw",
         "skillCard": true,
         "arcana": "Strength",
@@ -1387,9 +1550,12 @@ const personaMap : PersonaMap = {
         "stats": [5, 5, 5, 6, 4],
         "elems": ["-", "-", "-", "rs", "wk", "-", "-", "-", "-", "-"],
         "skills": {"Garu": 0, "Lunge": 0, "Resist Brainwash": 8, "Sukukaja": 9, "Terror Claw": 10},
-        "personality": "Upbeat"
+        "personality": "Upbeat",
+        "area": "Aiyatsbus",
+        "floor": "L3"
     },
     "Kikuri-Hime": {
+        "inherits": "Healing",
         "item": "Divine Grace",
         "skillCard": true,
         "arcana": "Priestess",
@@ -1397,9 +1563,12 @@ const personaMap : PersonaMap = {
         "stats": [22, 31, 24, 28, 22],
         "elems": ["-", "-", "wk", "-", "-", "nu", "-", "-", "rs", "-"],
         "skills": {"Divine Grace": 45, "Energy Drop": 0, "Lullaby": 0, "Marakukaja": 0, "Mediarama": 41, "Tetraja": 43},
-        "personality": "Unknown"
+        "personality": "Unknown",
+        "area": "Sheriruth",
+        "floor": "L3-5 (before Palace 7) / L2 & 3 (after Palace 7)"
     },
     "Kin-Ki": {
+        "inherits": "Physical",
         "item": "Regenerate 1",
         "skillCard": true,
         "arcana": "Chariot",
@@ -1415,9 +1584,12 @@ const personaMap : PersonaMap = {
             "Regenerate 1": 0,
             "Sledgehammer": 28
         },
-        "personality": "Gloomy"
+        "personality": "Gloomy",
+        "area": "Kaitul",
+        "floor": "L4, 5, 7-9"
     },
     "King Frost": {
+        "inherits": "Ice",
         "item": "King Frost Cape",
         "arcana": "Emperor",
         "level": 61,
@@ -1432,9 +1604,12 @@ const personaMap : PersonaMap = {
             "Megaton Raid": 0,
             "Null Despair": 65
         },
-        "personality": "Unknown"
+        "personality": "Unknown",
+        "area": "Sheriruth",
+        "floor": "L8, 11, 12, 13 (after Palace 7)"
     },
     "Kodama": {
+        "inherits": "Ailment",
         "item": "Fear Boost",
         "skillCard": true,
         "arcana": "Star",
@@ -1450,7 +1625,9 @@ const personaMap : PersonaMap = {
             "Resist Fear": 17,
             "Tarukaja": 14
         },
-        "personality": "Upbeat"
+        "personality": "Upbeat",
+        "area": "Aiyatsbus",
+        "floor": "L1-3"
     },
     "Koh-i-Noor": {
         "item": "Koh-i-Noor",
@@ -1468,9 +1645,12 @@ const personaMap : PersonaMap = {
             "Dodge Psy": 0,
             "Dodge Wind": 0
         },
-        "rare": true
+        "rare": true,
+        "area": "Adyeshach",
+        "floor": "L1-4, 6-8, 10-12"
     },
     "Kohryu": {
+        "inherits": "Psy",
         "item": "Sudarshana",
         "arcana": "Hierophant",
         "level": 76,
@@ -1489,6 +1669,7 @@ const personaMap : PersonaMap = {
         "max": true
     },
     "Koppa Tengu": {
+        "inherits": "Wind",
         "item": "Growth 1",
         "skillCard": true,
         "arcana": "Temperance",
@@ -1496,9 +1677,12 @@ const personaMap : PersonaMap = {
         "stats": [7, 8, 8, 11, 6],
         "elems": ["-", "-", "-", "wk", "-", "rs", "-", "-", "wk", "-"],
         "skills": {"Snap": 0, "Garu": 0, "Growth 1": 12, "Taunt": 13, "Rage Boost": 14, "Wage War": 15},
-        "personality": "Upbeat"
+        "personality": "Upbeat",
+        "area": "Chemdah",
+        "floor": "L6 & 7"
     },
     "Koropokguru": {
+        "inherits": "Ice",
         "item": "Bufu",
         "skillCard": true,
         "arcana": "Hermit",
@@ -1506,9 +1690,12 @@ const personaMap : PersonaMap = {
         "stats": [5, 8, 6, 9, 6],
         "elems": ["-", "rs", "wk", "rs", "-", "rs", "-", "-", "-", "-"],
         "skills": {"Bufu": 0, "Dodge Ice": 11, "Fire Wall": 13, "Mabufu": 14, "Makajam": 0, "Rakunda": 12},
-        "personality": "Timid"
+        "personality": "Timid",
+        "area": "Chemdah",
+        "floor": "L2 & 3"
     },
     "Koumokuten": {
+        "inherits": "Physical",
         "item": "Regenerate 2",
         "skillCard": true,
         "arcana": "Hermit",
@@ -1527,6 +1714,7 @@ const personaMap : PersonaMap = {
         }
     },
     "Kumbhanda": {
+        "inherits": "Ailment",
         "item": "Rage Boost",
         "skillCard": true,
         "arcana": "Hermit",
@@ -1541,18 +1729,24 @@ const personaMap : PersonaMap = {
             "Stagnant Air": 0,
             "Tempest Slash": 43,
             "Wage War": 0
-        }
+        },
+        "area": "Sheriruth",
+        "floor": "L8, 9, 11-13 (before Palace 7) / L4 & 5 (after Palace 7)"
     },
     "Kurama Tengu": {
+        "inherits": "Wind",
         "item": "Garudyne",
         "skillCard": true,
         "arcana": "Hermit",
         "level": 56,
         "stats": [34, 38, 34, 42, 27],
         "elems": ["-", "-", "-", "wk", "-", "rp", "-", "-", "rs", "rs"],
-        "skills": {"Brain Buster": 0, "Garudyne": 57, "Growth 3": 58, "Heat Wave": 0, "Magarudyne": 60, "Masukunda": 0}
+        "skills": {"Brain Buster": 0, "Garudyne": 57, "Growth 3": 58, "Heat Wave": 0, "Magarudyne": 60, "Masukunda": 0},
+        "area": "Sheriruth",
+        "floor": "L11 (after Palace 7)"
     },
     "Kushinada": {
+        "inherits": "Healing",
         "item": "Wind Wall",
         "skillCard": true,
         "arcana": "Lovers",
@@ -1567,9 +1761,12 @@ const personaMap : PersonaMap = {
             "Mediarama": 0,
             "Null Sleep": 45,
             "Wind Wall": 46
-        }
+        },
+        "area": "Sheriruth",
+        "floor": "L5, 7-9 (before Palace 7) / L3 & 4 (after Palace 7)"
     },
     "Kushi Mitama": {
+        "inherits": "Healing",
         "item": "Forget Boost",
         "skillCard": true,
         "arcana": "Strength",
@@ -1587,6 +1784,7 @@ const personaMap : PersonaMap = {
         }
     },
     "Lachesis": {
+        "inherits": "Ice",
         "item": "Ice Boost",
         "skillCard": true,
         "arcana": "Fortune",
@@ -1604,6 +1802,7 @@ const personaMap : PersonaMap = {
         }
     },
     "Lakshmi": {
+        "inherits": "Healing",
         "item": "Life Aid",
         "skillCard": true,
         "arcana": "Fortune",
@@ -1622,6 +1821,7 @@ const personaMap : PersonaMap = {
         "max": true
     },
     "Lamia": {
+        "inherits": "Fire",
         "item": "Despair Boost",
         "skillCard": true,
         "arcana": "Empress",
@@ -1637,9 +1837,12 @@ const personaMap : PersonaMap = {
             "Rakukaja": 0,
             "Ominous Words": 27
         },
-        "personality": "Gloomy"
+        "personality": "Gloomy",
+        "area": "Akzeriyyuth",
+        "floor": "L3, 5-7, 9-11"
     },
     "Leanan Sidhe": {
+        "inherits": "Almighty",
         "item": "Recarm",
         "skillCard": true,
         "arcana": "Lovers",
@@ -1647,18 +1850,24 @@ const personaMap : PersonaMap = {
         "stats": [9, 17, 12, 16, 10],
         "elems": ["-", "-", "wk", "-", "-", "rs", "rs", "-", "-", "-"],
         "skills": {"Eiga": 23, "Mamudo": 21, "Mapsi": 22, "Marin Karin": 20, "Psio": 0, "Rakunda": 0},
-        "personality": "Irritable"
+        "personality": "Irritable",
+        "area": "Kaitul",
+        "floor": "L3-5"
     },
     "Legion": {
+        "inherits": "Psy",
         "item": "Legion's Jail",
         "arcana": "Fool",
         "level": 38,
         "stats": [24, 24, 30, 23, 20],
         "elems": ["rs", "rs", "rs", "-", "-", "-", "rs", "-", "wk", "nu"],
         "skills": {"Life Drain": 0, "Negative Pile": 0, "Null Dizzy": 42, "Psio": 39, "Rampage": 0, "Tetra Break": 40},
-        "personality": "Unknown"
+        "personality": "Unknown",
+        "area": "Adyeshach",
+        "floor": "L1-4"
     },
     "Lilim": {
+        "inherits": "Ice",
         "item": "Lullaby",
         "skillCard": true,
         "arcana": "Devil",
@@ -1674,9 +1883,12 @@ const personaMap : PersonaMap = {
             "Masukunda": 0,
             "Spirit Drain": 36
         },
-        "personality": "Gloomy"
+        "personality": "Gloomy",
+        "area": "Adyeshach",
+        "floor": "L6-8, 10-12"
     },
     "Lilith": {
+        "inherits": "Almighty",
         "item": "Mabufudyne",
         "skillCard": true,
         "arcana": "Moon",
@@ -1694,6 +1906,7 @@ const personaMap : PersonaMap = {
         }
     },
     "Lucifer": {
+        "inherits": "Almighty",
         "item": "Tyrant Pistol",
         "arcana": "Star",
         "level": 93,
@@ -1713,6 +1926,7 @@ const personaMap : PersonaMap = {
         "max": true
     },
     "Mada": {
+        "inherits": "Fire",
         "item": "Unshaken Will",
         "skillCard": true,
         "arcana": "Tower",
@@ -1732,6 +1946,7 @@ const personaMap : PersonaMap = {
         "max": true
     },
     "Magatsu-Izanagi": {
+        "inherits": "Almighty",
         "item": "Black Headband",
         "arcana": "Tower",
         "level": 44,
@@ -1749,6 +1964,7 @@ const personaMap : PersonaMap = {
         "dlc": true
     },
     "Magatsu-Izanagi Picaro": {
+        "inherits": "Almighty",
         "item": "Heat Riser",
         "skillCard": true,
         "arcana": "Tower",
@@ -1767,6 +1983,7 @@ const personaMap : PersonaMap = {
         "dlc": true
     },
     "Makami": {
+        "inherits": "Nuclear",
         "item": "Makajam",
         "skillCard": true,
         "arcana": "Temperance",
@@ -1782,9 +1999,12 @@ const personaMap : PersonaMap = {
             "Makajam": 18,
             "Resist Despair": 19
         },
-        "personality": "Upbeat"
+        "personality": "Upbeat",
+        "area": "Chemdah",
+        "floor": "L6 & 7"
     },
     "Mandrake": {
+        "inherits": "Electric",
         "item": "Energy Drop",
         "skillCard": true,
         "arcana": "Death",
@@ -1792,9 +2012,12 @@ const personaMap : PersonaMap = {
         "stats": [2, 3, 3, 4, 4],
         "elems": ["-", "-", "wk", "-", "rs", "-", "-", "-", "-", "-"],
         "skills": {"Energy Drop": 0, "Lunge": 4, "Pulinpa": 0, "Skull Cracker": 7, "Sukunda": 5},
-        "personality": "Upbeat"
+        "personality": "Upbeat",
+        "area": "Qimranut / Aiyatsbus",
+        "floor": "All / L1"
     },
     "Mara": {
+        "inherits": "Fire",
         "item": "Maragidyne",
         "skillCard": true,
         "arcana": "Tower",
@@ -1812,6 +2035,7 @@ const personaMap : PersonaMap = {
         }
     },
     "Matador": {
+        "inherits": "Psy",
         "item": "Garula",
         "skillCard": true,
         "arcana": "Death",
@@ -1821,6 +2045,7 @@ const personaMap : PersonaMap = {
         "skills": {"Garula": 23, "Null Dizzy": 0, "Psi": 0, "Sukukaja": 0, "Swift Strike": 20, "Trigger Happy": 22}
     },
     "Melchizedek": {
+        "inherits": "Bless",
         "item": "Mahamaon",
         "skillCard": true,
         "arcana": "Justice",
@@ -1838,6 +2063,7 @@ const personaMap : PersonaMap = {
         }
     },
     "Messiah": {
+        "inherits": "Almighty",
         "item": "Lucifer Guard",
         "arcana": "Judgement",
         "level": 81,
@@ -1856,6 +2082,7 @@ const personaMap : PersonaMap = {
         "dlc": true
     },
     "Messiah Picaro": {
+        "inherits": "Almighty",
         "item": "Insta-Heal",
         "skillCard": true,
         "arcana": "Judgement",
@@ -1875,6 +2102,7 @@ const personaMap : PersonaMap = {
         "dlc": true
     },
     "Metatron": {
+        "inherits": "Bless",
         "item": "Nataraja",
         "arcana": "Justice",
         "level": 89,
@@ -1894,6 +2122,7 @@ const personaMap : PersonaMap = {
         "max": true
     },
     "Michael": {
+        "inherits": "Almighty",
         "item": "Judge of the Dead",
         "arcana": "Judgement",
         "level": 87,
@@ -1912,6 +2141,7 @@ const personaMap : PersonaMap = {
         "note": "Needs Strength cooperation rank 5 to be fused"
     },
     "Mitra": {
+        "inherits": "Bless",
         "item": "Death Contract",
         "arcana": "Temperance",
         "level": 33,
@@ -1928,6 +2158,7 @@ const personaMap : PersonaMap = {
         }
     },
     "Mithras": {
+        "inherits": "Nuclear",
         "item": "Petra Genetrix",
         "arcana": "Sun",
         "level": 39,
@@ -1941,9 +2172,12 @@ const personaMap : PersonaMap = {
             "Tentarafoo": 0,
             "Tetra Break": 41
         },
-        "personality": "Gloomy"
+        "personality": "Gloomy",
+        "area": "Adyeshach",
+        "floor": "L11 & 12"
     },
     "Mokoi": {
+        "inherits": "Ailment",
         "item": "Dekunda",
         "skillCard": true,
         "arcana": "Death",
@@ -1958,9 +2192,12 @@ const personaMap : PersonaMap = {
             "Skull Cracker": 0,
             "Tarukaja": 0
         },
-        "personality": "Gloomy"
+        "personality": "Gloomy",
+        "area": "Chemdah",
+        "floor": "L1-4"
     },
     "Moloch": {
+        "inherits": "Psy",
         "item": "Nuke Amp",
         "skillCard": true,
         "arcana": "Hanged Man",
@@ -1978,6 +2215,7 @@ const personaMap : PersonaMap = {
         }
     },
     "Mot": {
+        "inherits": "Ailment",
         "item": "Concentrate",
         "skillCard": true,
         "arcana": "Death",
@@ -1994,6 +2232,7 @@ const personaMap : PersonaMap = {
         }
     },
     "Mother Harlot": {
+        "inherits": "Ice",
         "item": "Claiomh Solais - Sable",
         "arcana": "Empress",
         "level": 80,
@@ -2011,6 +2250,7 @@ const personaMap : PersonaMap = {
         "max": true
     },
     "Mothman": {
+        "inherits": "Electric",
         "item": "Foul Breath",
         "skillCard": true,
         "arcana": "Moon",
@@ -2025,9 +2265,12 @@ const personaMap : PersonaMap = {
             "Skull Cracker": 0,
             "Tentarafoo": 35
         },
-        "personality": "Timid"
+        "personality": "Timid",
+        "area": "Adyeshach",
+        "floor": "L3, 4, 7, 8, 10"
     },
     "Naga": {
+        "inherits": "Electric",
         "item": "Elec Boost",
         "skillCard": true,
         "arcana": "Hermit",
@@ -2043,9 +2286,12 @@ const personaMap : PersonaMap = {
             "Mazionga": 28,
             "Zionga": 0
         },
-        "personality": "Gloomy"
+        "personality": "Gloomy",
+        "area": "Akzeriyyuth",
+        "floor": "L2, 3, 5-7, 9"
     },
     "Narcissus": {
+        "inherits": "Ailment",
         "item": "Daffodils",
         "arcana": "Lovers",
         "level": 50,
@@ -2059,9 +2305,12 @@ const personaMap : PersonaMap = {
             "Growth 3": 52,
             "Magarula": 0,
             "Mediarama": 54
-        }
+        },
+        "area": "Sheriruth",
+        "floor": "L7 & 8 (after Palace 7)"
     },
     "Nebiros": {
+        "inherits": "Curse",
         "item": "Eigaon",
         "skillCard": true,
         "arcana": "Devil",
@@ -2079,6 +2328,7 @@ const personaMap : PersonaMap = {
         }
     },
     "Neko Shogun": {
+        "inherits": "Almighty",
         "item": "Catnap",
         "arcana": "Star",
         "level": 30,
@@ -2097,6 +2347,7 @@ const personaMap : PersonaMap = {
         "note": "Needs Strength cooperation rank 1 to be fused"
     },
     "Nekomata": {
+        "inherits": "Ailment",
         "item": "Pawzooka",
         "arcana": "Magician",
         "level": 17,
@@ -2111,9 +2362,12 @@ const personaMap : PersonaMap = {
             "Terror Claw": 0,
             "Wind Break": 20
         },
-        "personality": "Upbeat"
+        "personality": "Upbeat",
+        "area": "Kaitul",
+        "floor": "L2-4"
     },
     "Nigi Mitama": {
+        "inherits": "Healing",
         "item": "Me Patra",
         "skillCard": true,
         "arcana": "Temperance",
@@ -2123,6 +2377,7 @@ const personaMap : PersonaMap = {
         "skills": {"Baisudi": 0, "Divine Grace": 22, "Makouha": 0, "Me Patra": 23, "Media": 0, "Rainy Play": 24}
     },
     "Norn": {
+        "inherits": "Almighty",
         "item": "Diarahan",
         "skillCard": true,
         "arcana": "Fortune",
@@ -2137,9 +2392,12 @@ const personaMap : PersonaMap = {
             "Samarecarm": 57,
             "Tetraja": 56,
             "Ziodyne": 0
-        }
+        },
+        "area": "Sheriruth",
+        "floor": "L11-13 (before Palace 7) / L5 (after Palace 7)"
     },
     "Nue": {
+        "inherits": "Curse",
         "item": "Skull Cracker",
         "skillCard": true,
         "arcana": "Moon",
@@ -2155,9 +2413,12 @@ const personaMap : PersonaMap = {
             "Pulinpa": 22,
             "Skull Cracker": 0
         },
-        "personality": "Irritable"
+        "personality": "Irritable",
+        "area": "Chemdah",
+        "floor": "L4"
     },
     "Obariyon": {
+        "inherits": "Physical",
         "item": "Lucky Punch",
         "skillCard": true,
         "arcana": "Fool",
@@ -2165,9 +2426,12 @@ const personaMap : PersonaMap = {
         "stats": [7, 3, 9, 8, 4],
         "elems": ["rs", "-", "-", "-", "wk", "-", "-", "-", "-", "-"],
         "skills": {"Dekaja": 12, "Snap": 0, "Lucky Punch": 9, "Resist Fear": 10, "Sukunda": 0},
-        "personality": "Unknown"
+        "personality": "Unknown",
+        "area": "Aiyatsbus",
+        "floor": "L3, 5 & 6"
     },
     "Oberon": {
+        "inherits": "Electric",
         "item": "Elec Amp",
         "skillCard": true,
         "arcana": "Emperor",
@@ -2184,9 +2448,12 @@ const personaMap : PersonaMap = {
             "Samarecarm": 71,
             "Ziodyne": 0
         },
-        "personality": "Unknown"
+        "personality": "Unknown",
+        "area": "Sheriruth",
+        "floor": "L13 (after Palace 7)"
     },
     "Odin": {
+        "inherits": "Electric",
         "item": "Wild Hunt",
         "arcana": "Emperor",
         "level": 82,
@@ -2204,6 +2471,7 @@ const personaMap : PersonaMap = {
         "max": true
     },
     "Okuninushi": {
+        "inherits": "Psy",
         "item": "Official's Robe",
         "arcana": "Emperor",
         "level": 44,
@@ -2220,6 +2488,7 @@ const personaMap : PersonaMap = {
         }
     },
     "Ongyo-Ki": {
+        "inherits": "Physical",
         "item": "Myriad Slashes",
         "skillCard": true,
         "arcana": "Hermit",
@@ -2239,6 +2508,7 @@ const personaMap : PersonaMap = {
         "max": true
     },
     "Oni": {
+        "inherits": "Physical",
         "item": "Rampage",
         "skillCard": true,
         "arcana": "Strength",
@@ -2246,9 +2516,12 @@ const personaMap : PersonaMap = {
         "stats": [17, 8, 16, 13, 10],
         "elems": ["rs", "rs", "-", "-", "-", "-", "-", "-", "-", "-"],
         "skills": {"Memory Blow": 23, "Sharp Student": 22, "Counter": 0, "Snap": 0, "Giant Slice": 21, "Rampage": 0},
-        "personality": "Upbeat"
+        "personality": "Upbeat",
+        "area": "Kaitul",
+        "floor": "L3-5, 8, 9"
     },
     "Onmoraki": {
+        "inherits": "Curse",
         "item": "Confuse Boost",
         "skillCard": true,
         "arcana": "Moon",
@@ -2256,7 +2529,9 @@ const personaMap : PersonaMap = {
         "stats": [9, 12, 7, 10, 5],
         "elems": ["-", "wk", "rs", "-", "-", "-", "-", "-", "wk", "nu"],
         "skills": {"Agi": 13, "Ice Wall": 0, "Mudo": 0, "Confuse Boost": 15, "Pulinpa": 14, "Resist Fear": 17},
-        "personality": "Gloomy"
+        "personality": "Gloomy",
+        "area": "Chemdah",
+        "floor": "L3 & 4"
     },
     "Orlov": {
         "item": "Orlov",
@@ -2274,9 +2549,12 @@ const personaMap : PersonaMap = {
             "Maragion": 0,
             "Mazionga": 0
         },
-        "rare": true
+        "rare": true,
+        "area": "Sheriruth",
+        "floor": "All (before Palace 7) / L1-5 (after Palace 7)"
     },
     "Orobas": {
+        "inherits": "Fire",
         "item": "Maragi",
         "skillCard": true,
         "arcana": "Hierophant",
@@ -2284,9 +2562,12 @@ const personaMap : PersonaMap = {
         "stats": [11, 14, 15, 12, 6],
         "elems": ["-", "-", "-", "-", "-", "rs", "-", "-", "wk", "rs"],
         "skills": {"Dekaja": 0, "Fire Break": 20, "Makajamon": 21, "Maragi": 0, "Marakunda": 19, "Sukukaja": 0},
-        "personality": "Timid"
+        "personality": "Timid",
+        "area": "Kaitul",
+        "floor": "L1-3"
     },
     "Orpheus": {
+        "inherits": "Almighty",
         "item": "Hades Harp",
         "arcana": "Fool",
         "level": 26,
@@ -2304,6 +2585,7 @@ const personaMap : PersonaMap = {
         "dlc": true
     },
     "Orpheus Picaro": {
+        "inherits": "Almighty",
         "item": "Agidyne",
         "skillCard": true,
         "arcana": "Fool",
@@ -2322,6 +2604,7 @@ const personaMap : PersonaMap = {
         "dlc": true
     },
     "Orthrus": {
+        "inherits": "Fire",
         "item": "Burn Boost",
         "skillCard": true,
         "arcana": "Hanged Man",
@@ -2329,9 +2612,12 @@ const personaMap : PersonaMap = {
         "stats": [16, 14, 14, 19, 7],
         "elems": ["-", "-", "ab", "wk", "-", "-", "-", "rs", "-", "-"],
         "skills": {"Agilao": 0, "Burn Boost": 22, "Dodge Ice": 0, "Double Fangs": 0, "Matarukaja": 26, "Rat Fang": 24},
-        "personality": "Irritable"
+        "personality": "Irritable",
+        "area": "Kaitul",
+        "floor": "L4, 5, 7-9"
     },
     "Ose": {
+        "inherits": "Ailment",
         "item": "Matarukaja",
         "skillCard": true,
         "arcana": "Fool",
@@ -2339,9 +2625,12 @@ const personaMap : PersonaMap = {
         "stats": [32, 24, 25, 31, 21],
         "elems": ["-", "-", "rs", "-", "-", "-", "-", "-", "wk", "nu"],
         "skills": {"Counterstrike": 0, "Heat Wave": 47, "Matarukaja": 45, "Oni Kagura": 0, "Tempest Slash": 43},
-        "personality": "Unknown"
+        "personality": "Unknown",
+        "area": "Sheriruth",
+        "floor": "L1-5, 9 (before Palace 7) / L1-4 (after Palace 7)"
     },
     "Pale Rider": {
+        "inherits": "Curse",
         "item": "Megidola",
         "skillCard": true,
         "arcana": "Death",
@@ -2359,6 +2648,7 @@ const personaMap : PersonaMap = {
         }
     },
     "Parvati": {
+        "inherits": "Psy",
         "item": "Psiodyne",
         "skillCard": true,
         "arcana": "Lovers",
@@ -2374,9 +2664,12 @@ const personaMap : PersonaMap = {
             "Mapsiodyne": 59,
             "Psiodyne": 0
         },
-        "personality": "Unknown"
+        "personality": "Unknown",
+        "area": "Sheriruth",
+        "floor": "L9, 11, 12 (after Palace 7)"
     },
     "Pazuzu": {
+        "inherits": "Curse",
         "item": "Maeiga",
         "skillCard": true,
         "arcana": "Devil",
@@ -2394,6 +2687,7 @@ const personaMap : PersonaMap = {
         }
     },
     "Pisaca": {
+        "inherits": "Curse",
         "item": "Headhunter Ladle",
         "arcana": "Death",
         "level": 29,
@@ -2408,9 +2702,12 @@ const personaMap : PersonaMap = {
             "Rampage": 0,
             "Stagnant Air": 0
         },
-        "personality": "Unknown"
+        "personality": "Unknown",
+        "area": "Akzeriyyuth",
+        "floor": "L5-7, 9-11"
     },
     "Pixie": {
+        "inherits": "Electric",
         "item": "Dia",
         "skillCard": true,
         "arcana": "Lovers",
@@ -2418,9 +2715,12 @@ const personaMap : PersonaMap = {
         "stats": [1, 3, 3, 4, 2],
         "elems": ["-", "wk", "-", "wk", "rs", "-", "-", "-", "rs", "wk"],
         "skills": {"Dia": 0, "Patra": 3, "Resist Confuse": 6, "Tarukaja": 5, "Zio": 0},
-        "personality": "Timid"
+        "personality": "Timid",
+        "area": "Qimranut / Aiyatsbus",
+        "floor": "All / L1 & 3"
     },
     "Power": {
+        "inherits": "Bless",
         "item": "Masukukaja",
         "skillCard": true,
         "arcana": "Justice",
@@ -2436,9 +2736,12 @@ const personaMap : PersonaMap = {
             "Sukukaja": 0,
             "Swift Strike": 42
         },
-        "personality": "Unknown"
+        "personality": "Unknown",
+        "area": "Sheriruth",
+        "floor": "L1-5, 7 (before Palace 7) / L1-3 (after Palace 7)"
     },
     "Principality": {
+        "inherits": "Bless",
         "item": "Tetraja",
         "skillCard": true,
         "arcana": "Justice",
@@ -2448,15 +2751,19 @@ const personaMap : PersonaMap = {
         "skills": {"Bless Boost": 34, "Mabaisudi": 32, "Makajamon": 0, "Makouga": 0, "Mediarama": 31, "Tetraja": 0}
     },
     "Queen Mab": {
+        "inherits": "Almighty",
         "item": "Masquerade Ribbon",
         "arcana": "Magician",
         "level": 43,
         "stats": [23, 35, 26, 30, 22],
         "elems": ["-", "-", "nu", "-", "rs", "wk", "-", "-", "-", "-"],
         "skills": {"Agidyne": 48, "Makajamon": 0, "Makara Break": 46, "Matarunda": 44, "Mazionga": 0, "Wind Wall": 0},
-        "personality": "Unknown"
+        "personality": "Unknown",
+        "area": "Sheriruth",
+        "floor": "L5, 7-9 (before Palace 7) / L3 & 4 (after Palace 7)"
     },
     "Quetzalcoatl": {
+        "inherits": "Wind",
         "item": "Regenerate 3",
         "skillCard": true,
         "arcana": "Sun",
@@ -2474,6 +2781,7 @@ const personaMap : PersonaMap = {
         }
     },
     "Raja Naga": {
+        "inherits": "Electric",
         "item": "Ziodyne",
         "skillCard": true,
         "arcana": "Temperance",
@@ -2491,6 +2799,7 @@ const personaMap : PersonaMap = {
         }
     },
     "Rakshasa": {
+        "inherits": "Physical",
         "item": "Mind Slice",
         "skillCard": true,
         "arcana": "Strength",
@@ -2506,9 +2815,12 @@ const personaMap : PersonaMap = {
             "Tarukaja": 0,
             "Wind Wall": 0
         },
-        "personality": "Irritable"
+        "personality": "Irritable",
+        "area": "Kaitul",
+        "floor": "L5, 7-9"
     },
     "Rangda": {
+        "inherits": "Curse",
         "item": "Bloodbath",
         "skillCard": true,
         "arcana": "Magician",
@@ -2516,9 +2828,12 @@ const personaMap : PersonaMap = {
         "stats": [28, 34, 30, 33, 26],
         "elems": ["rp", "rp", "nu", "-", "wk", "-", "-", "-", "wk", "nu"],
         "skills": {"Bloodbath": 0, "Counterstrike": 0, "Eigaon": 49, "Matarunda": 51, "Mudoon": 53, "Swift Strike": 0},
-        "personality": "Unknown"
+        "personality": "Unknown",
+        "area": "Sheriruth",
+        "floor": "L11-13 (before Palace 7) / L5 (after Palace 7)"
     },
     "Raphael": {
+        "inherits": "Almighty",
         "item": "Heat Riser",
         "skillCard": true,
         "arcana": "Lovers",
@@ -2536,6 +2851,7 @@ const personaMap : PersonaMap = {
         }
     },
     "Red Rider": {
+        "inherits": "Psy",
         "item": "Psy Break",
         "skillCard": true,
         "arcana": "Tower",
@@ -2568,9 +2884,12 @@ const personaMap : PersonaMap = {
             "Maragi": 0,
             "Mazio": 0
         },
-        "rare": true
+        "rare": true,
+        "area": "Qimranut / Aiyatsbus / Chemdah",
+        "floor": "All / L1-3, 5 & 6 / L1-4, 6 & 7"
     },
     "Saki Mitama": {
+        "inherits": "Healing",
         "item": "Rakukaja",
         "skillCard": true,
         "arcana": "Lovers",
@@ -2580,6 +2899,7 @@ const personaMap : PersonaMap = {
         "skills": {"Bufu": 0, "Energy Drop": 0, "Growth 1": 7, "Rakukaja": 8, "Resist Dizzy": 10, "Wind Wall": 0}
     },
     "Sandalphon": {
+        "inherits": "Bless",
         "item": "Angelic Grace",
         "skillCard": true,
         "arcana": "Moon",
@@ -2597,6 +2917,7 @@ const personaMap : PersonaMap = {
         "max": true
     },
     "Sandman": {
+        "inherits": "Wind",
         "item": "Sleep Boost",
         "skillCard": true,
         "arcana": "Magician",
@@ -2612,9 +2933,12 @@ const personaMap : PersonaMap = {
             "Sleep Boost": 29,
             "Sukunda": 25
         },
-        "personality": "Irritable"
+        "personality": "Irritable",
+        "area": "Akzeriyyuth",
+        "floor": "L1-3"
     },
     "Sarasvati": {
+        "inherits": "Healing",
         "item": "Mediarama",
         "skillCard": true,
         "arcana": "Priestess",
@@ -2629,9 +2953,12 @@ const personaMap : PersonaMap = {
             "Mediarama": 0,
             "Null Sleep": 51,
             "Tentarafoo": 0
-        }
+        },
+        "area": "Sheriruth",
+        "floor": "L7-9. 12 (after Palace 7)"
     },
     "Satan": {
+        "inherits": "Ice",
         "item": "Tantric Oath",
         "arcana": "Judgement",
         "level": 92,
@@ -2650,6 +2977,7 @@ const personaMap : PersonaMap = {
         "max": true
     },
     "Satanael": {
+        "inherits": "Almighty",
         "item": "Paradise Lost",
         "arcana": "Fool",
         "level": 95,
@@ -2669,6 +2997,7 @@ const personaMap : PersonaMap = {
         "note": "Only available on NG+"
     },
     "Scathach": {
+        "inherits": "Wind",
         "item": "Tempest Slash",
         "skillCard": true,
         "arcana": "Priestess",
@@ -2684,9 +3013,12 @@ const personaMap : PersonaMap = {
             "Matarukaja": 48,
             "Tempest Slash": 0
         },
-        "personality": "Upbeat"
+        "personality": "Upbeat",
+        "area": "Adyeshach",
+        "floor": "L10-12"
     },
     "Seiryu": {
+        "inherits": "Ice",
         "item": "Amrita Drop",
         "skillCard": true,
         "arcana": "Temperance",
@@ -2704,6 +3036,7 @@ const personaMap : PersonaMap = {
         }
     },
     "Setanta": {
+        "inherits": "Physical",
         "item": "Counter",
         "skillCard": true,
         "arcana": "Emperor",
@@ -2720,6 +3053,7 @@ const personaMap : PersonaMap = {
         }
     },
     "Seth": {
+        "inherits": "Fire",
         "item": "One-shot Kill",
         "skillCard": true,
         "arcana": "Tower",
@@ -2738,6 +3072,7 @@ const personaMap : PersonaMap = {
         "note": "Needs Strength cooperation rank 1 to be fused"
     },
     "Shiisaa": {
+        "inherits": "Electric",
         "item": "Mazio",
         "skillCard": true,
         "arcana": "Chariot",
@@ -2754,6 +3089,7 @@ const personaMap : PersonaMap = {
         }
     },
     "Shiki-Ouji": {
+        "inherits": "Psy",
         "item": "Dormin Rush",
         "skillCard": true,
         "arcana": "Chariot",
@@ -2761,9 +3097,12 @@ const personaMap : PersonaMap = {
         "stats": [16, 14, 15, 14, 11],
         "elems": ["nu", "nu", "-", "-", "-", "-", "-", "wk", "-", "nu"],
         "skills": {"Dekaja": 24, "Snap": 0, "Mapsi": 22, "Oni Kagura": 27, "Taunt": 0, "Psio": 26, "Tarukaja": 0},
-        "personality": "Irritable"
+        "personality": "Irritable",
+        "area": "Chemdah",
+        "floor": "L6 & 7"
     },
     "Shiva": {
+        "inherits": "Psy",
         "item": "Megido Fire",
         "arcana": "Judgement",
         "level": 82,
@@ -2781,6 +3120,7 @@ const personaMap : PersonaMap = {
         "special": true
     },
     "Siegfried": {
+        "inherits": "Physical",
         "item": "Vorpal Blade",
         "skillCard": true,
         "arcana": "Strength",
@@ -2797,15 +3137,19 @@ const personaMap : PersonaMap = {
         }
     },
     "Silky": {
+        "inherits": "Healing",
         "item": "Silk Dress",
         "arcana": "Priestess",
         "level": 6,
         "stats": [4, 7, 4, 5, 5],
         "elems": ["-", "-", "wk", "rs", "wk", "-", "-", "-", "-", "-"],
         "skills": {"Bufu": 0, "Sharp Student": 10, "Dia": 7, "Dormina": 0, "Patra": 9},
-        "personality": "Gloomy"
+        "personality": "Gloomy",
+        "area": "Aiyatsbus",
+        "floor": "L2, 3, 5 & 6"
     },
     "Skadi": {
+        "inherits": "Ice",
         "item": "Snow Queen's Whip",
         "arcana": "Priestess",
         "level": 55,
@@ -2819,9 +3163,12 @@ const personaMap : PersonaMap = {
             "Null Despair": 0,
             "Repel Ice": 60,
             "Spirit Drain": 59
-        }
+        },
+        "area": "Sheriruth",
+        "floor": "L12 & 13 (before Palace 7) / L5 (after Palace 7)"
     },
     "Slime": {
+        "inherits": "Curse",
         "item": "Headbutt",
         "skillCard": true,
         "arcana": "Chariot",
@@ -2829,9 +3176,12 @@ const personaMap : PersonaMap = {
         "stats": [9, 6, 11, 6, 5],
         "elems": ["rs", "-", "wk", "-", "-", "wk", "-", "-", "-", "-"],
         "skills": {"Evil Touch": 0, "Eiha": 11, "Fire Wall": 13, "Headbutt": 14, "Lunge": 0},
-        "personality": "Timid"
+        "personality": "Timid",
+        "area": "Qimranut / Aiyatsbus",
+        "floor": "All / L1, 2, 3, 6"
     },
     "Sraosha": {
+        "inherits": "Bless",
         "item": "Archangel Bra",
         "arcana": "Star",
         "level": 80,
@@ -2856,18 +3206,24 @@ const personaMap : PersonaMap = {
         "stats": [20, 20, 20, 20, 20],
         "elems": ["nu", "nu", "nu", "nu", "nu", "nu", "nu", "nu", "nu", "wk"],
         "skills": {"Agilao": 0, "Bufula": 0, "Eiga": 0, "Freila": 0, "Garula": 0, "Kouga": 0, "Psio": 0, "Zionga": 0},
-        "rare": true
+        "rare": true,
+        "area": "Akzeriyyuth",
+        "floor": "L1-3, 5-7, 9-11"
     },
     "Succubus": {
+        "inherits": "Curse",
         "item": "Brain Shot",
         "arcana": "Moon",
         "level": 7,
         "stats": [4, 7, 5, 8, 4],
         "elems": ["-", "wk", "rs", "-", "-", "-", "-", "-", "wk", "nu"],
         "skills": {"Agi": 8, "Brainwash Boost": 11, "Dekaja": 10, "Marin Karin": 0, "Mudo": 12, "Rebellion": 0},
-        "personality": "Irritable"
+        "personality": "Irritable",
+        "area": "Aiyatsbus",
+        "floor": "L5 & 6"
     },
     "Sudama": {
+        "inherits": "Wind",
         "item": "Magaru",
         "skillCard": true,
         "arcana": "Hermit",
@@ -2882,9 +3238,12 @@ const personaMap : PersonaMap = {
             "Lucky Punch": 0,
             "Magaru": 0,
             "Wind Wall": 21
-        }
+        },
+        "area": "Chemdah",
+        "floor": "L6 & 7"
     },
     "Sui-Ki": {
+        "inherits": "Ice",
         "item": "Mabufu",
         "skillCard": true,
         "arcana": "Moon",
@@ -2900,9 +3259,12 @@ const personaMap : PersonaMap = {
             "Null Nuke": 26,
             "Wage War": 27
         },
-        "personality": "Unknown"
+        "personality": "Unknown",
+        "area": "Kaitul",
+        "floor": "L7-9"
     },
     "Surt": {
+        "inherits": "Fire",
         "item": "Fire Amp",
         "skillCard": true,
         "arcana": "Magician",
@@ -2919,6 +3281,7 @@ const personaMap : PersonaMap = {
         }
     },
     "Suzaku": {
+        "inherits": "Nuclear",
         "item": "Mafrei",
         "skillCard": true,
         "arcana": "Sun",
@@ -2936,6 +3299,7 @@ const personaMap : PersonaMap = {
         }
     },
     "Take-Minakata": {
+        "inherits": "Electric",
         "item": "Thunder Band",
         "arcana": "Hanged Man",
         "level": 29,
@@ -2949,9 +3313,12 @@ const personaMap : PersonaMap = {
             "Mazionga": 30,
             "Zionga": 0
         },
-        "personality": "Gloomy"
+        "personality": "Gloomy",
+        "area": "Kaitul",
+        "floor": "L7-9"
     },
     "Thanatos": {
+        "inherits": "Almighty",
         "item": "Darkness Ring",
         "arcana": "Death",
         "level": 65,
@@ -2969,6 +3336,7 @@ const personaMap : PersonaMap = {
         "dlc": true
     },
     "Thanatos Picaro": {
+        "inherits": "Almighty",
         "item": "Maeigaon",
         "skillCard": true,
         "arcana": "Death",
@@ -3002,9 +3370,12 @@ const personaMap : PersonaMap = {
             "Tarukaja": 0,
             "Tarunda": 0
         },
-        "rare": true
+        "rare": true,
+        "area": "Kaitul",
+        "floor": "L1-5, 7-9"
     },
     "Thor": {
+        "inherits": "Electric",
         "item": "Mjolnir",
         "arcana": "Chariot",
         "level": 64,
@@ -3021,6 +3392,7 @@ const personaMap : PersonaMap = {
         }
     },
     "Thoth": {
+        "inherits": "Nuclear",
         "item": "Growth 2",
         "skillCard": true,
         "arcana": "Emperor",
@@ -3036,9 +3408,12 @@ const personaMap : PersonaMap = {
             "Taunt": 0,
             "Psy Wall": 39
         },
-        "personality": "Gloomy"
+        "personality": "Gloomy",
+        "area": "Akzeriyyuth",
+        "floor": "L6, 7, 9-11"
     },
     "Throne": {
+        "inherits": "Bless",
         "item": "Invigorate 3",
         "skillCard": true,
         "arcana": "Justice",
@@ -3058,6 +3433,7 @@ const personaMap : PersonaMap = {
         "note": "Needs Strength cooperation rank 5 to be fused"
     },
     "Titania": {
+        "inherits": "Nuclear",
         "item": "Mediarahan",
         "skillCard": true,
         "arcana": "Empress",
@@ -3071,9 +3447,12 @@ const personaMap : PersonaMap = {
             "Makara Break": 0,
             "Mediarahan": 61,
             "Nuke Amp": 60
-        }
+        },
+        "area": "Sheriruth",
+        "floor": "L8, 9, 11-13 (after Palace 7)"
     },
     "Trumpeter": {
+        "inherits": "Almighty",
         "item": "Debilitate",
         "skillCard": true,
         "arcana": "Judgement",
@@ -3093,6 +3472,7 @@ const personaMap : PersonaMap = {
         "note": "Needs Strength cooperation rank 5 to be fused"
     },
     "Tsukiyomi": {
+        "inherits": "Almighty",
         "item": "Black Moon",
         "arcana": "Moon",
         "level": 50,
@@ -3110,6 +3490,7 @@ const personaMap : PersonaMap = {
         "dlc": true
     },
     "Tsukiyomi Picaro": {
+        "inherits": "Almighty",
         "item": "Spell Master",
         "skillCard": true,
         "arcana": "Moon",
@@ -3128,6 +3509,7 @@ const personaMap : PersonaMap = {
         "dlc": true
     },
     "Unicorn": {
+        "inherits": "Bless",
         "item": "Samarecarm",
         "skillCard": true,
         "arcana": "Hierophant",
@@ -3143,9 +3525,12 @@ const personaMap : PersonaMap = {
             "Samarecarm": 41,
             "Swift Strike": 42
         },
-        "personality": "Unknown"
+        "personality": "Unknown",
+        "area": "Sheriruth",
+        "floor": "L1-4 (before Palace 7) / L1 & 2 (after Palace 7)"
     },
     "Uriel": {
+        "inherits": "Almighty",
         "item": "Heaven's Gate",
         "arcana": "Justice",
         "level": 81,
@@ -3162,6 +3547,7 @@ const personaMap : PersonaMap = {
         }
     },
     "Valkyrie": {
+        "inherits": "Physical",
         "item": "Giant Slice",
         "skillCard": true,
         "arcana": "Strength",
@@ -3175,9 +3561,12 @@ const personaMap : PersonaMap = {
             "Dodge Physical": 49,
             "Matarukaja": 47,
             "Rising Slash": 0
-        }
+        },
+        "area": "Sheriruth",
+        "floor": "L3-5, 7-9 (before Palace 7) / L2-4 (after Palace 7)"
     },
     "Vasuki": {
+        "inherits": "Ailment",
         "item": "Kuzuryu Gouhou",
         "arcana": "Hanged Man",
         "level": 68,
@@ -3196,6 +3585,7 @@ const personaMap : PersonaMap = {
         "note": "Needs Strength cooperation rank 1 to be fused"
     },
     "Vishnu": {
+        "inherits": "Almighty",
         "item": "Riot Gun",
         "skillCard": true,
         "arcana": "Fool",
@@ -3215,6 +3605,7 @@ const personaMap : PersonaMap = {
         "max": true
     },
     "White Rider": {
+        "inherits": "Curse",
         "item": "Triple Down",
         "skillCard": true,
         "arcana": "Chariot",
@@ -3233,6 +3624,7 @@ const personaMap : PersonaMap = {
         }
     },
     "Yaksini": {
+        "inherits": "Ice",
         "item": "Vicious Strike",
         "skillCard": true,
         "arcana": "Empress",
@@ -3247,9 +3639,12 @@ const personaMap : PersonaMap = {
             "Vicious Strike": 24,
             "Wage War": 0
         },
-        "personality": "Irritable"
+        "personality": "Irritable",
+        "area": "Kaitul",
+        "floor": "L3-5, 7"
     },
     "Yamata-no-Orochi": {
+        "inherits": "Ice",
         "item": "Oni Kagura",
         "skillCard": true,
         "arcana": "Judgement",
@@ -3266,6 +3661,7 @@ const personaMap : PersonaMap = {
         }
     },
     "Yatagarasu": {
+        "inherits": "Fire",
         "item": "Black Wing Robe",
         "arcana": "Sun",
         "level": 57,
@@ -3282,6 +3678,7 @@ const personaMap : PersonaMap = {
         }
     },
     "Yoshitsune": {
+        "inherits": "Physical",
         "item": "Usumidori",
         "arcana": "Tower",
         "level": 79,
@@ -3300,6 +3697,7 @@ const personaMap : PersonaMap = {
         "note": "Needs Strength cooperation rank 5 to be fused"
     },
     "Yurlungur": {
+        "inherits": "Electric",
         "item": "Mirrirmina",
         "arcana": "Sun",
         "level": 42,
@@ -3316,6 +3714,7 @@ const personaMap : PersonaMap = {
         }
     },
     "Zaou-Gongen": {
+        "inherits": "Fire",
         "item": "God's Hand",
         "skillCard": true,
         "arcana": "Strength",
@@ -3334,6 +3733,7 @@ const personaMap : PersonaMap = {
         "max": true
     },
     "Zouchouten": {
+        "inherits": "Electric",
         "item": "Sharp Student",
         "skillCard": true,
         "arcana": "Strength",

--- a/data/PersonaDataRoyal.js
+++ b/data/PersonaDataRoyal.js
@@ -1,6 +1,6 @@
 var personaMapRoyal = {
     "Abaddon": {
-        "inherits": "curse",
+        "inherits": "Curse",
         "item": "Megaton Raid Belt",
         "itemr": "God's Hand Belt",
         "level": 75,
@@ -16,10 +16,12 @@ var personaMapRoyal = {
             "Gigantomachia": 81
         },
         "stats": [51, 42, 58, 38, 43],
-        "trait": "Mouth of Savoring"
+        "trait": "Mouth of Savoring",
+        "area": "Da'at",
+        "floor": "All"
     },
     "Agathion": {
-        "inherits": "elec",
+        "inherits": "Electric",
         "item": "Zio",
         "itemr": "Mazio",
         "skillCard": true,
@@ -28,11 +30,13 @@ var personaMapRoyal = {
         "elems": ["-", "rs", "-", "-", "rs", "wk", "-", "-", "-", "-"],
         "skills": {"Dia": 0, "Baisudi": 0, "Lunge": 4, "Rakukaja": 6, "Zio": 7, "Dodge Elec": 8},
         "stats": [3, 4, 5, 7, 3],
-        "trait": "Rare Antibody"
+        "trait": "Rare Antibody",
+        "area": "Aiyatsbus",
+        "floor": "L1"
     },
     "Alice": {
         "special": true,
-        "inherits": "curse",
+        "inherits": "Curse",
         "item": "Spiral Hell Ring",
         "itemr": "Cursed Ribbon",
         "level": 83,
@@ -52,7 +56,7 @@ var personaMapRoyal = {
         "max": true
     },
     "Alilat": {
-        "inherits": "ice",
+        "inherits": "Ice",
         "item": "Mabufudyne",
         "itemr": "Diamond Dust",
         "skillCard": true,
@@ -74,7 +78,7 @@ var personaMapRoyal = {
         "note": "Only available after 1/12"
     },
     "Ame-no-Uzume": {
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Senryou Yakusha",
         "itemr": "Senryou Yakusha R",
         "level": 13,
@@ -82,10 +86,12 @@ var personaMapRoyal = {
         "elems": ["-", "-", "ab", "-", "-", "-", "wk", "-", "-", "-"],
         "skills": {"Mazio": 0, "Magaru": 0, "Media": 0, "Nocturnal Flash": 15, "Baisudi": 16, "Divine Grace": 18},
         "stats": [7, 10, 9, 11, 9],
-        "trait": "Electric Bloodline"
+        "trait": "Electric Bloodline",
+        "area": "Chemdah",
+        "floor": "L6 & 7"
     },
     "Ananta": {
-        "inherits": "nuke",
+        "inherits": "Nuclear",
         "item": "Spiral Nuclear Ring",
         "itemr": "Reactor Ring",
         "level": 44,
@@ -105,7 +111,7 @@ var personaMapRoyal = {
         "trait": "Atomic Bloodline"
     },
     "Andras": {
-        "inherits": "ice",
+        "inherits": "Ice",
         "item": "Evil Touch",
         "itemr": "Evil Smile",
         "skillCard": true,
@@ -121,10 +127,12 @@ var personaMapRoyal = {
             "Ghastly Wail": 32
         },
         "stats": [15, 19, 19, 21, 14],
-        "trait": "Foul Odor"
+        "trait": "Foul Odor",
+        "area": "Akzeriyyuth",
+        "floor": "???"
     },
     "Angel": {
-        "inherits": "bless",
+        "inherits": "Bless",
         "item": "Kouha",
         "itemr": "Makouha",
         "skillCard": true,
@@ -133,10 +141,12 @@ var personaMapRoyal = {
         "elems": ["-", "wk", "-", "-", "rs", "-", "-", "-", "nu", "wk"],
         "skills": {"Kouha": 0, "Makajam": 0, "Dia": 0, "Baisudi": 10, "Dodge Curse": 11, "Dekunda": 12},
         "stats": [6, 9, 5, 9, 5],
-        "trait": "Skillful Combo"
+        "trait": "Skillful Combo",
+        "area": "Aiyatsbus / Kaitul",
+        "floor": "L5 & 6 / L1-4"
     },
     "Anubis": {
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Makouga",
         "itemr": "Kougaon",
         "skillCard": true,
@@ -145,10 +155,12 @@ var personaMapRoyal = {
         "elems": ["-", "rs", "-", "-", "-", "-", "rs", "-", "nu", "nu"],
         "skills": {"Hamaon": 0, "Mudoon": 0, "Makouga": 0, "Maeiga": 36, "Dekunda": 37, "Resist Bless": 38},
         "stats": [19, 24, 22, 21, 23],
-        "trait": "Deathly Illness"
+        "trait": "Deathly Illness",
+        "area": "Akzeriyyuth",
+        "floor": "L10 & 11"
     },
     "Anzu": {
-        "inherits": "wind",
+        "inherits": "Wind",
         "item": "Garula",
         "itemr": "Magarula",
         "skillCard": true,
@@ -157,10 +169,12 @@ var personaMapRoyal = {
         "elems": ["-", "wk", "-", "-", "rs", "rp", "-", "wk", "-", "-"],
         "skills": {"Garula": 0, "Masukukaja": 0, "Wind Break": 0, "Assault Dive": 27, "Dekaja": 28, "Null Forget": 29},
         "stats": [14, 18, 15, 21, 14],
-        "trait": "Wind Bloodline"
+        "trait": "Wind Bloodline",
+        "area": "Akzeriyyuth",
+        "floor": "L1-3, 5-7, 9-11"
     },
     "Apsaras": {
-        "inherits": "ice",
+        "inherits": "Ice",
         "item": "Media",
         "itemr": "Diarama",
         "skillCard": true,
@@ -169,10 +183,12 @@ var personaMapRoyal = {
         "elems": ["-", "-", "wk", "rs", "wk", "-", "-", "-", "-", "-"],
         "skills": {"Rebellion": 0, "Ice Wall": 0, "Bufu": 0, "Media": 13, "Elec Wall": 14, "Wind Wall": 16},
         "stats": [7, 11, 6, 10, 6],
-        "trait": "Internal Hypnosis"
+        "trait": "Internal Hypnosis",
+        "area": "Chemdah",
+        "floor": "L1-4"
     },
     "Ara Mitama": {
-        "inherits": "nuke",
+        "inherits": "Nuclear",
         "item": "Nuclear Ring",
         "itemr": "Spiral Nuclear Ring",
         "level": 30,
@@ -191,7 +207,7 @@ var personaMapRoyal = {
         "trait": "Atomic Bloodline"
     },
     "Arahabaki": {
-        "inherits": "ailment",
+        "inherits": "Ailment",
         "item": "Tapsuan",
         "itemr": "Fine Tapsuan",
         "level": 35,
@@ -206,10 +222,12 @@ var personaMapRoyal = {
             "Defense Master": 39
         },
         "stats": [21, 23, 22, 24, 22],
-        "trait": "Immunity"
+        "trait": "Immunity",
+        "area": "Adyeshach",
+        "floor": "L1-4, 6-8, 10"
     },
     "Archangel": {
-        "inherits": "bless",
+        "inherits": "Bless",
         "item": "Hama",
         "itemr": "Mahama",
         "skillCard": true,
@@ -218,11 +236,13 @@ var personaMapRoyal = {
         "elems": ["-", "-", "-", "-", "wk", "-", "-", "-", "nu", "wk"],
         "skills": {"Giant Slice": 0, "Dazzler": 0, "Hama": 0, "Rebellion": 16, "Power Slash": 17, "Vajra Blast": 19},
         "stats": [11, 9, 10, 12, 7],
-        "trait": "Skillful Combo"
+        "trait": "Skillful Combo",
+        "area": "Aiyatsbus",
+        "floor": "L5 & 6"
     },
     "Ardha": {
         "special": true,
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Sahasrara",
         "itemr": "Sahasrara EX",
         "level": 84,
@@ -242,7 +262,7 @@ var personaMapRoyal = {
         "max": true
     },
     "Arsène": {
-        "inherits": "curse",
+        "inherits": "Curse",
         "item": "Arsène's Cane",
         "itemr": "The Great Thief Stick",
         "level": 1,
@@ -254,7 +274,7 @@ var personaMapRoyal = {
     },
     "Asura": {
         "special": true,
-        "inherits": "nuke",
+        "inherits": "Nuclear",
         "item": "Vajra",
         "itemr": "Unparalleled Vajra",
         "level": 76,
@@ -274,7 +294,7 @@ var personaMapRoyal = {
         "max": true
     },
     "Atavaka": {
-        "inherits": "phys",
+        "inherits": "Physical",
         "item": "Brave Blade",
         "itemr": "Sword Dance",
         "skillCard": true,
@@ -294,7 +314,7 @@ var personaMapRoyal = {
         "trait": "Savior Bloodline"
     },
     "Atropos": {
-        "inherits": "elec",
+        "inherits": "Electric",
         "item": "Mazionga",
         "itemr": "Ziodyne",
         "skillCard": true,
@@ -314,7 +334,7 @@ var personaMapRoyal = {
         "trait": "Mighty Gaze"
     },
     "Attis": {
-        "inherits": "fire",
+        "inherits": "Fire",
         "item": "Null Curse",
         "itemr": "Absorb Curse",
         "skillCard": true,
@@ -335,7 +355,7 @@ var personaMapRoyal = {
         "max": true
     },
     "Baal": {
-        "inherits": "wind",
+        "inherits": "Wind",
         "item": "Yagrush",
         "itemr": "Yagrush EX",
         "level": 82,
@@ -354,7 +374,7 @@ var personaMapRoyal = {
         "trait": "Wind Bloodline"
     },
     "Baphomet": {
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Bufudyne",
         "itemr": "Mabufudyne",
         "skillCard": true,
@@ -371,10 +391,12 @@ var personaMapRoyal = {
             "Freeze Boost": 63
         },
         "stats": [34, 42, 36, 38, 31],
-        "trait": "Thermal Conduct"
+        "trait": "Thermal Conduct",
+        "area": "Sheriruth",
+        "floor": "L13 (after Palace 7)"
     },
     "Barong": {
-        "inherits": "elec",
+        "inherits": "Electric",
         "item": "Ziodyne",
         "itemr": "Maziodyne",
         "skillCard": true,
@@ -383,10 +405,12 @@ var personaMapRoyal = {
         "elems": ["-", "rs", "-", "-", "rs", "wk", "-", "-", "nu", "wk"],
         "skills": {"Ziodyne": 0, "Wage War": 0, "Invigorate 2": 0, "Elec Break": 54, "Null Elec": 55, "Maziodyne": 57},
         "stats": [33, 35, 33, 37, 25],
-        "trait": "Blessed Bloodline"
+        "trait": "Blessed Bloodline",
+        "area": "Sheriruth",
+        "floor": "L11 & 12 (after Palace 7)"
     },
     "Beelzebub": {
-        "inherits": "curse",
+        "inherits": "Curse",
         "item": "Fleurs du Mal",
         "itemr": "Fleurs du Mal R",
         "level": 87,
@@ -407,7 +431,7 @@ var personaMapRoyal = {
         "max": true
     },
     "Belial": {
-        "inherits": "curse",
+        "inherits": "Curse",
         "item": "Mamudoon",
         "itemr": "Demonic Decree",
         "skillCard": true,
@@ -427,7 +451,7 @@ var personaMapRoyal = {
         "trait": "Bloodstained Eyes"
     },
     "Belphegor": {
-        "inherits": "ice",
+        "inherits": "Ice",
         "item": "Mabufula",
         "itemr": "Bufudyne",
         "skillCard": true,
@@ -436,10 +460,12 @@ var personaMapRoyal = {
         "elems": ["-", "-", "wk", "rs", "rs", "-", "-", "rs", "-", "rp"],
         "skills": {"Mabufula": 0, "Ice Break": 0, "Null Rage": 38, "Dodge Fire": 39, "Bufudyne": 41, "Concentrate": 42},
         "stats": [25, 27, 24, 23, 19],
-        "trait": "Intense Focus"
+        "trait": "Intense Focus",
+        "area": "Adyeshach",
+        "floor": "L6-8, 10"
     },
     "Berith": {
-        "inherits": "phys",
+        "inherits": "Physical",
         "item": "Cleave",
         "itemr": "Power Slash",
         "skillCard": true,
@@ -448,10 +474,12 @@ var personaMapRoyal = {
         "elems": ["-", "nu", "rs", "wk", "-", "-", "-", "-", "-", "-"],
         "skills": {"Cleave": 0, "Rakukaja": 0, "Tarukaja": 10, "Dodge Fire": 11, "Power Slash": 13},
         "stats": [9, 6, 8, 8, 3],
-        "trait": "Crisis Control"
+        "trait": "Crisis Control",
+        "area": "Aiyatsbus",
+        "floor": "L5 & 6"
     },
     "Bicorn": {
-        "inherits": "wind",
+        "inherits": "Wind",
         "item": "Lunge",
         "itemr": "Assault Dive",
         "skillCard": true,
@@ -460,10 +488,12 @@ var personaMapRoyal = {
         "elems": ["-", "-", "-", "-", "wk", "-", "-", "-", "-", "rs"],
         "skills": {"Lunge": 0, "Tarunda": 0, "Garu": 6, "Ice Wall": 7, "Apt Pupil": 8},
         "stats": [5, 3, 3, 5, 3],
-        "trait": "Striking Weight"
+        "trait": "Striking Weight",
+        "area": "Aiyatsbus",
+        "floor": "L1 & 2"
     },
     "Bishamonten": {
-        "inherits": "nuke",
+        "inherits": "Nuclear",
         "item": "Mafreidyne",
         "itemr": "Atomic Flare",
         "skillCard": true,
@@ -484,7 +514,7 @@ var personaMapRoyal = {
     },
     "Black Frost": {
         "special": true,
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Naraka Whip",
         "itemr": "Dainaraka Whip",
         "level": 67,
@@ -503,7 +533,7 @@ var personaMapRoyal = {
         "trait": "Frigid Bloodline"
     },
     "Black Ooze": {
-        "inherits": "curse",
+        "inherits": "Curse",
         "item": "Headbutt",
         "itemr": "Memory Blow",
         "skillCard": true,
@@ -520,10 +550,12 @@ var personaMapRoyal = {
             "Flash Bomb": 24
         },
         "stats": [15, 7, 16, 8, 15],
-        "trait": "Rare Antibody"
+        "trait": "Rare Antibody",
+        "area": "Adyeshach",
+        "floor": "L1-4, 6"
     },
     "Black Rider": {
-        "inherits": "curse",
+        "inherits": "Curse",
         "item": "Megidola",
         "itemr": "Megidolaon",
         "skillCard": true,
@@ -544,7 +576,7 @@ var personaMapRoyal = {
     },
     "Bugs": {
         "special": true,
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Bear Gloves",
         "itemr": "Big Bear Gloves",
         "level": 49,
@@ -563,7 +595,7 @@ var personaMapRoyal = {
         "trait": "Potent Hypnosis"
     },
     "Byakhee": {
-        "inherits": "fire",
+        "inherits": "Fire",
         "item": "Null Wind",
         "itemr": "Repel Wind",
         "skillCard": true,
@@ -584,7 +616,7 @@ var personaMapRoyal = {
         "note": "Only available after 1/12"
     },
     "Byakko": {
-        "inherits": "ice",
+        "inherits": "Ice",
         "item": "Spiral Snow Ring",
         "itemr": "Blizzard Ring",
         "level": 45,
@@ -604,7 +636,7 @@ var personaMapRoyal = {
         "trait": "Retaliating Body"
     },
     "Cait Sith": {
-        "inherits": "ailment",
+        "inherits": "Ailment",
         "item": "Agi",
         "itemr": "Maragi",
         "skillCard": true,
@@ -616,7 +648,7 @@ var personaMapRoyal = {
         "trait": "Thermal Conduct"
     },
     "Cerberus": {
-        "inherits": "fire",
+        "inherits": "Fire",
         "item": "Megaton Raid",
         "itemr": "God's Hand",
         "skillCard": true,
@@ -632,10 +664,12 @@ var personaMapRoyal = {
             "Enduring Soul": 60
         },
         "stats": [39, 35, 32, 39, 27],
-        "trait": "Heated Bloodline"
+        "trait": "Heated Bloodline",
+        "area": "Sheriruth",
+        "floor": "L7-9 (after Palace 7)"
     },
     "Chernobog": {
-        "inherits": "ailment",
+        "inherits": "Ailment",
         "item": "Mudoon",
         "itemr": "Mamudoon",
         "skillCard": true,
@@ -652,11 +686,13 @@ var personaMapRoyal = {
             "Brave Blade": 67
         },
         "stats": [40, 37, 39, 38, 39],
-        "trait": "Crisis Control"
+        "trait": "Crisis Control",
+        "area": "Da'at",
+        "floor": "All"
     },
     "Chi You": {
         "special": true,
-        "inherits": "psy",
+        "inherits": "Psy",
         "item": "Repel Phys",
         "itemr": "Absorb Phys",
         "skillCard": true,
@@ -676,7 +712,7 @@ var personaMapRoyal = {
         "trait": "Chi You's Blessing"
     },
     "Chimera": {
-        "inherits": "phys",
+        "inherits": "Physical",
         "item": "Null Fire",
         "itemr": "Absorb Fire",
         "skillCard": true,
@@ -697,7 +733,7 @@ var personaMapRoyal = {
         "note": "Only available after 1/12"
     },
     "Choronzon": {
-        "inherits": "curse",
+        "inherits": "Curse",
         "item": "Curse Ring",
         "itemr": "Spiral Curse Ring",
         "level": 28,
@@ -714,10 +750,12 @@ var personaMapRoyal = {
             "Climate Decorum": 33
         },
         "stats": [16, 19, 19, 18, 19],
-        "trait": "Draining Mouth"
+        "trait": "Draining Mouth",
+        "area": "Kaitul",
+        "floor": "L1-4"
     },
     "Clotho": {
-        "inherits": "healing",
+        "inherits": "Healing",
         "item": "Tetraja",
         "itemr": "Makarakarn",
         "skillCard": true,
@@ -738,7 +776,7 @@ var personaMapRoyal = {
     },
     "Crystal Skull": {
         "rare": true,
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Crystal Skull",
         "itemr": "Crystal Skull R",
         "level": 50,
@@ -758,10 +796,12 @@ var personaMapRoyal = {
             "Cursed Bloodline": 0
         },
         "stats": [50, 50, 50, 50, 50],
-        "trait": "Ultimate Vessel"
+        "trait": "Ultimate Vessel",
+        "area": "Sheriruth / Da'at",
+        "floor": "L7-9. 11-13 (after Palace 7) / All"
     },
     "Cu Chulainn": {
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "One-shot Kill",
         "itemr": "Riot Gun",
         "skillCard": true,
@@ -781,7 +821,7 @@ var personaMapRoyal = {
         "trait": "Potent Hypnosis"
     },
     "Cybele": {
-        "inherits": "healing",
+        "inherits": "Healing",
         "item": "Sabazios",
         "itemr": "Gordios",
         "level": 83,
@@ -801,7 +841,7 @@ var personaMapRoyal = {
         "max": true
     },
     "Daisoujou": {
-        "inherits": "bless",
+        "inherits": "Bless",
         "item": "Spiral Blessing Ring",
         "itemr": "Divine Ring",
         "level": 40,
@@ -820,7 +860,7 @@ var personaMapRoyal = {
         "trait": "Draining Mouth"
     },
     "Dakini": {
-        "inherits": "phys",
+        "inherits": "Physical",
         "item": "Tempest Slash",
         "itemr": "Myriad Slashes",
         "skillCard": true,
@@ -837,10 +877,12 @@ var personaMapRoyal = {
             "Charge": 55
         },
         "stats": [34, 32, 34, 28, 29],
-        "trait": "Skillful Combo"
+        "trait": "Skillful Combo",
+        "area": "Sheriruth",
+        "floor": "L7-9 (after Palace 7)"
     },
     "Decarabia": {
-        "inherits": "fire",
+        "inherits": "Fire",
         "item": "Maragion",
         "itemr": "Agidyne",
         "skillCard": true,
@@ -857,10 +899,12 @@ var personaMapRoyal = {
             "Megidola": 38
         },
         "stats": [21, 23, 19, 22, 18],
-        "trait": "Heated Bloodline"
+        "trait": "Heated Bloodline",
+        "area": "Adyeshach",
+        "floor": "L3, 4, 6-8"
     },
     "Dionysus": {
-        "inherits": "ailment",
+        "inherits": "Ailment",
         "item": "Maziodyne",
         "itemr": "Thunder Reign",
         "skillCard": true,
@@ -880,7 +924,7 @@ var personaMapRoyal = {
         "trait": "Pinch Anchor"
     },
     "Dominion": {
-        "inherits": "bless",
+        "inherits": "Bless",
         "item": "Makougaon",
         "itemr": "Divine Judgement",
         "skillCard": true,
@@ -897,10 +941,12 @@ var personaMapRoyal = {
             "Evade Curse": 74
         },
         "stats": [42, 45, 43, 44, 37],
-        "trait": "Blessed Bloodline"
+        "trait": "Blessed Bloodline",
+        "area": "Da'at",
+        "floor": "All"
     },
     "Eligor": {
-        "inherits": "fire",
+        "inherits": "Fire",
         "item": "Tarukaja",
         "itemr": "Matarukaja",
         "skillCard": true,
@@ -916,11 +962,13 @@ var personaMapRoyal = {
             "Memory Blow": 20
         },
         "stats": [12, 10, 13, 10, 10],
-        "trait": "Thermal Conduct"
+        "trait": "Thermal Conduct",
+        "area": "Chemdah",
+        "floor": "L3 & 4"
     },
     "Emperor's Amulet": {
         "rare": true,
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Emperor's Amulet",
         "itemr": "Emperor's Charm R",
         "level": 35,
@@ -940,10 +988,12 @@ var personaMapRoyal = {
             "Psychic Bloodline": 0
         },
         "stats": [35, 35, 35, 35, 35],
-        "trait": "Ultimate Vessel"
+        "trait": "Ultimate Vessel",
+        "area": "Sheriruth",
+        "floor": "L7-9, 11-13 (after Palace 7)"
     },
     "Fafnir": {
-        "inherits": "nuke",
+        "inherits": "Nuclear",
         "item": "Spiral Reactor Ring",
         "itemr": "Fire Dragon Horn",
         "level": 86,
@@ -964,7 +1014,7 @@ var personaMapRoyal = {
     },
     "Flauros": {
         "special": true,
-        "inherits": "ailment",
+        "inherits": "Ailment",
         "item": "Giant Slice Belt",
         "itemr": "Rising Slash Belt",
         "level": 19,
@@ -983,7 +1033,7 @@ var personaMapRoyal = {
         "trait": "Gluttonmouth"
     },
     "Forneus": {
-        "inherits": "psy",
+        "inherits": "Psy",
         "item": "Psiodyne",
         "itemr": "Mapsiodyne",
         "skillCard": true,
@@ -1000,10 +1050,12 @@ var personaMapRoyal = {
             "Evade Psy": 68
         },
         "stats": [41, 39, 40, 42, 34],
-        "trait": "Bloodstained Eyes"
+        "trait": "Bloodstained Eyes",
+        "area": "Sheriruth",
+        "floor": "L12 & 13 (after Palace 7)"
     },
     "Fortuna": {
-        "inherits": "wind",
+        "inherits": "Wind",
         "item": "Lucky Robe",
         "itemr": "Super Lucky Robe",
         "level": 46,
@@ -1022,7 +1074,7 @@ var personaMapRoyal = {
         "trait": "Wind Bloodline"
     },
     "Futsunushi": {
-        "inherits": "phys",
+        "inherits": "Physical",
         "item": "Hinokagutsuchi",
         "itemr": "Hinokagutsuchi II",
         "level": 86,
@@ -1043,7 +1095,7 @@ var personaMapRoyal = {
         "max": true
     },
     "Fuu-Ki": {
-        "inherits": "wind",
+        "inherits": "Wind",
         "item": "Wind Boost",
         "itemr": "Wind Amp",
         "skillCard": true,
@@ -1052,10 +1104,12 @@ var personaMapRoyal = {
         "elems": ["-", "rs", "-", "-", "wk", "ab", "-", "-", "-", "-"],
         "skills": {"Tetra Break": 0, "Tarukaja": 0, "Garula": 0, "Wind Boost": 25, "Magarula": 26, "Resist Wind": 27},
         "stats": [14, 17, 16, 15, 14],
-        "trait": "Intense Focus"
+        "trait": "Intense Focus",
+        "area": "Kaitul",
+        "floor": "L8 & 9"
     },
     "Gabriel": {
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Spiral Blizzard Ring",
         "itemr": "Diamond Dust Lily",
         "level": 77,
@@ -1075,7 +1129,7 @@ var personaMapRoyal = {
         "trait": "Relentless"
     },
     "Ganesha": {
-        "inherits": "ailment",
+        "inherits": "Ailment",
         "item": "Rebellion",
         "itemr": "Revolution",
         "skillCard": true,
@@ -1092,10 +1146,12 @@ var personaMapRoyal = {
             "Charge": 60
         },
         "stats": [39, 31, 37, 33, 26],
-        "trait": "Gluttonmouth"
+        "trait": "Gluttonmouth",
+        "area": "Sheriruth",
+        "floor": "L5, 7-9 (before Palace 7) / L3 & 4 (after Palace 7)"
     },
     "Garuda": {
-        "inherits": "wind",
+        "inherits": "Wind",
         "item": "Garudyne",
         "itemr": "Magarudyne",
         "skillCard": true,
@@ -1112,10 +1168,12 @@ var personaMapRoyal = {
             "Wind Amp": 59
         },
         "stats": [30, 36, 29, 39, 29],
-        "trait": "Wind Bloodline"
+        "trait": "Wind Bloodline",
+        "area": "Sheriruth",
+        "floor": "L12 (after Palace 7)"
     },
     "Genbu": {
-        "inherits": "ice",
+        "inherits": "Ice",
         "item": "Frost Ring",
         "itemr": "Spiral Frost Ring",
         "level": 7,
@@ -1126,7 +1184,7 @@ var personaMapRoyal = {
         "trait": "Cold-Blooded"
     },
     "Girimehkala": {
-        "inherits": "ailment",
+        "inherits": "Ailment",
         "item": "Swift Strike",
         "itemr": "Deathbound",
         "skillCard": true,
@@ -1135,10 +1193,12 @@ var personaMapRoyal = {
         "elems": ["rp", "rp", "rs", "-", "-", "-", "-", "-", "wk", "nu"],
         "skills": {"Mudoon": 0, "Marakunda": 0, "Deathbound": 0, "Agidyne": 45, "Wage War": 47, "Repel Phys": 50},
         "stats": [32, 24, 32, 29, 19],
-        "trait": "Cursed Bloodline"
+        "trait": "Cursed Bloodline",
+        "area": "Adyeshach",
+        "floor": "L4, 6-8, 10"
     },
     "Hanuman": {
-        "inherits": "phys",
+        "inherits": "Physical",
         "item": "Ruyi Jingu Bang",
         "itemr": "Fine Ruyi Jingu Bang",
         "level": 64,
@@ -1153,10 +1213,12 @@ var personaMapRoyal = {
             "Regenerate 3": 69
         },
         "stats": [43, 38, 40, 40, 38],
-        "trait": "Potent Hypnosis"
+        "trait": "Potent Hypnosis",
+        "area": "Sheriruth",
+        "floor": "L12 & 13 (after Palace 7)"
     },
     "Hariti": {
-        "inherits": "elec",
+        "inherits": "Electric",
         "item": "Revival Charm",
         "itemr": "Rejuvenate Charm",
         "level": 40,
@@ -1176,7 +1238,7 @@ var personaMapRoyal = {
         "trait": "Electric Bloodline"
     },
     "Hastur": {
-        "inherits": "wind",
+        "inherits": "Wind",
         "item": "Spiral Gale Ring",
         "itemr": "Storm Sculpture",
         "level": 84,
@@ -1196,7 +1258,7 @@ var personaMapRoyal = {
         "note": "Only available after 1/12"
     },
     "Hecatoncheires": {
-        "inherits": "phys",
+        "inherits": "Physical",
         "item": "Swift Strike Belt",
         "itemr": "Gatling Belt",
         "level": 42,
@@ -1209,14 +1271,14 @@ var personaMapRoyal = {
             "Endure": 43,
             "Rebellion": 45,
             "Fortified Moxy": 46,
-            "Gattling Blows": 49
+            "Gatling Blows": 49
         },
         "stats": [35, 22, 27, 23, 26],
         "trait": "Gluttonmouth"
     },
     "Hell Biker": {
         "special": true,
-        "inherits": "fire",
+        "inherits": "Fire",
         "item": "Black Jacket",
         "itemr": "Dark Jacket",
         "level": 37,
@@ -1235,7 +1297,7 @@ var personaMapRoyal = {
         "trait": "Internal Hypnosis"
     },
     "High Pixie": {
-        "inherits": "healing",
+        "inherits": "Healing",
         "item": "Magaru",
         "itemr": "Garula",
         "skillCard": true,
@@ -1244,11 +1306,13 @@ var personaMapRoyal = {
         "elems": ["-", "wk", "-", "-", "rs", "rs", "-", "wk", "-", "-"],
         "skills": {"Garu": 0, "Media": 0, "Dormina": 0, "Diarama": 19, "Pulinpa": 20, "Magaru": 22},
         "stats": [8, 14, 10, 13, 10],
-        "trait": "Skillful Combo"
+        "trait": "Skillful Combo",
+        "area": "Kaitul",
+        "floor": "L1-3"
     },
     "Hope Diamond": {
         "rare": true,
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Hope Diamond",
         "itemr": "Hope Diamond R",
         "level": 40,
@@ -1268,10 +1332,12 @@ var personaMapRoyal = {
             "Retaliating Body": 0
         },
         "stats": [40, 40, 40, 40, 40],
-        "trait": "Ultimate Vessel"
+        "trait": "Ultimate Vessel",
+        "area": "Sheriruth",
+        "floor": "L7-9. 11-13 (after Palace 7)"
     },
     "Horus": {
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Hallowed Ring",
         "itemr": "Spiral Hallowed Ring",
         "level": 47,
@@ -1290,7 +1356,7 @@ var personaMapRoyal = {
         "trait": "Potent Hypnosis"
     },
     "Hua Po": {
-        "inherits": "fire",
+        "inherits": "Fire",
         "item": "Ember Ring",
         "itemr": "Spiral Ember Ring",
         "level": 9,
@@ -1298,10 +1364,12 @@ var personaMapRoyal = {
         "elems": ["-", "wk", "rp", "wk", "-", "-", "-", "-", "-", "-"],
         "skills": {"Agi": 0, "Dormina": 0, "Tarunda": 11, "Resist Forget": 12, "Maragi": 13, "Burn Boost": 15},
         "stats": [4, 10, 4, 8, 8],
-        "trait": "Thermal Conduct"
+        "trait": "Thermal Conduct",
+        "area": "Chemdah",
+        "floor": "L1-3"
     },
     "Incubus": {
-        "inherits": "ailment",
+        "inherits": "Ailment",
         "item": "Dream Needle",
         "itemr": "Dormin Rush",
         "skillCard": true,
@@ -1310,10 +1378,12 @@ var personaMapRoyal = {
         "elems": ["-", "-", "wk", "-", "rs", "-", "-", "-", "wk", "-"],
         "skills": {"Life Drain": 0, "Dream Needle": 0, "Dormina": 7, "Tarunda": 8, "Dodge Curse": 9},
         "stats": [4, 6, 4, 5, 3],
-        "trait": "Draining Mouth"
+        "trait": "Draining Mouth",
+        "area": "Aiyatsbus",
+        "floor": "L2, 3 & 6"
     },
     "Inugami": {
-        "inherits": "fire",
+        "inherits": "Fire",
         "item": "Giant Slice",
         "itemr": "Rising Slash",
         "skillCard": true,
@@ -1330,10 +1400,12 @@ var personaMapRoyal = {
             "Confuse Boost": 19
         },
         "stats": [11, 9, 9, 12, 8],
-        "trait": "Foul Odor"
+        "trait": "Foul Odor",
+        "area": "Chemdah",
+        "floor": "L4, 6 & 7"
     },
     "Ippon-Datara": {
-        "inherits": "phys",
+        "inherits": "Physical",
         "item": "Sledgehammer",
         "itemr": "Flash Bomb",
         "skillCard": true,
@@ -1349,10 +1421,12 @@ var personaMapRoyal = {
             "Counter": 18
         },
         "stats": [11, 7, 14, 6, 8],
-        "trait": "Striking Weight"
+        "trait": "Striking Weight",
+        "area": "Chemdah",
+        "floor": "L1-4"
     },
     "Ishtar": {
-        "inherits": "healing",
+        "inherits": "Healing",
         "item": "Spiral Thunder Ring",
         "itemr": "Goddess Horn",
         "level": 85,
@@ -1372,7 +1446,7 @@ var personaMapRoyal = {
         "max": true
     },
     "Isis": {
-        "inherits": "healing",
+        "inherits": "Healing",
         "item": "Kouga",
         "itemr": "Makouga",
         "skillCard": true,
@@ -1389,10 +1463,12 @@ var personaMapRoyal = {
             "Makarakarn": 32
         },
         "stats": [14, 20, 17, 18, 16],
-        "trait": "Savior Bloodline"
+        "trait": "Savior Bloodline",
+        "area": "Akzeriyyuth",
+        "floor": "L5-7, 9-11"
     },
     "Jack Frost": {
-        "inherits": "ice",
+        "inherits": "Ice",
         "item": "Frost Hood",
         "itemr": "Frost Ace Hood",
         "level": 11,
@@ -1400,10 +1476,12 @@ var personaMapRoyal = {
         "elems": ["-", "-", "wk", "nu", "-", "-", "-", "-", "-", "-"],
         "skills": {"Bufu": 0, "Ice Break": 0, "Baisudi": 0, "Mabufu": 12, "Rakunda": 13, "Freeze Boost": 15},
         "stats": [8, 9, 7, 9, 7],
-        "trait": "Frigid Bloodline"
+        "trait": "Frigid Bloodline",
+        "area": "Chemdah",
+        "floor": "L4 & 6"
     },
     "Jack-o'-Lantern": {
-        "inherits": "fire",
+        "inherits": "Fire",
         "item": "Pumpkin Bomb",
         "itemr": "Pumpkin Buster",
         "level": 2,
@@ -1411,10 +1489,12 @@ var personaMapRoyal = {
         "elems": ["-", "-", "ab", "wk", "-", "wk", "-", "-", "-", "-"],
         "skills": {"Agi": 0, "Rakunda": 0, "Sharp Student": 4, "Dazzler": 5, "Resist Sleep": 7},
         "stats": [2, 3, 3, 3, 2],
-        "trait": "Thermal Conduct"
+        "trait": "Thermal Conduct",
+        "area": "Qimranut / Aiyatsbus",
+        "floor": "All / L1"
     },
     "Jatayu": {
-        "inherits": "wind",
+        "inherits": "Wind",
         "item": "Speed Master",
         "itemr": "Auto-Masuku",
         "skillCard": true,
@@ -1434,7 +1514,7 @@ var personaMapRoyal = {
         "trait": "Wind Bloodline"
     },
     "Jikokuten": {
-        "inherits": "phys",
+        "inherits": "Physical",
         "item": "Assault Belt",
         "itemr": "Rush Belt",
         "level": 22,
@@ -1453,7 +1533,7 @@ var personaMapRoyal = {
         "trait": "Internal Hypnosis"
     },
     "Kaiwan": {
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Makajam",
         "itemr": "Makajamaon",
         "skillCard": true,
@@ -1470,10 +1550,12 @@ var personaMapRoyal = {
             "Marakunda": 41
         },
         "stats": [23, 26, 24, 22, 20],
-        "trait": "Psychic Bloodline"
+        "trait": "Psychic Bloodline",
+        "area": "Adyeshach",
+        "floor": "L10-12"
     },
     "Kali": {
-        "inherits": "fire",
+        "inherits": "Fire",
         "item": "Null Psy",
         "itemr": "Repel Psy",
         "skillCard": true,
@@ -1493,7 +1575,7 @@ var personaMapRoyal = {
         "trait": "Relentless"
     },
     "Kelpie": {
-        "inherits": "wind",
+        "inherits": "Wind",
         "item": "Garu",
         "itemr": "Magaru",
         "skillCard": true,
@@ -1502,10 +1584,12 @@ var personaMapRoyal = {
         "elems": ["-", "-", "-", "rs", "wk", "-", "-", "-", "-", "-"],
         "skills": {"Garu": 0, "Lunge": 0, "Resist Brainwash": 8, "Sukukaja": 9, "Terror Claw": 10},
         "stats": [5, 5, 5, 6, 4],
-        "trait": "Striking Weight"
+        "trait": "Striking Weight",
+        "area": "Aiyatsbus",
+        "floor": "L3"
     },
     "Kikuri-Hime": {
-        "inherits": "healing",
+        "inherits": "Healing",
         "item": "Energy Drop",
         "itemr": "Energy Shower",
         "skillCard": true,
@@ -1514,10 +1598,12 @@ var personaMapRoyal = {
         "elems": ["-", "-", "wk", "-", "-", "nu", "-", "-", "rs", "-"],
         "skills": {"Lullaby": 0, "Marakukaja": 0, "Energy Drop": 0, "Mediarama": 41, "Tetraja": 43, "Divine Grace": 45},
         "stats": [22, 31, 24, 28, 22],
-        "trait": "Relief Bloodline"
+        "trait": "Relief Bloodline",
+        "area": "Sheriruth",
+        "floor": "L3-5 (before Palace 7) / L2 & 3 (after Palace 7)"
     },
     "Kin-Ki": {
-        "inherits": "phys",
+        "inherits": "Physical",
         "item": "Vajra Blast",
         "itemr": "Vicious Strike",
         "skillCard": true,
@@ -1534,10 +1620,12 @@ var personaMapRoyal = {
             "Counterstrike": 31
         },
         "stats": [21, 13, 21, 15, 12],
-        "trait": "Retaliating Body"
+        "trait": "Retaliating Body",
+        "area": "Kaitul",
+        "floor": "L4, 5, 7-9"
     },
     "King Frost": {
-        "inherits": "ice",
+        "inherits": "Ice",
         "item": "King Frost Cape",
         "itemr": "King Frost Cape EX",
         "level": 61,
@@ -1553,10 +1641,12 @@ var personaMapRoyal = {
             "Ice Amp": 67
         },
         "stats": [40, 44, 43, 29, 34],
-        "trait": "Frigid Bloodline"
+        "trait": "Frigid Bloodline",
+        "area": "Sheriruth",
+        "floor": "L8, 11, 12, 13 (after Palace 7)"
     },
     "Kodama": {
-        "inherits": "ailment",
+        "inherits": "Ailment",
         "item": "Psy Ring",
         "itemr": "Spiral Psy Ring",
         "level": 11,
@@ -1572,11 +1662,13 @@ var personaMapRoyal = {
             "Resist Fear": 17
         },
         "stats": [7, 11, 8, 10, 4],
-        "trait": "Skillful Combo"
+        "trait": "Skillful Combo",
+        "area": "Aiyatsbus",
+        "floor": "L1-3"
     },
     "Koh-i-Noor": {
         "rare": true,
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Koh-i-Noor",
         "itemr": "Koh-i-Noor R",
         "level": 25,
@@ -1596,11 +1688,13 @@ var personaMapRoyal = {
             "Rare Antibody": 0
         },
         "stats": [25, 25, 25, 25, 25],
-        "trait": "Ultimate Vessel"
+        "trait": "Ultimate Vessel",
+        "area": "Adyeshach",
+        "floor": "L1-4, 6-8, 10-12"
     },
     "Kohryu": {
         "special": true,
-        "inherits": "psy",
+        "inherits": "Psy",
         "item": "Spiral Mystic Ring",
         "itemr": "Dragon's Heart",
         "level": 76,
@@ -1620,7 +1714,7 @@ var personaMapRoyal = {
         "max": true
     },
     "Koppa Tengu": {
-        "inherits": "wind",
+        "inherits": "Wind",
         "item": "Breeze Ring",
         "itemr": "Spiral Breeze Ring",
         "level": 11,
@@ -1628,10 +1722,12 @@ var personaMapRoyal = {
         "elems": ["-", "-", "-", "wk", "-", "rs", "-", "-", "wk", "-"],
         "skills": {"Garu": 0, "Sukukaja": 0, "Growth 1": 12, "Taunt": 13, "Rage Boost": 14, "Wage War": 15},
         "stats": [7, 8, 8, 11, 6],
-        "trait": "Intense Focus"
+        "trait": "Intense Focus",
+        "area": "Chemdah",
+        "floor": "L6 & 7"
     },
     "Koropokkuru": {
-        "inherits": "ice",
+        "inherits": "Ice",
         "item": "Bufu",
         "itemr": "Mabufu",
         "skillCard": true,
@@ -1648,10 +1744,12 @@ var personaMapRoyal = {
             "Climate Decorum": 15
         },
         "stats": [5, 8, 6, 9, 6],
-        "trait": "Foul Odor"
+        "trait": "Foul Odor",
+        "area": "Chemdah",
+        "floor": "L2 & 3"
     },
     "Koumokuten": {
-        "inherits": "phys",
+        "inherits": "Physical",
         "item": "Regenerate 2",
         "itemr": "Regenerate 3",
         "skillCard": true,
@@ -1671,7 +1769,7 @@ var personaMapRoyal = {
         "trait": "Gluttonmouth"
     },
     "Kumbhanda": {
-        "inherits": "ailment",
+        "inherits": "Ailment",
         "item": "Terror Claw",
         "itemr": "Bloodbath",
         "skillCard": true,
@@ -1688,10 +1786,12 @@ var personaMapRoyal = {
             "Revolution": 47
         },
         "stats": [25, 30, 25, 27, 26],
-        "trait": "Rare Antibody"
+        "trait": "Rare Antibody",
+        "area": "Sheriruth",
+        "floor": "L8, 9, 11-13 (before Palace 7) / L4 & 5 (after Palace 7)"
     },
     "Kurama Tengu": {
-        "inherits": "wind",
+        "inherits": "Wind",
         "item": "Wind Ring",
         "itemr": "Spiral Wind Ring",
         "level": 31,
@@ -1699,10 +1799,12 @@ var personaMapRoyal = {
         "elems": ["-", "-", "-", "nu", "-", "rp", "-", "-", "rs", "rs"],
         "skills": {"Double Shot": 0, "Masukunda": 0, "Magarula": 0, "Wind Boost": 32, "Brain Jack": 34, "Growth 2": 36},
         "stats": [20, 19, 21, 24, 16],
-        "trait": "Skillful Combo"
+        "trait": "Skillful Combo",
+        "area": "Sheriruth",
+        "floor": "L11 (after Palace 7)"
     },
     "Kushinada": {
-        "inherits": "healing",
+        "inherits": "Healing",
         "item": "Cure Charm",
         "itemr": "Spiral Cure Charm",
         "level": 42,
@@ -1719,10 +1821,12 @@ var personaMapRoyal = {
             "Null Ice": 48
         },
         "stats": [24, 30, 26, 28, 25],
-        "trait": "Savior Bloodline"
+        "trait": "Savior Bloodline",
+        "area": "Sheriruth",
+        "floor": "L5, 7-9 (before Palace 7) / L3 & 4 (after Palace 7)"
     },
     "Kushi Mitama": {
-        "inherits": "healing",
+        "inherits": "Healing",
         "item": "Aid Charm",
         "itemr": "Spiral Aid Charm",
         "level": 12,
@@ -1733,7 +1837,7 @@ var personaMapRoyal = {
         "trait": "Gluttonmouth"
     },
     "Lachesis": {
-        "inherits": "ice",
+        "inherits": "Ice",
         "item": "Snow Ring",
         "itemr": "Spiral Snow Ring",
         "level": 35,
@@ -1752,7 +1856,7 @@ var personaMapRoyal = {
         "trait": "Internal Hypnosis"
     },
     "Lakshmi": {
-        "inherits": "healing",
+        "inherits": "Healing",
         "item": "Amrita Charm",
         "itemr": "Spiral Amrita Charm",
         "level": 69,
@@ -1772,7 +1876,7 @@ var personaMapRoyal = {
         "max": true
     },
     "Lamia": {
-        "inherits": "fire",
+        "inherits": "Fire",
         "item": "Rakukaja",
         "itemr": "Marakukaja",
         "skillCard": true,
@@ -1789,21 +1893,26 @@ var personaMapRoyal = {
             "Despair Boost": 31
         },
         "stats": [21, 15, 18, 19, 12],
-        "trait": "Foul Odor"
+        "trait": "Foul Odor",
+        "area": "Akzeriyyuth",
+        "floor": "L3, 5-7, 9-11"
     },
     "Leanan Sidhe": {
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Mudo",
         "itemr": "Mamudo",
+        "skillCard": true,
         "level": 19,
         "arcana": "Lovers",
         "elems": ["-", "-", "wk", "-", "-", "rs", "rs", "-", "-", "-"],
         "skills": {"Rakunda": 0, "Psio": 0, "Marin Karin": 20, "Mamudo": 21, "Mapsi": 22, "Eiga": 23},
         "stats": [9, 17, 12, 16, 10],
-        "trait": "Skillful Technique"
+        "trait": "Skillful Technique",
+        "area": "Kaitul",
+        "floor": "L3-5"
     },
     "Legion": {
-        "inherits": "psy",
+        "inherits": "Psy",
         "item": "Foul Breath",
         "itemr": "Stagnant Air",
         "skillCard": true,
@@ -1820,10 +1929,12 @@ var personaMapRoyal = {
             "Eigaon": 45
         },
         "stats": [24, 24, 30, 23, 20],
-        "trait": "Draining Mouth"
+        "trait": "Draining Mouth",
+        "area": "Adyeshach",
+        "floor": "L1-4"
     },
     "Lilim": {
-        "inherits": "ice",
+        "inherits": "Ice",
         "item": "Ice Boost",
         "itemr": "Ice Amp",
         "skillCard": true,
@@ -1840,10 +1951,12 @@ var personaMapRoyal = {
             "Mabufula": 37
         },
         "stats": [17, 23, 18, 25, 20],
-        "trait": "Cold-Blooded"
+        "trait": "Cold-Blooded",
+        "area": "Adyeshach",
+        "floor": "L6-8, 10-12"
     },
     "Lilith": {
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Null Nuke",
         "itemr": "Repel Nuke",
         "skillCard": true,
@@ -1860,10 +1973,12 @@ var personaMapRoyal = {
             "Nuke Amp": 65
         },
         "stats": [33, 43, 37, 39, 35],
-        "trait": "Mighty Gaze"
+        "trait": "Mighty Gaze",
+        "area": "Da'at",
+        "floor": "All"
     },
     "Loa": {
-        "inherits": "curse",
+        "inherits": "Curse",
         "item": "Ominous Words",
         "itemr": "Abysmal Surge",
         "skillCard": true,
@@ -1885,7 +2000,7 @@ var personaMapRoyal = {
     },
     "Lucifer": {
         "special": true,
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Tyrant Pistol",
         "itemr": "Tyrant Pistol EX",
         "level": 93,
@@ -1906,7 +2021,7 @@ var personaMapRoyal = {
         "max": true
     },
     "Macabre": {
-        "inherits": "curse",
+        "inherits": "Curse",
         "item": "Bloodbath",
         "itemr": "Death Scythe",
         "skillCard": true,
@@ -1927,7 +2042,7 @@ var personaMapRoyal = {
         "note": "Only available after 1/12"
     },
     "Mada": {
-        "inherits": "fire",
+        "inherits": "Fire",
         "item": "Spiral Inferno Ring",
         "itemr": "Dark Flame Band",
         "level": 90,
@@ -1948,7 +2063,7 @@ var personaMapRoyal = {
         "max": true
     },
     "Makami": {
-        "inherits": "nuke",
+        "inherits": "Nuclear",
         "item": "Frei",
         "itemr": "Mafrei",
         "skillCard": true,
@@ -1965,10 +2080,12 @@ var personaMapRoyal = {
             "Dodge Elec": 20
         },
         "stats": [13, 12, 8, 11, 8],
-        "trait": "Skillful Technique"
+        "trait": "Skillful Technique",
+        "area": "Chemdah",
+        "floor": "L6 & 7"
     },
     "Mandrake": {
-        "inherits": "elec",
+        "inherits": "Electric",
         "item": "Sukunda",
         "itemr": "Masukunda",
         "skillCard": true,
@@ -1977,10 +2094,12 @@ var personaMapRoyal = {
         "elems": ["-", "-", "wk", "-", "rs", "-", "-", "-", "-", "-"],
         "skills": {"Pulinpa": 0, "Energy Drop": 0, "Lunge": 4, "Sukunda": 5},
         "stats": [2, 3, 3, 4, 4],
-        "trait": "Savior Bloodline"
+        "trait": "Savior Bloodline",
+        "area": "Qimranut / Aiyatsbus",
+        "floor": "All / L1"
     },
     "Mara": {
-        "inherits": "psy",
+        "inherits": "Psy",
         "item": "Mapsiodyne",
         "itemr": "Psycho Force",
         "skillCard": true,
@@ -1997,10 +2116,12 @@ var personaMapRoyal = {
             "Psycho Force": 78
         },
         "stats": [51, 43, 43, 45, 44],
-        "trait": "Mighty Gaze"
+        "trait": "Mighty Gaze",
+        "area": "Da'at",
+        "floor": "All"
     },
     "Maria": {
-        "inherits": "healing",
+        "inherits": "Healing",
         "item": "Spiral Heal Charm",
         "itemr": "Rosary of Purity",
         "level": 93,
@@ -2020,7 +2141,7 @@ var personaMapRoyal = {
         "max": true
     },
     "Matador": {
-        "inherits": "psy",
+        "inherits": "Psy",
         "item": "Blood Red Capote",
         "itemr": "Bloodied Capote",
         "level": 17,
@@ -2031,7 +2152,7 @@ var personaMapRoyal = {
         "trait": "Potent Hypnosis"
     },
     "Melchizedek": {
-        "inherits": "bless",
+        "inherits": "Bless",
         "item": "Hamaon",
         "itemr": "Mahamaon",
         "skillCard": true,
@@ -2048,11 +2169,13 @@ var personaMapRoyal = {
             "God's Hand": 65
         },
         "stats": [37, 32, 40, 39, 33],
-        "trait": "Deathly Illness"
+        "trait": "Deathly Illness",
+        "area": "Da'at",
+        "floor": "All"
     },
     "Metatron": {
         "special": true,
-        "inherits": "bless",
+        "inherits": "Bless",
         "item": "Nataraja",
         "itemr": "Nataraja EX",
         "level": 89,
@@ -2073,7 +2196,7 @@ var personaMapRoyal = {
     },
     "Michael": {
         "special": true,
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Judge of Hell",
         "itemr": "Judge End",
         "level": 87,
@@ -2092,7 +2215,7 @@ var personaMapRoyal = {
         "trait": "Potent Hypnosis"
     },
     "Mishaguji": {
-        "inherits": "ailment",
+        "inherits": "Ailment",
         "item": "Spiral Karma Ring",
         "itemr": "Mystic Ring",
         "level": 52,
@@ -2110,8 +2233,8 @@ var personaMapRoyal = {
         "stats": [32, 32, 32, 32, 35],
         "trait": "Ailment Hunter"
     },
-    "Mithra": {
-        "inherits": "bless",
+    "Mitra": {
+        "inherits": "Bless",
         "item": "Death Contract",
         "itemr": "Death Promise",
         "level": 33,
@@ -2130,7 +2253,7 @@ var personaMapRoyal = {
         "trait": "Blessed Bloodline"
     },
     "Mithras": {
-        "inherits": "nuke",
+        "inherits": "Nuclear",
         "item": "Nuke Boost",
         "itemr": "Nuke Amp",
         "skillCard": true,
@@ -2147,10 +2270,12 @@ var personaMapRoyal = {
             "Freidyne": 45
         },
         "stats": [27, 25, 27, 25, 20],
-        "trait": "Skillful Technique"
+        "trait": "Skillful Technique",
+        "area": "Adyeshach",
+        "floor": "L11 & 12"
     },
     "Mokoi": {
-        "inherits": "ailment",
+        "inherits": "Ailment",
         "item": "Dekunda",
         "itemr": "Dekaja",
         "skillCard": true,
@@ -2166,10 +2291,12 @@ var personaMapRoyal = {
             "Dekunda": 14
         },
         "stats": [9, 5, 6, 10, 4],
-        "trait": "Gloomy Child"
+        "trait": "Gloomy Child",
+        "area": "Chemdah",
+        "floor": "L1-4"
     },
     "Moloch": {
-        "inherits": "fire",
+        "inherits": "Fire",
         "item": "Inferno Ring",
         "itemr": "Spiral Inferno Ring",
         "level": 60,
@@ -2185,10 +2312,12 @@ var personaMapRoyal = {
             "Fire Amp": 65
         },
         "stats": [32, 45, 42, 31, 37],
-        "trait": "Immunity"
+        "trait": "Immunity",
+        "area": "Da'at",
+        "floor": "All"
     },
     "Mot": {
-        "inherits": "ailment",
+        "inherits": "Ailment",
         "item": "Null Elec",
         "itemr": "Repel Elec",
         "skillCard": true,
@@ -2204,10 +2333,12 @@ var personaMapRoyal = {
             "Repel Elec": 77
         },
         "stats": [43, 51, 48, 42, 39],
-        "trait": "Mighty Gaze"
+        "trait": "Mighty Gaze",
+        "area": "Da'at",
+        "floor": "All"
     },
     "Mother Harlot": {
-        "inherits": "ice",
+        "inherits": "Ice",
         "item": "Claiomh Solais",
         "itemr": "Claiomh Solais R",
         "level": 85,
@@ -2227,7 +2358,7 @@ var personaMapRoyal = {
         "max": true
     },
     "Mothman": {
-        "inherits": "elec",
+        "inherits": "Electric",
         "item": "Skull Cracker",
         "itemr": "Mind Slice",
         "skillCard": true,
@@ -2244,10 +2375,12 @@ var personaMapRoyal = {
             "Ziodyne": 38
         },
         "stats": [21, 24, 16, 24, 21],
-        "trait": "Static Electricity"
+        "trait": "Static Electricity",
+        "area": "Adyeshach",
+        "floor": "L3, 4, 7, 8, 10"
     },
     "Naga": {
-        "inherits": "elec",
+        "inherits": "Electric",
         "item": "Counter",
         "itemr": "Counterstrike",
         "skillCard": true,
@@ -2264,10 +2397,12 @@ var personaMapRoyal = {
             "Marakukaja": 29
         },
         "stats": [15, 17, 15, 17, 15],
-        "trait": "Striking Weight"
+        "trait": "Striking Weight",
+        "area": "Akzeriyyuth",
+        "floor": "L2, 3, 5-7, 9"
     },
     "Narcissus": {
-        "inherits": "ailment",
+        "inherits": "Ailment",
         "item": "Dazzler",
         "itemr": "Nocturnal Flash",
         "skillCard": true,
@@ -2284,10 +2419,12 @@ var personaMapRoyal = {
             "Ambient Aid": 53
         },
         "stats": [27, 31, 29, 33, 31],
-        "trait": "Gluttonmouth"
+        "trait": "Gluttonmouth",
+        "area": "Sheriruth",
+        "floor": "L7 & 8 (after Palace 7)"
     },
     "Nebiros": {
-        "inherits": "curse",
+        "inherits": "Curse",
         "item": "Marin Karin",
         "itemr": "Brain Jack",
         "skillCard": true,
@@ -2308,7 +2445,7 @@ var personaMapRoyal = {
     },
     "Neko Shogun": {
         "special": true,
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Catnap",
         "itemr": "Cat Buster",
         "level": 30,
@@ -2327,7 +2464,7 @@ var personaMapRoyal = {
         "trait": "Pinch Anchor"
     },
     "Nekomata": {
-        "inherits": "ailment",
+        "inherits": "Ailment",
         "item": "Pawzooka",
         "itemr": "Paw-omber",
         "level": 17,
@@ -2343,10 +2480,12 @@ var personaMapRoyal = {
             "Dodge Elec": 22
         },
         "stats": [13, 10, 12, 15, 8],
-        "trait": "Foul Odor"
+        "trait": "Foul Odor",
+        "area": "Kaitul",
+        "floor": "L2-4"
     },
     "Nigi Mitama": {
-        "inherits": "healing",
+        "inherits": "Healing",
         "item": "Prayer Ring",
         "itemr": "Spiral Prayer Ring",
         "level": 22,
@@ -2357,7 +2496,7 @@ var personaMapRoyal = {
         "trait": "Relief Bloodline"
     },
     "Norn": {
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Recarm",
         "itemr": "Samarecarm",
         "skillCard": true,
@@ -2374,10 +2513,12 @@ var personaMapRoyal = {
             "Samarecarm": 57
         },
         "stats": [30, 38, 33, 34, 28],
-        "trait": "Intense Focus"
+        "trait": "Intense Focus",
+        "area": "Sheriruth",
+        "floor": "L11-13 (before Palace 7) / L5 (after Palace 7)"
     },
     "Nue": {
-        "inherits": "curse",
+        "inherits": "Curse",
         "item": "Maeiha",
         "itemr": "Eiga",
         "skillCard": true,
@@ -2394,10 +2535,12 @@ var personaMapRoyal = {
             "Curse Boost": 26
         },
         "stats": [16, 10, 17, 14, 10],
-        "trait": "Mighty Gaze"
+        "trait": "Mighty Gaze",
+        "area": "Chemdah",
+        "floor": "L4"
     },
     "Obariyon": {
-        "inherits": "phys",
+        "inherits": "Physical",
         "item": "Lucky Punch",
         "itemr": "Miracle Punch",
         "skillCard": true,
@@ -2406,10 +2549,12 @@ var personaMapRoyal = {
         "elems": ["rs", "-", "-", "-", "wk", "-", "-", "-", "-", "-"],
         "skills": {"Snap": 0, "Sukunda": 0, "Lucky Punch": 9, "Resist Fear": 10, "Dekaja": 12},
         "stats": [7, 3, 9, 8, 4],
-        "trait": "Striking Weight"
+        "trait": "Striking Weight",
+        "area": "Aiyatsbus",
+        "floor": "L3, 5 & 6"
     },
     "Oberon": {
-        "inherits": "elec",
+        "inherits": "Electric",
         "item": "Heat Wave",
         "itemr": "Vorpal Blade",
         "skillCard": true,
@@ -2427,10 +2572,12 @@ var personaMapRoyal = {
             "Elec Amp": 72
         },
         "stats": [40, 45, 42, 43, 35],
-        "trait": "Static Electricity"
+        "trait": "Static Electricity",
+        "area": "Sheriruth",
+        "floor": "L13 (after Palace 7)"
     },
     "Odin": {
-        "inherits": "elec",
+        "inherits": "Electric",
         "item": "Wild Hunt",
         "itemr": "Gungnir",
         "level": 84,
@@ -2450,7 +2597,7 @@ var personaMapRoyal = {
         "max": true
     },
     "Okuninushi": {
-        "inherits": "psy",
+        "inherits": "Psy",
         "item": "Official's Robe",
         "itemr": "Official's Robe R",
         "level": 54,
@@ -2470,7 +2617,7 @@ var personaMapRoyal = {
     },
     "Ongyo-Ki": {
         "special": true,
-        "inherits": "phys",
+        "inherits": "Physical",
         "item": "Myriad Slash Belt",
         "itemr": "Sword Dance Belt",
         "level": 89,
@@ -2490,7 +2637,7 @@ var personaMapRoyal = {
         "max": true
     },
     "Oni": {
-        "inherits": "phys",
+        "inherits": "Physical",
         "item": "Rampage",
         "itemr": "Kill Rush",
         "skillCard": true,
@@ -2499,10 +2646,12 @@ var personaMapRoyal = {
         "elems": ["rs", "rs", "-", "-", "-", "-", "-", "-", "-", "-"],
         "skills": {"Rampage": 0, "Counter": 0, "Snap": 0, "Giant Slice": 22, "Sharp Student": 23, "Memory Blow": 24},
         "stats": [19, 9, 17, 12, 10],
-        "trait": "Retaliating Body"
+        "trait": "Retaliating Body",
+        "area": "Kaitul",
+        "floor": "L3-5, 8, 9"
     },
     "Onmoraki": {
-        "inherits": "curse",
+        "inherits": "Curse",
         "item": "Grudge Ring",
         "itemr": "Spiral Grudge Ring",
         "level": 12,
@@ -2510,11 +2659,13 @@ var personaMapRoyal = {
         "elems": ["-", "-", "rs", "wk", "-", "-", "-", "-", "wk", "nu"],
         "skills": {"Eiha": 0, "Ice Wall": 0, "Agi": 13, "Evil Touch": 14, "Pulinpa": 15, "Confuse Boost": 17},
         "stats": [9, 12, 7, 10, 5],
-        "trait": "Intense Focus"
+        "trait": "Intense Focus",
+        "area": "Chemdah",
+        "floor": "L3 & 4"
     },
     "Orichalcum": {
         "rare": true,
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Orichalcum",
         "itemr": "Orichalcum R",
         "level": 60,
@@ -2538,7 +2689,7 @@ var personaMapRoyal = {
     },
     "Orlov": {
         "rare": true,
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Orlov",
         "itemr": "Orlov R",
         "level": 30,
@@ -2558,10 +2709,12 @@ var personaMapRoyal = {
             "Atomic Bloodline": 0
         },
         "stats": [30, 30, 30, 30, 30],
-        "trait": "Ultimate Vessel"
+        "trait": "Ultimate Vessel",
+        "area": "Sheriruth",
+        "floor": "All (before Palace 7) / L1-5 (after Palace 7)"
     },
     "Orobas": {
-        "inherits": "fire",
+        "inherits": "Fire",
         "item": "Rakunda",
         "itemr": "Marakunda",
         "skillCard": true,
@@ -2570,10 +2723,12 @@ var personaMapRoyal = {
         "elems": ["-", "-", "-", "wk", "-", "rs", "-", "-", "-", "rs"],
         "skills": {"Maragi": 0, "Sukukaja": 0, "Dekaja": 0, "Marakunda": 19, "Fire Break": 20, "Makajamaon": 21},
         "stats": [11, 14, 15, 12, 6],
-        "trait": "Mighty Gaze"
+        "trait": "Mighty Gaze",
+        "area": "Kaitul",
+        "floor": "L1-3"
     },
     "Orthrus": {
-        "inherits": "fire",
+        "inherits": "Fire",
         "item": "Agilao",
         "itemr": "Maragion",
         "skillCard": true,
@@ -2589,10 +2744,12 @@ var personaMapRoyal = {
             "Matarukaja": 26
         },
         "stats": [16, 14, 14, 19, 7],
-        "trait": "Thermal Conduct"
+        "trait": "Thermal Conduct",
+        "area": "Kaitul",
+        "floor": "L4, 5, 7-9"
     },
     "Ose": {
-        "inherits": "ailment",
+        "inherits": "Ailment",
         "item": "Counterstrike",
         "itemr": "High Counter",
         "skillCard": true,
@@ -2608,10 +2765,12 @@ var personaMapRoyal = {
             "Heat Wave": 47
         },
         "stats": [32, 24, 25, 31, 21],
-        "trait": "Retaliating Body"
+        "trait": "Retaliating Body",
+        "area": "Sheriruth",
+        "floor": "L1-5, 9 (before Palace 7) / L1-4 (after Palace 7)"
     },
     "Pale Rider": {
-        "inherits": "curse",
+        "inherits": "Curse",
         "item": "Hex Ring",
         "itemr": "Spiral Hex Ring",
         "level": 54,
@@ -2630,7 +2789,7 @@ var personaMapRoyal = {
         "trait": "Foul Stench"
     },
     "Parvati": {
-        "inherits": "psy",
+        "inherits": "Psy",
         "item": "Null Ice",
         "itemr": "Repel Ice",
         "skillCard": true,
@@ -2647,10 +2806,12 @@ var personaMapRoyal = {
             "Null Ice": 61
         },
         "stats": [33, 39, 33, 39, 31],
-        "trait": "Skillful Technique"
+        "trait": "Skillful Technique",
+        "area": "Sheriruth",
+        "floor": "L9, 11, 12 (after Palace 7)"
     },
     "Pazuzu": {
-        "inherits": "curse",
+        "inherits": "Curse",
         "item": "Spiral Curse Ring",
         "itemr": "Hex Ring",
         "level": 45,
@@ -2669,7 +2830,7 @@ var personaMapRoyal = {
         "trait": "Cursed Bloodline"
     },
     "Phoenix": {
-        "inherits": "nuke",
+        "inherits": "Nuclear",
         "item": "Heavensent Dress",
         "itemr": "Godsent Dress",
         "level": 21,
@@ -2680,7 +2841,7 @@ var personaMapRoyal = {
         "trait": "Atomic Bloodline"
     },
     "Pisaca": {
-        "inherits": "curse",
+        "inherits": "Curse",
         "item": "Headhunter Ladle",
         "itemr": "Headhunter Ladle EX",
         "level": 28,
@@ -2696,10 +2857,12 @@ var personaMapRoyal = {
             "Mudoon": 33
         },
         "stats": [19, 21, 21, 16, 14],
-        "trait": "Rare Antibody"
+        "trait": "Rare Antibody",
+        "area": "Akzeriyyuth",
+        "floor": "L5-7, 9-11"
     },
     "Pixie": {
-        "inherits": "elec",
+        "inherits": "Electric",
         "item": "Static Ring",
         "itemr": "Spiral Static Ring",
         "level": 2,
@@ -2707,10 +2870,12 @@ var personaMapRoyal = {
         "elems": ["-", "wk", "-", "wk", "rs", "-", "-", "-", "rs", "wk"],
         "skills": {"Zio": 0, "Dia": 0, "Patra": 3, "Tarukaja": 5, "Resist Confuse": 6},
         "stats": [1, 3, 3, 4, 2],
-        "trait": "Static Electricity"
+        "trait": "Static Electricity",
+        "area": "Qimranut / Aiyatsbus",
+        "floor": "All / L1 & 3"
     },
     "Power": {
-        "inherits": "bless",
+        "inherits": "Bless",
         "item": "Bless Boost",
         "itemr": "Bless Amp",
         "skillCard": true,
@@ -2727,10 +2892,12 @@ var personaMapRoyal = {
             "Null Curse": 46
         },
         "stats": [30, 26, 28, 25, 21],
-        "trait": "Internal Hypnosis"
+        "trait": "Internal Hypnosis",
+        "area": "Sheriruth",
+        "floor": "L1-5, 7 (before Palace 7) / L1-3 (after Palace 7)"
     },
     "Principality": {
-        "inherits": "bless",
+        "inherits": "Bless",
         "item": "Blessing Ring",
         "itemr": "Spiral Blessing Ring",
         "level": 29,
@@ -2749,7 +2916,7 @@ var personaMapRoyal = {
         "trait": "Blessed Bloodline"
     },
     "Queen Mab": {
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Masquerade Ribbon",
         "itemr": "Masquerade Ribbon R",
         "level": 43,
@@ -2765,11 +2932,13 @@ var personaMapRoyal = {
             "Concentrate": 48
         },
         "stats": [23, 35, 26, 30, 22],
-        "trait": "Static Electricity"
+        "trait": "Static Electricity",
+        "area": "Sheriruth",
+        "floor": "L5, 7-9 (before Palace 7) / L3 & 4 (after Palace 7)"
     },
     "Queen's Necklace": {
         "rare": true,
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Queen's Necklace",
         "itemr": "Queen's Necklace R",
         "level": 15,
@@ -2789,10 +2958,12 @@ var personaMapRoyal = {
             "Savior Bloodline": 0
         },
         "stats": [15, 15, 15, 15, 15],
-        "trait": "Ultimate Vessel"
+        "trait": "Ultimate Vessel",
+        "area": "Kaitul",
+        "floor": "L1-5, 7-9"
     },
     "Quetzalcoatl": {
-        "inherits": "wind",
+        "inherits": "Wind",
         "item": "Magarudyne",
         "itemr": "Panta Rhei",
         "skillCard": true,
@@ -2812,7 +2983,7 @@ var personaMapRoyal = {
         "trait": "Wind Bloodline"
     },
     "Raja Naga": {
-        "inherits": "elec",
+        "inherits": "Electric",
         "item": "Thunder Ring",
         "itemr": "Spiral Thunder Ring",
         "level": 55,
@@ -2831,7 +3002,7 @@ var personaMapRoyal = {
         "trait": "Electric Bloodline"
     },
     "Rakshasa": {
-        "inherits": "phys",
+        "inherits": "Physical",
         "item": "Regenerate 1",
         "itemr": "Regenerate 2",
         "skillCard": true,
@@ -2848,10 +3019,13 @@ var personaMapRoyal = {
             "Adverse Resolve": 30
         },
         "stats": [20, 15, 18, 17, 9],
-        "trait": "Skillful Combo"
+        "trait": "Skillful Combo",
+        "personality": "Irritable",
+        "area": "Kaitul",
+        "floor": "L5, 7-9"
     },
     "Rangda": {
-        "inherits": "curse",
+        "inherits": "Curse",
         "item": "Maeiga",
         "itemr": "Eigaon",
         "skillCard": true,
@@ -2860,10 +3034,12 @@ var personaMapRoyal = {
         "elems": ["rp", "rp", "nu", "-", "wk", "-", "-", "-", "wk", "nu"],
         "skills": {"Swift Strike": 0, "Bloodbath": 0, "Counterstrike": 0, "Eigaon": 49, "Matarunda": 51, "Mudoon": 53},
         "stats": [28, 34, 30, 33, 26],
-        "trait": "Cursed Bloodline"
+        "trait": "Cursed Bloodline",
+        "area": "Sheriruth",
+        "floor": "L11-13 (before Palace 7) / L5 (after Palace 7)"
     },
     "Raphael": {
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Null Bless",
         "itemr": "Repel Bless",
         "skillCard": true,
@@ -2883,7 +3059,7 @@ var personaMapRoyal = {
         "trait": "Pinch Anchor"
     },
     "Red Rider": {
-        "inherits": "psy",
+        "inherits": "Psy",
         "item": "Karma Ring",
         "itemr": "Spiral Karma Ring",
         "level": 41,
@@ -2903,7 +3079,7 @@ var personaMapRoyal = {
     },
     "Regent": {
         "rare": true,
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Regent",
         "itemr": "Regent R",
         "level": 10,
@@ -2923,10 +3099,12 @@ var personaMapRoyal = {
             "Skillful Combo": 0
         },
         "stats": [10, 10, 10, 10, 10],
-        "trait": "Ultimate Vessel"
+        "trait": "Ultimate Vessel",
+        "area": "Qimranut / Aiyatsbus / Chemdah",
+        "floor": "All / L1-3, 5 & 6 / L1-4, 6 & 7"
     },
     "Saki Mitama": {
-        "inherits": "healing",
+        "inherits": "Healing",
         "item": "Energy Charm",
         "itemr": "Spiral Energy Charm",
         "level": 6,
@@ -2937,7 +3115,7 @@ var personaMapRoyal = {
         "trait": "Internal Hypnosis"
     },
     "Sandalphon": {
-        "inherits": "bless",
+        "inherits": "Bless",
         "item": "Sword of Sinai",
         "itemr": "Sword of Sinai II",
         "level": 75,
@@ -2957,7 +3135,7 @@ var personaMapRoyal = {
         "max": true
     },
     "Sandman": {
-        "inherits": "wind",
+        "inherits": "Wind",
         "item": "Dormina",
         "itemr": "Lullaby",
         "skillCard": true,
@@ -2974,10 +3152,12 @@ var personaMapRoyal = {
             "Sleep Boost": 28
         },
         "stats": [11, 13, 14, 17, 21],
-        "trait": "Foul Odor"
+        "trait": "Foul Odor",
+        "area": "Akzeriyyuth",
+        "floor": "L1-3"
     },
     "Sarasvati": {
-        "inherits": "healing",
+        "inherits": "Healing",
         "item": "Mediarama",
         "itemr": "Diarahan",
         "skillCard": true,
@@ -2994,10 +3174,12 @@ var personaMapRoyal = {
             "Diarahan": 54
         },
         "stats": [30, 35, 32, 33, 27],
-        "trait": "Relief Bloodline"
+        "trait": "Relief Bloodline",
+        "area": "Sheriruth",
+        "floor": "L7-9. 12 (after Palace 7)"
     },
     "Satan": {
-        "inherits": "ice",
+        "inherits": "Ice",
         "item": "Tantric Oath",
         "itemr": "Tantric Oath R",
         "level": 92,
@@ -3019,7 +3201,7 @@ var personaMapRoyal = {
     },
     "Satanael": {
         "special": true,
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Paradise Lost",
         "itemr": "Paradise Lost R",
         "level": 95,
@@ -3040,7 +3222,7 @@ var personaMapRoyal = {
         "note": "Only available on NG+"
     },
     "Scathach": {
-        "inherits": "wind",
+        "inherits": "Wind",
         "item": "Makarakarn",
         "itemr": "Tetrakarn",
         "skillCard": true,
@@ -3057,10 +3239,12 @@ var personaMapRoyal = {
             "Attack Master": 82
         },
         "stats": [48, 52, 46, 48, 44],
-        "trait": "Skillful Technique"
+        "trait": "Skillful Technique",
+        "area": "Adyeshach",
+        "floor": "L10-12"
     },
     "Seiryu": {
-        "inherits": "ice",
+        "inherits": "Ice",
         "item": "Blizzard Ring",
         "itemr": "Spiral Blizzard Ring",
         "level": 62,
@@ -3079,7 +3263,7 @@ var personaMapRoyal = {
         "trait": "Relentless"
     },
     "Setanta": {
-        "inherits": "phys",
+        "inherits": "Physical",
         "item": "Rebellion Anklet",
         "itemr": "Revolution Anklet",
         "level": 25,
@@ -3091,7 +3275,7 @@ var personaMapRoyal = {
     },
     "Seth": {
         "special": true,
-        "inherits": "fire",
+        "inherits": "Fire",
         "item": "Triple Shot Belt",
         "itemr": "Special Shot Belt",
         "level": 51,
@@ -3109,7 +3293,7 @@ var personaMapRoyal = {
         "trait": "Potent Hypnosis"
     },
     "Shiisaa": {
-        "inherits": "elec",
+        "inherits": "Electric",
         "item": "Double Fangs",
         "itemr": "Cornered Fang",
         "skillCard": true,
@@ -3128,7 +3312,7 @@ var personaMapRoyal = {
         "trait": "Atomic Bloodline"
     },
     "Shiki-Ouji": {
-        "inherits": "psy",
+        "inherits": "Psy",
         "item": "Double Shot",
         "itemr": "Triple Down",
         "skillCard": true,
@@ -3145,11 +3329,13 @@ var personaMapRoyal = {
             "Oni Kagura": 24
         },
         "stats": [16, 14, 12, 9, 10],
-        "trait": "Psychic Bloodline"
+        "trait": "Psychic Bloodline",
+        "area": "Chemdah",
+        "floor": "L6 & 7"
     },
     "Shiva": {
         "special": true,
-        "inherits": "psy",
+        "inherits": "Psy",
         "item": "Megido Fire",
         "itemr": "Megido Blaster",
         "level": 82,
@@ -3168,7 +3354,7 @@ var personaMapRoyal = {
         "trait": "Psychic Bloodline"
     },
     "Siegfried": {
-        "inherits": "phys",
+        "inherits": "Physical",
         "item": "Vorpal Blade Belt",
         "itemr": "Brave Belt",
         "level": 84,
@@ -3187,7 +3373,7 @@ var personaMapRoyal = {
         "trait": "Retaliating Body"
     },
     "Silky": {
-        "inherits": "healing",
+        "inherits": "Healing",
         "item": "Silk Dress",
         "itemr": "Fine Silk Dress",
         "level": 6,
@@ -3195,10 +3381,12 @@ var personaMapRoyal = {
         "elems": ["-", "-", "wk", "rs", "wk", "-", "-", "-", "-", "-"],
         "skills": {"Dormina": 0, "Bufu": 0, "Dia": 7, "Patra": 9, "Sharp Student": 10},
         "stats": [4, 7, 4, 5, 5],
-        "trait": "Intense Focus"
+        "trait": "Intense Focus",
+        "area": "Aiyatsbus",
+        "floor": "L2, 3, 5 & 6"
     },
     "Skadi": {
-        "inherits": "ice",
+        "inherits": "Ice",
         "item": "Snow Queen's Whip",
         "itemr": "Snow Queen's Whip II",
         "level": 53,
@@ -3214,10 +3402,12 @@ var personaMapRoyal = {
             "Spirit Drain": 58
         },
         "stats": [33, 39, 32, 34, 28],
-        "trait": "Bloodstained Eyes"
+        "trait": "Bloodstained Eyes",
+        "area": "Sheriruth",
+        "floor": "L12 & 13 (before Palace 7) / L5 (after Palace 7)"
     },
     "Slime": {
-        "inherits": "curse",
+        "inherits": "Curse",
         "item": "Tarunda",
         "itemr": "Matarunda",
         "skillCard": true,
@@ -3226,11 +3416,13 @@ var personaMapRoyal = {
         "elems": ["rs", "rs", "wk", "-", "-", "wk", "-", "-", "-", "-"],
         "skills": {"Lunge": 0, "Evil Touch": 0, "Tarunda": 11, "Fire Wall": 13, "Headbutt": 14},
         "stats": [9, 6, 11, 6, 5],
-        "trait": "Rare Antibody"
+        "trait": "Rare Antibody",
+        "area": "Qimranut / Aiyatsbus",
+        "floor": "All / L1, 2, 3, 6"
     },
     "Sraosha": {
         "special": true,
-        "inherits": "bless",
+        "inherits": "Bless",
         "item": "Archangel Bra",
         "itemr": "High Archangel Bra",
         "level": 80,
@@ -3250,7 +3442,7 @@ var personaMapRoyal = {
     },
     "Stone of Scone": {
         "rare": true,
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Stone of Scone",
         "itemr": "Stone of Scone R",
         "level": 20,
@@ -3270,10 +3462,12 @@ var personaMapRoyal = {
             "Intense Focus": 0
         },
         "stats": [20, 20, 20, 20, 20],
-        "trait": "Ultimate Vessel"
+        "trait": "Ultimate Vessel",
+        "area": "Akzeriyyuth",
+        "floor": "L1-3, 5-7, 9-11"
     },
     "Succubus": {
-        "inherits": "curse",
+        "inherits": "Curse",
         "item": "Brain Shot",
         "itemr": "Pink Buster",
         "level": 7,
@@ -3281,10 +3475,12 @@ var personaMapRoyal = {
         "elems": ["-", "-", "rs", "-", "-", "wk", "-", "-", "wk", "nu"],
         "skills": {"Dormina": 0, "Rebellion": 0, "Agi": 8, "Dekaja": 10, "Sleep Boost": 11, "Mudo": 12},
         "stats": [4, 7, 5, 8, 4],
-        "trait": "Foul Odor"
+        "trait": "Foul Odor",
+        "area": "Aiyatsbus",
+        "floor": "L5 & 6"
     },
     "Sudama": {
-        "inherits": "psy",
+        "inherits": "Psy",
         "item": "Mapsi",
         "itemr": "Psio",
         "skillCard": true,
@@ -3301,10 +3497,12 @@ var personaMapRoyal = {
             "Psio": 23
         },
         "stats": [9, 14, 12, 13, 10],
-        "trait": "Gloomy Child"
+        "trait": "Gloomy Child",
+        "area": "Chemdah",
+        "floor": "L6 & 7"
     },
     "Sui-Ki": {
-        "inherits": "ice",
+        "inherits": "Ice",
         "item": "Bufula",
         "itemr": "Mabufula",
         "skillCard": true,
@@ -3321,10 +3519,12 @@ var personaMapRoyal = {
             "Dodge Fire": 29
         },
         "stats": [16, 15, 15, 18, 15],
-        "trait": "Frigid Bloodline"
+        "trait": "Frigid Bloodline",
+        "area": "Kaitul",
+        "floor": "L7-9"
     },
     "Surt": {
-        "inherits": "fire",
+        "inherits": "Fire",
         "item": "Maragidyne",
         "itemr": "Inferno",
         "skillCard": true,
@@ -3344,7 +3544,7 @@ var personaMapRoyal = {
         "trait": "Heated Bloodline"
     },
     "Suzaku": {
-        "inherits": "nuke",
+        "inherits": "Nuclear",
         "item": "Atom Ring",
         "itemr": "Spiral Atom Ring",
         "level": 16,
@@ -3363,7 +3563,7 @@ var personaMapRoyal = {
         "trait": "Gluttonmouth"
     },
     "Take-Minakata": {
-        "inherits": "elec",
+        "inherits": "Electric",
         "item": "Zionga",
         "itemr": "Mazionga",
         "skillCard": true,
@@ -3380,11 +3580,13 @@ var personaMapRoyal = {
             "Shock Boost": 32
         },
         "stats": [17, 19, 18, 16, 15],
-        "trait": "Electric Bloodline"
+        "trait": "Electric Bloodline",
+        "area": "Kaitul",
+        "floor": "L7-9"
     },
     "Tam Lin": {
         "special": true,
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Fairy Knight Armor",
         "itemr": "Fairy Hero Armor",
         "level": 27,
@@ -3403,7 +3605,7 @@ var personaMapRoyal = {
         "trait": "Gluttonmouth"
     },
     "Thor": {
-        "inherits": "elec",
+        "inherits": "Electric",
         "item": "Mjolnir",
         "itemr": "Imprisoned Mjolnir",
         "level": 64,
@@ -3419,10 +3621,12 @@ var personaMapRoyal = {
             "Wild Thunder": 71
         },
         "stats": [44, 39, 43, 38, 35],
-        "trait": "Intense Focus"
+        "trait": "Intense Focus",
+        "area": "Da'at",
+        "floor": "All"
     },
     "Thoth": {
-        "inherits": "nuke",
+        "inherits": "Nuclear",
         "item": "Mafreila",
         "itemr": "Freidyne",
         "skillCard": true,
@@ -3439,10 +3643,12 @@ var personaMapRoyal = {
             "Growth 2": 42
         },
         "stats": [21, 28, 21, 24, 21],
-        "trait": "Skillful Technique"
+        "trait": "Skillful Technique",
+        "area": "Akzeriyyuth",
+        "floor": "L6, 7, 9-11"
     },
     "Throne": {
-        "inherits": "bless",
+        "inherits": "Bless",
         "item": "Spiral Divine Ring",
         "itemr": "Judgement Cross",
         "level": 72,
@@ -3458,10 +3664,12 @@ var personaMapRoyal = {
             "Inferno": 78
         },
         "stats": [42, 49, 43, 46, 43],
-        "trait": "Crisis Control"
+        "trait": "Crisis Control",
+        "area": "Da'at",
+        "floor": "All"
     },
     "Thunderbird": {
-        "inherits": "elec",
+        "inherits": "Electric",
         "item": "Elec Boost",
         "itemr": "Elec Amp",
         "skillCard": true,
@@ -3481,7 +3689,7 @@ var personaMapRoyal = {
         "trait": "Electric Bloodline"
     },
     "Titania": {
-        "inherits": "nuke",
+        "inherits": "Nuclear",
         "item": "Freidyne",
         "itemr": "Mafreidyne",
         "skillCard": true,
@@ -3490,11 +3698,13 @@ var personaMapRoyal = {
         "elems": ["-", "-", "-", "-", "-", "-", "wk", "rs", "rs", "rs"],
         "skills": {"Freidyne": 0, "Ziodyne": 0, "Lullaby": 0, "Concentrate": 59, "Nuke Amp": 60, "Mediarahan": 61},
         "stats": [32, 40, 35, 38, 30],
-        "trait": "Foul Stench"
+        "trait": "Foul Stench",
+        "area": "Sheriruth",
+        "floor": "L8, 9, 11-13 (after Palace 7)"
     },
     "Trumpeter": {
         "special": true,
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Reactor Ring",
         "itemr": "Spiral Reactor Ring",
         "level": 59,
@@ -3513,7 +3723,7 @@ var personaMapRoyal = {
         "trait": "Relentless"
     },
     "Unicorn": {
-        "inherits": "bless",
+        "inherits": "Bless",
         "item": "Mahama",
         "itemr": "Hamaon",
         "skillCard": true,
@@ -3530,10 +3740,12 @@ var personaMapRoyal = {
             "Hamaon": 44
         },
         "stats": [20, 27, 25, 28, 24],
-        "trait": "Blessed Bloodline"
+        "trait": "Blessed Bloodline",
+        "area": "Sheriruth",
+        "floor": "L1-4 (before Palace 7) / L1 & 2 (after Palace 7)"
     },
     "Uriel": {
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Heaven's Gate",
         "itemr": "Providence",
         "level": 81,
@@ -3552,7 +3764,7 @@ var personaMapRoyal = {
         "trait": "Mouth of Savoring"
     },
     "Valkyrie": {
-        "inherits": "phys",
+        "inherits": "Physical",
         "item": "Rising Slash",
         "itemr": "Deadly Fury",
         "skillCard": true,
@@ -3568,11 +3780,13 @@ var personaMapRoyal = {
             "Dodge Phys": 49
         },
         "stats": [33, 24, 28, 29, 25],
-        "trait": "Skillful Combo"
+        "trait": "Skillful Combo",
+        "area": "Sheriruth",
+        "floor": "L3-5, 7-9 (before Palace 7) / L2-4 (after Palace 7)"
     },
     "Vasuki": {
         "special": true,
-        "inherits": "ailment",
+        "inherits": "Ailment",
         "item": "Kuzuryu Gouhou",
         "itemr": "Kuzuryu Gouhou EX",
         "level": 68,
@@ -3591,7 +3805,7 @@ var personaMapRoyal = {
         "trait": "Foul Stench"
     },
     "Vishnu": {
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Sudarshana",
         "itemr": "Sudarshana EX",
         "level": 83,
@@ -3612,7 +3826,7 @@ var personaMapRoyal = {
         "max": true
     },
     "Vohu Manah": {
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Doomsday",
         "itemr": "Ancient Day",
         "level": 80,
@@ -3632,7 +3846,7 @@ var personaMapRoyal = {
         "max": true
     },
     "White Rider": {
-        "inherits": "curse",
+        "inherits": "Curse",
         "item": "Gun Boost",
         "itemr": "Gun Amp",
         "skillCard": true,
@@ -3653,7 +3867,7 @@ var personaMapRoyal = {
         "trait": "Bloodstained Eyes"
     },
     "Yaksini": {
-        "inherits": "ice",
+        "inherits": "Ice",
         "item": "Hysterical Slap",
         "itemr": "Oni Kagura",
         "skillCard": true,
@@ -3669,10 +3883,12 @@ var personaMapRoyal = {
             "Vicious Strike": 24
         },
         "stats": [14, 11, 13, 16, 13],
-        "trait": "Foul Odor"
+        "trait": "Foul Odor",
+        "area": "Kaitul",
+        "floor": "L3-5, 7"
     },
     "Yamata-no-Orochi": {
-        "inherits": "ice",
+        "inherits": "Ice",
         "item": "Triple Down",
         "itemr": "One-shot Kill",
         "skillCard": true,
@@ -3688,10 +3904,12 @@ var personaMapRoyal = {
             "Diamond Dust": 69
         },
         "stats": [44, 38, 48, 36, 33],
-        "trait": "Cold-Blooded"
+        "trait": "Cold-Blooded",
+        "area": "Da'at",
+        "floor": "All"
     },
     "Yatagarasu": {
-        "inherits": "fire",
+        "inherits": "Fire",
         "item": "Black Wing Robe",
         "itemr": "Black Wing Robe R",
         "level": 57,
@@ -3711,7 +3929,7 @@ var personaMapRoyal = {
     },
     "Yoshitsune": {
         "special": true,
-        "inherits": "phys",
+        "inherits": "Physical",
         "item": "Usumidori",
         "itemr": "Usumidori R",
         "level": 87,
@@ -3730,7 +3948,7 @@ var personaMapRoyal = {
         "trait": "Retaliating Body"
     },
     "Yurlungur": {
-        "inherits": "elec",
+        "inherits": "Electric",
         "item": "Mirrirmina",
         "itemr": "Mirrirmina EX",
         "level": 43,
@@ -3749,7 +3967,7 @@ var personaMapRoyal = {
         "trait": "Mouth of Savoring"
     },
     "Zaou-Gongen": {
-        "inherits": "fire",
+        "inherits": "Fire",
         "item": "God's Hand Belt",
         "itemr": "Gigantomachia Belt",
         "level": 80,
@@ -3769,7 +3987,7 @@ var personaMapRoyal = {
         "max": true
     },
     "Zouchouten": {
-        "inherits": "elec",
+        "inherits": "Electric",
         "item": "Spark Ring",
         "itemr": "Spiral Spark Ring",
         "level": 31,
@@ -3788,7 +4006,7 @@ var personaMapRoyal = {
         "trait": "Electric Bloodline"
     },
     "Ariadne": {
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Red String",
         "itemr": "Red String R",
         "level": 30,
@@ -3808,7 +4026,7 @@ var personaMapRoyal = {
         "dlc": true
     },
     "Ariadne Picaro": {
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Auto-Mataru",
         "itemr": "Auto-Maraku",
         "skillCard": true,
@@ -3829,7 +4047,7 @@ var personaMapRoyal = {
         "dlc": true
     },
     "Asterius": {
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Blazing Horns",
         "itemr": "Inferno Horns",
         "level": 56,
@@ -3849,7 +4067,7 @@ var personaMapRoyal = {
         "dlc": true
     },
     "Asterius Picaro": {
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Gigantomachia",
         "itemr": "Agneyastra",
         "skillCard": true,
@@ -3870,14 +4088,14 @@ var personaMapRoyal = {
         "dlc": true
     },
     "Athena": {
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Kugelbein",
         "itemr": "Kugelbein R",
         "level": 46,
         "arcana": "Chariot",
         "elems": ["rs", "nu", "-", "-", "wk", "-", "-", "-", "-", "-"],
         "skills": {
-            "Akasha Arts": 0,
+            "Akashic Arts": 0,
             "Marakukaja": 0,
             "Rising Slash": 0,
             "Diarahan": 47,
@@ -3891,7 +4109,7 @@ var personaMapRoyal = {
         "dlc": true
     },
     "Athena Picaro": {
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Charge",
         "itemr": "Concentrate",
         "skillCard": true,
@@ -3899,7 +4117,7 @@ var personaMapRoyal = {
         "arcana": "Chariot",
         "elems": ["rs", "nu", "-", "-", "wk", "-", "-", "-", "-", "-"],
         "skills": {
-            "Akasha Arts": 0,
+            "Akashic Arts": 0,
             "Matarukaja": 0,
             "Rising Slash": 0,
             "Diarahan": 51,
@@ -3913,7 +4131,7 @@ var personaMapRoyal = {
         "dlc": true
     },
     "Izanagi": {
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "White Headband",
         "itemr": "White Headband R",
         "level": 20,
@@ -3933,7 +4151,7 @@ var personaMapRoyal = {
         "dlc": true
     },
     "Izanagi Picaro": {
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Growth 2",
         "itemr": "Growth 3",
         "skillCard": true,
@@ -3955,7 +4173,7 @@ var personaMapRoyal = {
     },
     "Izanagi-no-Okami": {
         "special": true,
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Shiny Belt",
         "itemr": "Shiny Belt R",
         "level": 80,
@@ -3977,7 +4195,7 @@ var personaMapRoyal = {
     },
     "Izanagi-no-Okami Picaro": {
         "special": true,
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Mediarahan",
         "itemr": "Salvation",
         "skillCard": true,
@@ -3999,7 +4217,7 @@ var personaMapRoyal = {
         "dlc": true
     },
     "Kaguya": {
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Moonlight Robe",
         "itemr": "Moonlight Robe R",
         "level": 16,
@@ -4019,7 +4237,7 @@ var personaMapRoyal = {
         "dlc": true
     },
     "Kaguya Picaro": {
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Diarahan",
         "itemr": "Mediarahan",
         "skillCard": true,
@@ -4040,7 +4258,7 @@ var personaMapRoyal = {
         "dlc": true
     },
     "Magatsu-Izanagi": {
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Black Headband",
         "itemr": "Black Headband R",
         "level": 44,
@@ -4060,7 +4278,7 @@ var personaMapRoyal = {
         "dlc": true
     },
     "Magatsu-Izanagi Picaro": {
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Heat Riser",
         "itemr": "Debilitate",
         "skillCard": true,
@@ -4081,7 +4299,7 @@ var personaMapRoyal = {
         "dlc": true
     },
     "Messiah": {
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Sirius Armor",
         "itemr": "Sirius Armor EX",
         "level": 81,
@@ -4102,7 +4320,7 @@ var personaMapRoyal = {
         "dlc": true
     },
     "Messiah Picaro": {
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Insta-Heal",
         "itemr": "Firm Stance",
         "skillCard": true,
@@ -4124,7 +4342,7 @@ var personaMapRoyal = {
         "dlc": true
     },
     "Orpheus": {
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Hades Harp",
         "itemr": "Hades Harp R",
         "level": 26,
@@ -4144,7 +4362,7 @@ var personaMapRoyal = {
         "dlc": true
     },
     "Orpheus F": {
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Graceful Harp",
         "itemr": "Graceful Harp R",
         "level": 11,
@@ -4164,7 +4382,7 @@ var personaMapRoyal = {
         "dlc": true
     },
     "Orpheus F Picaro": {
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Endure",
         "itemr": "Enduring Soul",
         "skillCard": true,
@@ -4185,7 +4403,7 @@ var personaMapRoyal = {
         "dlc": true
     },
     "Orpheus Picaro": {
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Agidyne",
         "itemr": "Maragidyne",
         "skillCard": true,
@@ -4206,7 +4424,7 @@ var personaMapRoyal = {
         "dlc": true
     },
     "Raoul": {
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Picaresque Hat",
         "itemr": "Picaresque Crown",
         "level": 76,
@@ -4227,7 +4445,7 @@ var personaMapRoyal = {
         "dlc": true
     },
     "Thanatos": {
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Darkness Ring",
         "itemr": "Darkness Ring R",
         "level": 65,
@@ -4247,7 +4465,7 @@ var personaMapRoyal = {
         "dlc": true
     },
     "Thanatos Picaro": {
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Maeigaon",
         "itemr": "Demonic Decree",
         "skillCard": true,
@@ -4268,7 +4486,7 @@ var personaMapRoyal = {
         "dlc": true
     },
     "Tsukiyomi": {
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Black Moon",
         "itemr": "Black Moon R",
         "level": 50,
@@ -4288,7 +4506,7 @@ var personaMapRoyal = {
         "dlc": true
     },
     "Tsukiyomi Picaro": {
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Spell Master",
         "itemr": "Arms Master",
         "skillCard": true,

--- a/data/PersonaDataRoyal.js
+++ b/data/PersonaDataRoyal.js
@@ -776,7 +776,6 @@ var personaMapRoyal = {
     },
     "Crystal Skull": {
         "rare": true,
-        "inherits": "Almighty",
         "item": "Crystal Skull",
         "itemr": "Crystal Skull R",
         "level": 50,
@@ -968,7 +967,6 @@ var personaMapRoyal = {
     },
     "Emperor's Amulet": {
         "rare": true,
-        "inherits": "Almighty",
         "item": "Emperor's Amulet",
         "itemr": "Emperor's Charm R",
         "level": 35,
@@ -1312,7 +1310,6 @@ var personaMapRoyal = {
     },
     "Hope Diamond": {
         "rare": true,
-        "inherits": "Almighty",
         "item": "Hope Diamond",
         "itemr": "Hope Diamond R",
         "level": 40,
@@ -1491,7 +1488,7 @@ var personaMapRoyal = {
         "stats": [2, 3, 3, 3, 2],
         "trait": "Thermal Conduct",
         "area": "Qimranut / Aiyatsbus",
-        "floor": "All / L1"
+        "floor": "Any / L1"
     },
     "Jatayu": {
         "inherits": "Wind",
@@ -1668,7 +1665,6 @@ var personaMapRoyal = {
     },
     "Koh-i-Noor": {
         "rare": true,
-        "inherits": "Almighty",
         "item": "Koh-i-Noor",
         "itemr": "Koh-i-Noor R",
         "level": 25,
@@ -2665,7 +2661,6 @@ var personaMapRoyal = {
     },
     "Orichalcum": {
         "rare": true,
-        "inherits": "Almighty",
         "item": "Orichalcum",
         "itemr": "Orichalcum R",
         "level": 60,
@@ -2689,7 +2684,6 @@ var personaMapRoyal = {
     },
     "Orlov": {
         "rare": true,
-        "inherits": "Almighty",
         "item": "Orlov",
         "itemr": "Orlov R",
         "level": 30,
@@ -2711,7 +2705,7 @@ var personaMapRoyal = {
         "stats": [30, 30, 30, 30, 30],
         "trait": "Ultimate Vessel",
         "area": "Sheriruth",
-        "floor": "All (before Palace 7) / L1-5 (after Palace 7)"
+        "floor": "Any (before Palace 7) / L1-5 (after Palace 7)"
     },
     "Orobas": {
         "inherits": "Fire",
@@ -2872,7 +2866,7 @@ var personaMapRoyal = {
         "stats": [1, 3, 3, 4, 2],
         "trait": "Static Electricity",
         "area": "Qimranut / Aiyatsbus",
-        "floor": "All / L1 & 3"
+        "floor": "Any / L1 & 3"
     },
     "Power": {
         "inherits": "Bless",
@@ -2938,7 +2932,6 @@ var personaMapRoyal = {
     },
     "Queen's Necklace": {
         "rare": true,
-        "inherits": "Almighty",
         "item": "Queen's Necklace",
         "itemr": "Queen's Necklace R",
         "level": 15,
@@ -3079,7 +3072,6 @@ var personaMapRoyal = {
     },
     "Regent": {
         "rare": true,
-        "inherits": "Almighty",
         "item": "Regent",
         "itemr": "Regent R",
         "level": 10,
@@ -3101,7 +3093,7 @@ var personaMapRoyal = {
         "stats": [10, 10, 10, 10, 10],
         "trait": "Ultimate Vessel",
         "area": "Qimranut / Aiyatsbus / Chemdah",
-        "floor": "All / L1-3, 5 & 6 / L1-4, 6 & 7"
+        "floor": "Any / L1-3, 5 & 6 / L1-4, 6 & 7"
     },
     "Saki Mitama": {
         "inherits": "Healing",
@@ -3418,7 +3410,7 @@ var personaMapRoyal = {
         "stats": [9, 6, 11, 6, 5],
         "trait": "Rare Antibody",
         "area": "Qimranut / Aiyatsbus",
-        "floor": "All / L1, 2, 3, 6"
+        "floor": "Any / L1, 2, 3, 6"
     },
     "Sraosha": {
         "special": true,
@@ -3442,7 +3434,6 @@ var personaMapRoyal = {
     },
     "Stone of Scone": {
         "rare": true,
-        "inherits": "Almighty",
         "item": "Stone of Scone",
         "itemr": "Stone of Scone R",
         "level": 20,

--- a/data/PersonaDataRoyal.ts
+++ b/data/PersonaDataRoyal.ts
@@ -776,7 +776,6 @@ const personaMapRoyal: PersonaMap = {
     },
     "Crystal Skull": {
         "rare": true,
-        "inherits": "Almighty",
         "item": "Crystal Skull",
         "itemr": "Crystal Skull R",
         "level": 50,
@@ -968,7 +967,6 @@ const personaMapRoyal: PersonaMap = {
     },
     "Emperor's Amulet": {
         "rare": true,
-        "inherits": "Almighty",
         "item": "Emperor's Amulet",
         "itemr": "Emperor's Charm R",
         "level": 35,
@@ -1312,7 +1310,6 @@ const personaMapRoyal: PersonaMap = {
     },
     "Hope Diamond": {
         "rare": true,
-        "inherits": "Almighty",
         "item": "Hope Diamond",
         "itemr": "Hope Diamond R",
         "level": 40,
@@ -1668,7 +1665,6 @@ const personaMapRoyal: PersonaMap = {
     },
     "Koh-i-Noor": {
         "rare": true,
-        "inherits": "Almighty",
         "item": "Koh-i-Noor",
         "itemr": "Koh-i-Noor R",
         "level": 25,
@@ -2665,7 +2661,6 @@ const personaMapRoyal: PersonaMap = {
     },
     "Orichalcum": {
         "rare": true,
-        "inherits": "Almighty",
         "item": "Orichalcum",
         "itemr": "Orichalcum R",
         "level": 60,
@@ -2689,7 +2684,6 @@ const personaMapRoyal: PersonaMap = {
     },
     "Orlov": {
         "rare": true,
-        "inherits": "Almighty",
         "item": "Orlov",
         "itemr": "Orlov R",
         "level": 30,
@@ -2938,7 +2932,6 @@ const personaMapRoyal: PersonaMap = {
     },
     "Queen's Necklace": {
         "rare": true,
-        "inherits": "Almighty",
         "item": "Queen's Necklace",
         "itemr": "Queen's Necklace R",
         "level": 15,
@@ -3079,7 +3072,6 @@ const personaMapRoyal: PersonaMap = {
     },
     "Regent": {
         "rare": true,
-        "inherits": "Almighty",
         "item": "Regent",
         "itemr": "Regent R",
         "level": 10,
@@ -3442,7 +3434,6 @@ const personaMapRoyal: PersonaMap = {
     },
     "Stone of Scone": {
         "rare": true,
-        "inherits": "Almighty",
         "item": "Stone of Scone",
         "itemr": "Stone of Scone R",
         "level": 20,

--- a/data/PersonaDataRoyal.ts
+++ b/data/PersonaDataRoyal.ts
@@ -1,6 +1,6 @@
 const personaMapRoyal: PersonaMap = {
     "Abaddon": {
-        "inherits": "curse",
+        "inherits": "Curse",
         "item": "Megaton Raid Belt",
         "itemr": "God's Hand Belt",
         "level": 75,
@@ -16,10 +16,12 @@ const personaMapRoyal: PersonaMap = {
             "Gigantomachia": 81
         },
         "stats": [51, 42, 58, 38, 43],
-        "trait": "Mouth of Savoring"
+        "trait": "Mouth of Savoring",
+        "area": "Da'at",
+        "floor": "All"
     },
     "Agathion": {
-        "inherits": "elec",
+        "inherits": "Electric",
         "item": "Zio",
         "itemr": "Mazio",
         "skillCard": true,
@@ -28,11 +30,13 @@ const personaMapRoyal: PersonaMap = {
         "elems": ["-", "rs", "-", "-", "rs", "wk", "-", "-", "-", "-"],
         "skills": {"Dia": 0, "Baisudi": 0, "Lunge": 4, "Rakukaja": 6, "Zio": 7, "Dodge Elec": 8},
         "stats": [3, 4, 5, 7, 3],
-        "trait": "Rare Antibody"
+        "trait": "Rare Antibody",
+        "area": "Aiyatsbus",
+        "floor": "L1"
     },
     "Alice": {
         "special": true,
-        "inherits": "curse",
+        "inherits": "Curse",
         "item": "Spiral Hell Ring",
         "itemr": "Cursed Ribbon",
         "level": 83,
@@ -52,7 +56,7 @@ const personaMapRoyal: PersonaMap = {
         "max": true
     },
     "Alilat": {
-        "inherits": "ice",
+        "inherits": "Ice",
         "item": "Mabufudyne",
         "itemr": "Diamond Dust",
         "skillCard": true,
@@ -74,7 +78,7 @@ const personaMapRoyal: PersonaMap = {
         "note": "Only available after 1/12"
     },
     "Ame-no-Uzume": {
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Senryou Yakusha",
         "itemr": "Senryou Yakusha R",
         "level": 13,
@@ -82,10 +86,12 @@ const personaMapRoyal: PersonaMap = {
         "elems": ["-", "-", "ab", "-", "-", "-", "wk", "-", "-", "-"],
         "skills": {"Mazio": 0, "Magaru": 0, "Media": 0, "Nocturnal Flash": 15, "Baisudi": 16, "Divine Grace": 18},
         "stats": [7, 10, 9, 11, 9],
-        "trait": "Electric Bloodline"
+        "trait": "Electric Bloodline",
+        "area": "Chemdah",
+        "floor": "L6 & 7"
     },
     "Ananta": {
-        "inherits": "nuke",
+        "inherits": "Nuclear",
         "item": "Spiral Nuclear Ring",
         "itemr": "Reactor Ring",
         "level": 44,
@@ -105,7 +111,7 @@ const personaMapRoyal: PersonaMap = {
         "trait": "Atomic Bloodline"
     },
     "Andras": {
-        "inherits": "ice",
+        "inherits": "Ice",
         "item": "Evil Touch",
         "itemr": "Evil Smile",
         "skillCard": true,
@@ -121,10 +127,12 @@ const personaMapRoyal: PersonaMap = {
             "Ghastly Wail": 32
         },
         "stats": [15, 19, 19, 21, 14],
-        "trait": "Foul Odor"
+        "trait": "Foul Odor",
+        "area": "Akzeriyyuth",
+        "floor": "???"
     },
     "Angel": {
-        "inherits": "bless",
+        "inherits": "Bless",
         "item": "Kouha",
         "itemr": "Makouha",
         "skillCard": true,
@@ -133,10 +141,12 @@ const personaMapRoyal: PersonaMap = {
         "elems": ["-", "wk", "-", "-", "rs", "-", "-", "-", "nu", "wk"],
         "skills": {"Kouha": 0, "Makajam": 0, "Dia": 0, "Baisudi": 10, "Dodge Curse": 11, "Dekunda": 12},
         "stats": [6, 9, 5, 9, 5],
-        "trait": "Skillful Combo"
+        "trait": "Skillful Combo",
+        "area": "Aiyatsbus / Kaitul",
+        "floor": "L5 & 6 / L1-4"
     },
     "Anubis": {
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Makouga",
         "itemr": "Kougaon",
         "skillCard": true,
@@ -145,10 +155,12 @@ const personaMapRoyal: PersonaMap = {
         "elems": ["-", "rs", "-", "-", "-", "-", "rs", "-", "nu", "nu"],
         "skills": {"Hamaon": 0, "Mudoon": 0, "Makouga": 0, "Maeiga": 36, "Dekunda": 37, "Resist Bless": 38},
         "stats": [19, 24, 22, 21, 23],
-        "trait": "Deathly Illness"
+        "trait": "Deathly Illness",
+        "area": "Akzeriyyuth",
+        "floor": "L10 & 11"
     },
     "Anzu": {
-        "inherits": "wind",
+        "inherits": "Wind",
         "item": "Garula",
         "itemr": "Magarula",
         "skillCard": true,
@@ -157,10 +169,12 @@ const personaMapRoyal: PersonaMap = {
         "elems": ["-", "wk", "-", "-", "rs", "rp", "-", "wk", "-", "-"],
         "skills": {"Garula": 0, "Masukukaja": 0, "Wind Break": 0, "Assault Dive": 27, "Dekaja": 28, "Null Forget": 29},
         "stats": [14, 18, 15, 21, 14],
-        "trait": "Wind Bloodline"
+        "trait": "Wind Bloodline",
+        "area": "Akzeriyyuth",
+        "floor": "L1-3, 5-7, 9-11"
     },
     "Apsaras": {
-        "inherits": "ice",
+        "inherits": "Ice",
         "item": "Media",
         "itemr": "Diarama",
         "skillCard": true,
@@ -169,10 +183,12 @@ const personaMapRoyal: PersonaMap = {
         "elems": ["-", "-", "wk", "rs", "wk", "-", "-", "-", "-", "-"],
         "skills": {"Rebellion": 0, "Ice Wall": 0, "Bufu": 0, "Media": 13, "Elec Wall": 14, "Wind Wall": 16},
         "stats": [7, 11, 6, 10, 6],
-        "trait": "Internal Hypnosis"
+        "trait": "Internal Hypnosis",
+        "area": "Chemdah",
+        "floor": "L1-4"
     },
     "Ara Mitama": {
-        "inherits": "nuke",
+        "inherits": "Nuclear",
         "item": "Nuclear Ring",
         "itemr": "Spiral Nuclear Ring",
         "level": 30,
@@ -191,7 +207,7 @@ const personaMapRoyal: PersonaMap = {
         "trait": "Atomic Bloodline"
     },
     "Arahabaki": {
-        "inherits": "ailment",
+        "inherits": "Ailment",
         "item": "Tapsuan",
         "itemr": "Fine Tapsuan",
         "level": 35,
@@ -206,10 +222,12 @@ const personaMapRoyal: PersonaMap = {
             "Defense Master": 39
         },
         "stats": [21, 23, 22, 24, 22],
-        "trait": "Immunity"
+        "trait": "Immunity",
+        "area": "Adyeshach",
+        "floor": "L1-4, 6-8, 10"
     },
     "Archangel": {
-        "inherits": "bless",
+        "inherits": "Bless",
         "item": "Hama",
         "itemr": "Mahama",
         "skillCard": true,
@@ -218,11 +236,13 @@ const personaMapRoyal: PersonaMap = {
         "elems": ["-", "-", "-", "-", "wk", "-", "-", "-", "nu", "wk"],
         "skills": {"Giant Slice": 0, "Dazzler": 0, "Hama": 0, "Rebellion": 16, "Power Slash": 17, "Vajra Blast": 19},
         "stats": [11, 9, 10, 12, 7],
-        "trait": "Skillful Combo"
+        "trait": "Skillful Combo",
+        "area": "Aiyatsbus",
+        "floor": "L5 & 6"
     },
     "Ardha": {
         "special": true,
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Sahasrara",
         "itemr": "Sahasrara EX",
         "level": 84,
@@ -242,7 +262,7 @@ const personaMapRoyal: PersonaMap = {
         "max": true
     },
     "Arsène": {
-        "inherits": "curse",
+        "inherits": "Curse",
         "item": "Arsène's Cane",
         "itemr": "The Great Thief Stick",
         "level": 1,
@@ -254,7 +274,7 @@ const personaMapRoyal: PersonaMap = {
     },
     "Asura": {
         "special": true,
-        "inherits": "nuke",
+        "inherits": "Nuclear",
         "item": "Vajra",
         "itemr": "Unparalleled Vajra",
         "level": 76,
@@ -274,7 +294,7 @@ const personaMapRoyal: PersonaMap = {
         "max": true
     },
     "Atavaka": {
-        "inherits": "phys",
+        "inherits": "Physical",
         "item": "Brave Blade",
         "itemr": "Sword Dance",
         "skillCard": true,
@@ -294,7 +314,7 @@ const personaMapRoyal: PersonaMap = {
         "trait": "Savior Bloodline"
     },
     "Atropos": {
-        "inherits": "elec",
+        "inherits": "Electric",
         "item": "Mazionga",
         "itemr": "Ziodyne",
         "skillCard": true,
@@ -314,7 +334,7 @@ const personaMapRoyal: PersonaMap = {
         "trait": "Mighty Gaze"
     },
     "Attis": {
-        "inherits": "fire",
+        "inherits": "Fire",
         "item": "Null Curse",
         "itemr": "Absorb Curse",
         "skillCard": true,
@@ -335,7 +355,7 @@ const personaMapRoyal: PersonaMap = {
         "max": true
     },
     "Baal": {
-        "inherits": "wind",
+        "inherits": "Wind",
         "item": "Yagrush",
         "itemr": "Yagrush EX",
         "level": 82,
@@ -354,7 +374,7 @@ const personaMapRoyal: PersonaMap = {
         "trait": "Wind Bloodline"
     },
     "Baphomet": {
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Bufudyne",
         "itemr": "Mabufudyne",
         "skillCard": true,
@@ -371,10 +391,12 @@ const personaMapRoyal: PersonaMap = {
             "Freeze Boost": 63
         },
         "stats": [34, 42, 36, 38, 31],
-        "trait": "Thermal Conduct"
+        "trait": "Thermal Conduct",
+        "area": "Sheriruth",
+        "floor": "L13 (after Palace 7)"
     },
     "Barong": {
-        "inherits": "elec",
+        "inherits": "Electric",
         "item": "Ziodyne",
         "itemr": "Maziodyne",
         "skillCard": true,
@@ -383,10 +405,12 @@ const personaMapRoyal: PersonaMap = {
         "elems": ["-", "rs", "-", "-", "rs", "wk", "-", "-", "nu", "wk"],
         "skills": {"Ziodyne": 0, "Wage War": 0, "Invigorate 2": 0, "Elec Break": 54, "Null Elec": 55, "Maziodyne": 57},
         "stats": [33, 35, 33, 37, 25],
-        "trait": "Blessed Bloodline"
+        "trait": "Blessed Bloodline",
+        "area": "Sheriruth",
+        "floor": "L11 & 12 (after Palace 7)"
     },
     "Beelzebub": {
-        "inherits": "curse",
+        "inherits": "Curse",
         "item": "Fleurs du Mal",
         "itemr": "Fleurs du Mal R",
         "level": 87,
@@ -407,7 +431,7 @@ const personaMapRoyal: PersonaMap = {
         "max": true
     },
     "Belial": {
-        "inherits": "curse",
+        "inherits": "Curse",
         "item": "Mamudoon",
         "itemr": "Demonic Decree",
         "skillCard": true,
@@ -427,7 +451,7 @@ const personaMapRoyal: PersonaMap = {
         "trait": "Bloodstained Eyes"
     },
     "Belphegor": {
-        "inherits": "ice",
+        "inherits": "Ice",
         "item": "Mabufula",
         "itemr": "Bufudyne",
         "skillCard": true,
@@ -436,10 +460,12 @@ const personaMapRoyal: PersonaMap = {
         "elems": ["-", "-", "wk", "rs", "rs", "-", "-", "rs", "-", "rp"],
         "skills": {"Mabufula": 0, "Ice Break": 0, "Null Rage": 38, "Dodge Fire": 39, "Bufudyne": 41, "Concentrate": 42},
         "stats": [25, 27, 24, 23, 19],
-        "trait": "Intense Focus"
+        "trait": "Intense Focus",
+        "area": "Adyeshach",
+        "floor": "L6-8, 10"
     },
     "Berith": {
-        "inherits": "phys",
+        "inherits": "Physical",
         "item": "Cleave",
         "itemr": "Power Slash",
         "skillCard": true,
@@ -448,10 +474,12 @@ const personaMapRoyal: PersonaMap = {
         "elems": ["-", "nu", "rs", "wk", "-", "-", "-", "-", "-", "-"],
         "skills": {"Cleave": 0, "Rakukaja": 0, "Tarukaja": 10, "Dodge Fire": 11, "Power Slash": 13},
         "stats": [9, 6, 8, 8, 3],
-        "trait": "Crisis Control"
+        "trait": "Crisis Control",
+        "area": "Aiyatsbus",
+        "floor": "L5 & 6"
     },
     "Bicorn": {
-        "inherits": "wind",
+        "inherits": "Wind",
         "item": "Lunge",
         "itemr": "Assault Dive",
         "skillCard": true,
@@ -460,10 +488,12 @@ const personaMapRoyal: PersonaMap = {
         "elems": ["-", "-", "-", "-", "wk", "-", "-", "-", "-", "rs"],
         "skills": {"Lunge": 0, "Tarunda": 0, "Garu": 6, "Ice Wall": 7, "Apt Pupil": 8},
         "stats": [5, 3, 3, 5, 3],
-        "trait": "Striking Weight"
+        "trait": "Striking Weight",
+        "area": "Aiyatsbus",
+        "floor": "L1 & 2"
     },
     "Bishamonten": {
-        "inherits": "nuke",
+        "inherits": "Nuclear",
         "item": "Mafreidyne",
         "itemr": "Atomic Flare",
         "skillCard": true,
@@ -484,7 +514,7 @@ const personaMapRoyal: PersonaMap = {
     },
     "Black Frost": {
         "special": true,
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Naraka Whip",
         "itemr": "Dainaraka Whip",
         "level": 67,
@@ -503,7 +533,7 @@ const personaMapRoyal: PersonaMap = {
         "trait": "Frigid Bloodline"
     },
     "Black Ooze": {
-        "inherits": "curse",
+        "inherits": "Curse",
         "item": "Headbutt",
         "itemr": "Memory Blow",
         "skillCard": true,
@@ -520,10 +550,12 @@ const personaMapRoyal: PersonaMap = {
             "Flash Bomb": 24
         },
         "stats": [15, 7, 16, 8, 15],
-        "trait": "Rare Antibody"
+        "trait": "Rare Antibody",
+        "area": "Adyeshach",
+        "floor": "L1-4, 6"
     },
     "Black Rider": {
-        "inherits": "curse",
+        "inherits": "Curse",
         "item": "Megidola",
         "itemr": "Megidolaon",
         "skillCard": true,
@@ -544,7 +576,7 @@ const personaMapRoyal: PersonaMap = {
     },
     "Bugs": {
         "special": true,
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Bear Gloves",
         "itemr": "Big Bear Gloves",
         "level": 49,
@@ -563,7 +595,7 @@ const personaMapRoyal: PersonaMap = {
         "trait": "Potent Hypnosis"
     },
     "Byakhee": {
-        "inherits": "fire",
+        "inherits": "Fire",
         "item": "Null Wind",
         "itemr": "Repel Wind",
         "skillCard": true,
@@ -584,7 +616,7 @@ const personaMapRoyal: PersonaMap = {
         "note": "Only available after 1/12"
     },
     "Byakko": {
-        "inherits": "ice",
+        "inherits": "Ice",
         "item": "Spiral Snow Ring",
         "itemr": "Blizzard Ring",
         "level": 45,
@@ -604,7 +636,7 @@ const personaMapRoyal: PersonaMap = {
         "trait": "Retaliating Body"
     },
     "Cait Sith": {
-        "inherits": "ailment",
+        "inherits": "Ailment",
         "item": "Agi",
         "itemr": "Maragi",
         "skillCard": true,
@@ -616,7 +648,7 @@ const personaMapRoyal: PersonaMap = {
         "trait": "Thermal Conduct"
     },
     "Cerberus": {
-        "inherits": "fire",
+        "inherits": "Fire",
         "item": "Megaton Raid",
         "itemr": "God's Hand",
         "skillCard": true,
@@ -632,10 +664,12 @@ const personaMapRoyal: PersonaMap = {
             "Enduring Soul": 60
         },
         "stats": [39, 35, 32, 39, 27],
-        "trait": "Heated Bloodline"
+        "trait": "Heated Bloodline",
+        "area": "Sheriruth",
+        "floor": "L7-9 (after Palace 7)"
     },
     "Chernobog": {
-        "inherits": "ailment",
+        "inherits": "Ailment",
         "item": "Mudoon",
         "itemr": "Mamudoon",
         "skillCard": true,
@@ -652,11 +686,13 @@ const personaMapRoyal: PersonaMap = {
             "Brave Blade": 67
         },
         "stats": [40, 37, 39, 38, 39],
-        "trait": "Crisis Control"
+        "trait": "Crisis Control",
+        "area": "Da'at",
+        "floor": "All"
     },
     "Chi You": {
         "special": true,
-        "inherits": "psy",
+        "inherits": "Psy",
         "item": "Repel Phys",
         "itemr": "Absorb Phys",
         "skillCard": true,
@@ -676,7 +712,7 @@ const personaMapRoyal: PersonaMap = {
         "trait": "Chi You's Blessing"
     },
     "Chimera": {
-        "inherits": "phys",
+        "inherits": "Physical",
         "item": "Null Fire",
         "itemr": "Absorb Fire",
         "skillCard": true,
@@ -697,7 +733,7 @@ const personaMapRoyal: PersonaMap = {
         "note": "Only available after 1/12"
     },
     "Choronzon": {
-        "inherits": "curse",
+        "inherits": "Curse",
         "item": "Curse Ring",
         "itemr": "Spiral Curse Ring",
         "level": 28,
@@ -714,10 +750,12 @@ const personaMapRoyal: PersonaMap = {
             "Climate Decorum": 33
         },
         "stats": [16, 19, 19, 18, 19],
-        "trait": "Draining Mouth"
+        "trait": "Draining Mouth",
+        "area": "Kaitul",
+        "floor": "L1-4"
     },
     "Clotho": {
-        "inherits": "healing",
+        "inherits": "Healing",
         "item": "Tetraja",
         "itemr": "Makarakarn",
         "skillCard": true,
@@ -738,7 +776,7 @@ const personaMapRoyal: PersonaMap = {
     },
     "Crystal Skull": {
         "rare": true,
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Crystal Skull",
         "itemr": "Crystal Skull R",
         "level": 50,
@@ -758,10 +796,12 @@ const personaMapRoyal: PersonaMap = {
             "Cursed Bloodline": 0
         },
         "stats": [50, 50, 50, 50, 50],
-        "trait": "Ultimate Vessel"
+        "trait": "Ultimate Vessel",
+        "area": "Sheriruth / Da'at",
+        "floor": "L7-9. 11-13 (after Palace 7) / All"
     },
     "Cu Chulainn": {
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "One-shot Kill",
         "itemr": "Riot Gun",
         "skillCard": true,
@@ -781,7 +821,7 @@ const personaMapRoyal: PersonaMap = {
         "trait": "Potent Hypnosis"
     },
     "Cybele": {
-        "inherits": "healing",
+        "inherits": "Healing",
         "item": "Sabazios",
         "itemr": "Gordios",
         "level": 83,
@@ -801,7 +841,7 @@ const personaMapRoyal: PersonaMap = {
         "max": true
     },
     "Daisoujou": {
-        "inherits": "bless",
+        "inherits": "Bless",
         "item": "Spiral Blessing Ring",
         "itemr": "Divine Ring",
         "level": 40,
@@ -820,7 +860,7 @@ const personaMapRoyal: PersonaMap = {
         "trait": "Draining Mouth"
     },
     "Dakini": {
-        "inherits": "phys",
+        "inherits": "Physical",
         "item": "Tempest Slash",
         "itemr": "Myriad Slashes",
         "skillCard": true,
@@ -837,10 +877,12 @@ const personaMapRoyal: PersonaMap = {
             "Charge": 55
         },
         "stats": [34, 32, 34, 28, 29],
-        "trait": "Skillful Combo"
+        "trait": "Skillful Combo",
+        "area": "Sheriruth",
+        "floor": "L7-9 (after Palace 7)"
     },
     "Decarabia": {
-        "inherits": "fire",
+        "inherits": "Fire",
         "item": "Maragion",
         "itemr": "Agidyne",
         "skillCard": true,
@@ -857,10 +899,12 @@ const personaMapRoyal: PersonaMap = {
             "Megidola": 38
         },
         "stats": [21, 23, 19, 22, 18],
-        "trait": "Heated Bloodline"
+        "trait": "Heated Bloodline",
+        "area": "Adyeshach",
+        "floor": "L3, 4, 6-8"
     },
     "Dionysus": {
-        "inherits": "ailment",
+        "inherits": "Ailment",
         "item": "Maziodyne",
         "itemr": "Thunder Reign",
         "skillCard": true,
@@ -880,7 +924,7 @@ const personaMapRoyal: PersonaMap = {
         "trait": "Pinch Anchor"
     },
     "Dominion": {
-        "inherits": "bless",
+        "inherits": "Bless",
         "item": "Makougaon",
         "itemr": "Divine Judgement",
         "skillCard": true,
@@ -897,10 +941,12 @@ const personaMapRoyal: PersonaMap = {
             "Evade Curse": 74
         },
         "stats": [42, 45, 43, 44, 37],
-        "trait": "Blessed Bloodline"
+        "trait": "Blessed Bloodline",
+        "area": "Da'at",
+        "floor": "All"
     },
     "Eligor": {
-        "inherits": "fire",
+        "inherits": "Fire",
         "item": "Tarukaja",
         "itemr": "Matarukaja",
         "skillCard": true,
@@ -916,11 +962,13 @@ const personaMapRoyal: PersonaMap = {
             "Memory Blow": 20
         },
         "stats": [12, 10, 13, 10, 10],
-        "trait": "Thermal Conduct"
+        "trait": "Thermal Conduct",
+        "area": "Chemdah",
+        "floor": "L3 & 4"
     },
     "Emperor's Amulet": {
         "rare": true,
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Emperor's Amulet",
         "itemr": "Emperor's Charm R",
         "level": 35,
@@ -940,10 +988,12 @@ const personaMapRoyal: PersonaMap = {
             "Psychic Bloodline": 0
         },
         "stats": [35, 35, 35, 35, 35],
-        "trait": "Ultimate Vessel"
+        "trait": "Ultimate Vessel",
+        "area": "Sheriruth",
+        "floor": "L7-9, 11-13 (after Palace 7)"
     },
     "Fafnir": {
-        "inherits": "nuke",
+        "inherits": "Nuclear",
         "item": "Spiral Reactor Ring",
         "itemr": "Fire Dragon Horn",
         "level": 86,
@@ -964,7 +1014,7 @@ const personaMapRoyal: PersonaMap = {
     },
     "Flauros": {
         "special": true,
-        "inherits": "ailment",
+        "inherits": "Ailment",
         "item": "Giant Slice Belt",
         "itemr": "Rising Slash Belt",
         "level": 19,
@@ -983,7 +1033,7 @@ const personaMapRoyal: PersonaMap = {
         "trait": "Gluttonmouth"
     },
     "Forneus": {
-        "inherits": "psy",
+        "inherits": "Psy",
         "item": "Psiodyne",
         "itemr": "Mapsiodyne",
         "skillCard": true,
@@ -1000,10 +1050,12 @@ const personaMapRoyal: PersonaMap = {
             "Evade Psy": 68
         },
         "stats": [41, 39, 40, 42, 34],
-        "trait": "Bloodstained Eyes"
+        "trait": "Bloodstained Eyes",
+        "area": "Sheriruth",
+        "floor": "L12 & 13 (after Palace 7)"
     },
     "Fortuna": {
-        "inherits": "wind",
+        "inherits": "Wind",
         "item": "Lucky Robe",
         "itemr": "Super Lucky Robe",
         "level": 46,
@@ -1022,7 +1074,7 @@ const personaMapRoyal: PersonaMap = {
         "trait": "Wind Bloodline"
     },
     "Futsunushi": {
-        "inherits": "phys",
+        "inherits": "Physical",
         "item": "Hinokagutsuchi",
         "itemr": "Hinokagutsuchi II",
         "level": 86,
@@ -1043,7 +1095,7 @@ const personaMapRoyal: PersonaMap = {
         "max": true
     },
     "Fuu-Ki": {
-        "inherits": "wind",
+        "inherits": "Wind",
         "item": "Wind Boost",
         "itemr": "Wind Amp",
         "skillCard": true,
@@ -1052,10 +1104,12 @@ const personaMapRoyal: PersonaMap = {
         "elems": ["-", "rs", "-", "-", "wk", "ab", "-", "-", "-", "-"],
         "skills": {"Tetra Break": 0, "Tarukaja": 0, "Garula": 0, "Wind Boost": 25, "Magarula": 26, "Resist Wind": 27},
         "stats": [14, 17, 16, 15, 14],
-        "trait": "Intense Focus"
+        "trait": "Intense Focus",
+        "area": "Kaitul",
+        "floor": "L8 & 9"
     },
     "Gabriel": {
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Spiral Blizzard Ring",
         "itemr": "Diamond Dust Lily",
         "level": 77,
@@ -1075,7 +1129,7 @@ const personaMapRoyal: PersonaMap = {
         "trait": "Relentless"
     },
     "Ganesha": {
-        "inherits": "ailment",
+        "inherits": "Ailment",
         "item": "Rebellion",
         "itemr": "Revolution",
         "skillCard": true,
@@ -1092,10 +1146,12 @@ const personaMapRoyal: PersonaMap = {
             "Charge": 60
         },
         "stats": [39, 31, 37, 33, 26],
-        "trait": "Gluttonmouth"
+        "trait": "Gluttonmouth",
+        "area": "Sheriruth",
+        "floor": "L5, 7-9 (before Palace 7) / L3 & 4 (after Palace 7)"
     },
     "Garuda": {
-        "inherits": "wind",
+        "inherits": "Wind",
         "item": "Garudyne",
         "itemr": "Magarudyne",
         "skillCard": true,
@@ -1112,10 +1168,12 @@ const personaMapRoyal: PersonaMap = {
             "Wind Amp": 59
         },
         "stats": [30, 36, 29, 39, 29],
-        "trait": "Wind Bloodline"
+        "trait": "Wind Bloodline",
+        "area": "Sheriruth",
+        "floor": "L12 (after Palace 7)"
     },
     "Genbu": {
-        "inherits": "ice",
+        "inherits": "Ice",
         "item": "Frost Ring",
         "itemr": "Spiral Frost Ring",
         "level": 7,
@@ -1126,7 +1184,7 @@ const personaMapRoyal: PersonaMap = {
         "trait": "Cold-Blooded"
     },
     "Girimehkala": {
-        "inherits": "ailment",
+        "inherits": "Ailment",
         "item": "Swift Strike",
         "itemr": "Deathbound",
         "skillCard": true,
@@ -1135,10 +1193,12 @@ const personaMapRoyal: PersonaMap = {
         "elems": ["rp", "rp", "rs", "-", "-", "-", "-", "-", "wk", "nu"],
         "skills": {"Mudoon": 0, "Marakunda": 0, "Deathbound": 0, "Agidyne": 45, "Wage War": 47, "Repel Phys": 50},
         "stats": [32, 24, 32, 29, 19],
-        "trait": "Cursed Bloodline"
+        "trait": "Cursed Bloodline",
+        "area": "Adyeshach",
+        "floor": "L4, 6-8, 10"
     },
     "Hanuman": {
-        "inherits": "phys",
+        "inherits": "Physical",
         "item": "Ruyi Jingu Bang",
         "itemr": "Fine Ruyi Jingu Bang",
         "level": 64,
@@ -1153,10 +1213,12 @@ const personaMapRoyal: PersonaMap = {
             "Regenerate 3": 69
         },
         "stats": [43, 38, 40, 40, 38],
-        "trait": "Potent Hypnosis"
+        "trait": "Potent Hypnosis",
+        "area": "Sheriruth",
+        "floor": "L12 & 13 (after Palace 7)"
     },
     "Hariti": {
-        "inherits": "elec",
+        "inherits": "Electric",
         "item": "Revival Charm",
         "itemr": "Rejuvenate Charm",
         "level": 40,
@@ -1176,7 +1238,7 @@ const personaMapRoyal: PersonaMap = {
         "trait": "Electric Bloodline"
     },
     "Hastur": {
-        "inherits": "wind",
+        "inherits": "Wind",
         "item": "Spiral Gale Ring",
         "itemr": "Storm Sculpture",
         "level": 84,
@@ -1196,7 +1258,7 @@ const personaMapRoyal: PersonaMap = {
         "note": "Only available after 1/12"
     },
     "Hecatoncheires": {
-        "inherits": "phys",
+        "inherits": "Physical",
         "item": "Swift Strike Belt",
         "itemr": "Gatling Belt",
         "level": 42,
@@ -1209,14 +1271,14 @@ const personaMapRoyal: PersonaMap = {
             "Endure": 43,
             "Rebellion": 45,
             "Fortified Moxy": 46,
-            "Gattling Blows": 49
+            "Gatling Blows": 49
         },
         "stats": [35, 22, 27, 23, 26],
         "trait": "Gluttonmouth"
     },
     "Hell Biker": {
         "special": true,
-        "inherits": "fire",
+        "inherits": "Fire",
         "item": "Black Jacket",
         "itemr": "Dark Jacket",
         "level": 37,
@@ -1235,7 +1297,7 @@ const personaMapRoyal: PersonaMap = {
         "trait": "Internal Hypnosis"
     },
     "High Pixie": {
-        "inherits": "healing",
+        "inherits": "Healing",
         "item": "Magaru",
         "itemr": "Garula",
         "skillCard": true,
@@ -1244,11 +1306,13 @@ const personaMapRoyal: PersonaMap = {
         "elems": ["-", "wk", "-", "-", "rs", "rs", "-", "wk", "-", "-"],
         "skills": {"Garu": 0, "Media": 0, "Dormina": 0, "Diarama": 19, "Pulinpa": 20, "Magaru": 22},
         "stats": [8, 14, 10, 13, 10],
-        "trait": "Skillful Combo"
+        "trait": "Skillful Combo",
+        "area": "Kaitul",
+        "floor": "L1-3"
     },
     "Hope Diamond": {
         "rare": true,
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Hope Diamond",
         "itemr": "Hope Diamond R",
         "level": 40,
@@ -1268,10 +1332,12 @@ const personaMapRoyal: PersonaMap = {
             "Retaliating Body": 0
         },
         "stats": [40, 40, 40, 40, 40],
-        "trait": "Ultimate Vessel"
+        "trait": "Ultimate Vessel",
+        "area": "Sheriruth",
+        "floor": "L7-9. 11-13 (after Palace 7)"
     },
     "Horus": {
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Hallowed Ring",
         "itemr": "Spiral Hallowed Ring",
         "level": 47,
@@ -1290,7 +1356,7 @@ const personaMapRoyal: PersonaMap = {
         "trait": "Potent Hypnosis"
     },
     "Hua Po": {
-        "inherits": "fire",
+        "inherits": "Fire",
         "item": "Ember Ring",
         "itemr": "Spiral Ember Ring",
         "level": 9,
@@ -1298,10 +1364,12 @@ const personaMapRoyal: PersonaMap = {
         "elems": ["-", "wk", "rp", "wk", "-", "-", "-", "-", "-", "-"],
         "skills": {"Agi": 0, "Dormina": 0, "Tarunda": 11, "Resist Forget": 12, "Maragi": 13, "Burn Boost": 15},
         "stats": [4, 10, 4, 8, 8],
-        "trait": "Thermal Conduct"
+        "trait": "Thermal Conduct",
+        "area": "Chemdah",
+        "floor": "L1-3"
     },
     "Incubus": {
-        "inherits": "ailment",
+        "inherits": "Ailment",
         "item": "Dream Needle",
         "itemr": "Dormin Rush",
         "skillCard": true,
@@ -1310,10 +1378,12 @@ const personaMapRoyal: PersonaMap = {
         "elems": ["-", "-", "wk", "-", "rs", "-", "-", "-", "wk", "-"],
         "skills": {"Life Drain": 0, "Dream Needle": 0, "Dormina": 7, "Tarunda": 8, "Dodge Curse": 9},
         "stats": [4, 6, 4, 5, 3],
-        "trait": "Draining Mouth"
+        "trait": "Draining Mouth",
+        "area": "Aiyatsbus",
+        "floor": "L2, 3 & 6"
     },
     "Inugami": {
-        "inherits": "fire",
+        "inherits": "Fire",
         "item": "Giant Slice",
         "itemr": "Rising Slash",
         "skillCard": true,
@@ -1330,10 +1400,12 @@ const personaMapRoyal: PersonaMap = {
             "Confuse Boost": 19
         },
         "stats": [11, 9, 9, 12, 8],
-        "trait": "Foul Odor"
+        "trait": "Foul Odor",
+        "area": "Chemdah",
+        "floor": "L4, 6 & 7"
     },
     "Ippon-Datara": {
-        "inherits": "phys",
+        "inherits": "Physical",
         "item": "Sledgehammer",
         "itemr": "Flash Bomb",
         "skillCard": true,
@@ -1349,10 +1421,12 @@ const personaMapRoyal: PersonaMap = {
             "Counter": 18
         },
         "stats": [11, 7, 14, 6, 8],
-        "trait": "Striking Weight"
+        "trait": "Striking Weight",
+        "area": "Chemdah",
+        "floor": "L1-4"
     },
     "Ishtar": {
-        "inherits": "healing",
+        "inherits": "Healing",
         "item": "Spiral Thunder Ring",
         "itemr": "Goddess Horn",
         "level": 85,
@@ -1372,7 +1446,7 @@ const personaMapRoyal: PersonaMap = {
         "max": true
     },
     "Isis": {
-        "inherits": "healing",
+        "inherits": "Healing",
         "item": "Kouga",
         "itemr": "Makouga",
         "skillCard": true,
@@ -1389,10 +1463,12 @@ const personaMapRoyal: PersonaMap = {
             "Makarakarn": 32
         },
         "stats": [14, 20, 17, 18, 16],
-        "trait": "Savior Bloodline"
+        "trait": "Savior Bloodline",
+        "area": "Akzeriyyuth",
+        "floor": "L5-7, 9-11"
     },
     "Jack Frost": {
-        "inherits": "ice",
+        "inherits": "Ice",
         "item": "Frost Hood",
         "itemr": "Frost Ace Hood",
         "level": 11,
@@ -1400,10 +1476,12 @@ const personaMapRoyal: PersonaMap = {
         "elems": ["-", "-", "wk", "nu", "-", "-", "-", "-", "-", "-"],
         "skills": {"Bufu": 0, "Ice Break": 0, "Baisudi": 0, "Mabufu": 12, "Rakunda": 13, "Freeze Boost": 15},
         "stats": [8, 9, 7, 9, 7],
-        "trait": "Frigid Bloodline"
+        "trait": "Frigid Bloodline",
+        "area": "Chemdah",
+        "floor": "L4 & 6"
     },
     "Jack-o'-Lantern": {
-        "inherits": "fire",
+        "inherits": "Fire",
         "item": "Pumpkin Bomb",
         "itemr": "Pumpkin Buster",
         "level": 2,
@@ -1411,10 +1489,12 @@ const personaMapRoyal: PersonaMap = {
         "elems": ["-", "-", "ab", "wk", "-", "wk", "-", "-", "-", "-"],
         "skills": {"Agi": 0, "Rakunda": 0, "Sharp Student": 4, "Dazzler": 5, "Resist Sleep": 7},
         "stats": [2, 3, 3, 3, 2],
-        "trait": "Thermal Conduct"
+        "trait": "Thermal Conduct",
+        "area": "Qimranut / Aiyatsbus",
+        "floor": "Any / L1"
     },
     "Jatayu": {
-        "inherits": "wind",
+        "inherits": "Wind",
         "item": "Speed Master",
         "itemr": "Auto-Masuku",
         "skillCard": true,
@@ -1434,7 +1514,7 @@ const personaMapRoyal: PersonaMap = {
         "trait": "Wind Bloodline"
     },
     "Jikokuten": {
-        "inherits": "phys",
+        "inherits": "Physical",
         "item": "Assault Belt",
         "itemr": "Rush Belt",
         "level": 22,
@@ -1453,7 +1533,7 @@ const personaMapRoyal: PersonaMap = {
         "trait": "Internal Hypnosis"
     },
     "Kaiwan": {
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Makajam",
         "itemr": "Makajamaon",
         "skillCard": true,
@@ -1470,10 +1550,12 @@ const personaMapRoyal: PersonaMap = {
             "Marakunda": 41
         },
         "stats": [23, 26, 24, 22, 20],
-        "trait": "Psychic Bloodline"
+        "trait": "Psychic Bloodline",
+        "area": "Adyeshach",
+        "floor": "L10-12"
     },
     "Kali": {
-        "inherits": "fire",
+        "inherits": "Fire",
         "item": "Null Psy",
         "itemr": "Repel Psy",
         "skillCard": true,
@@ -1493,7 +1575,7 @@ const personaMapRoyal: PersonaMap = {
         "trait": "Relentless"
     },
     "Kelpie": {
-        "inherits": "wind",
+        "inherits": "Wind",
         "item": "Garu",
         "itemr": "Magaru",
         "skillCard": true,
@@ -1502,10 +1584,12 @@ const personaMapRoyal: PersonaMap = {
         "elems": ["-", "-", "-", "rs", "wk", "-", "-", "-", "-", "-"],
         "skills": {"Garu": 0, "Lunge": 0, "Resist Brainwash": 8, "Sukukaja": 9, "Terror Claw": 10},
         "stats": [5, 5, 5, 6, 4],
-        "trait": "Striking Weight"
+        "trait": "Striking Weight",
+        "area": "Aiyatsbus",
+        "floor": "L3"
     },
     "Kikuri-Hime": {
-        "inherits": "healing",
+        "inherits": "Healing",
         "item": "Energy Drop",
         "itemr": "Energy Shower",
         "skillCard": true,
@@ -1514,10 +1598,12 @@ const personaMapRoyal: PersonaMap = {
         "elems": ["-", "-", "wk", "-", "-", "nu", "-", "-", "rs", "-"],
         "skills": {"Lullaby": 0, "Marakukaja": 0, "Energy Drop": 0, "Mediarama": 41, "Tetraja": 43, "Divine Grace": 45},
         "stats": [22, 31, 24, 28, 22],
-        "trait": "Relief Bloodline"
+        "trait": "Relief Bloodline",
+        "area": "Sheriruth",
+        "floor": "L3-5 (before Palace 7) / L2 & 3 (after Palace 7)"
     },
     "Kin-Ki": {
-        "inherits": "phys",
+        "inherits": "Physical",
         "item": "Vajra Blast",
         "itemr": "Vicious Strike",
         "skillCard": true,
@@ -1534,10 +1620,12 @@ const personaMapRoyal: PersonaMap = {
             "Counterstrike": 31
         },
         "stats": [21, 13, 21, 15, 12],
-        "trait": "Retaliating Body"
+        "trait": "Retaliating Body",
+        "area": "Kaitul",
+        "floor": "L4, 5, 7-9"
     },
     "King Frost": {
-        "inherits": "ice",
+        "inherits": "Ice",
         "item": "King Frost Cape",
         "itemr": "King Frost Cape EX",
         "level": 61,
@@ -1553,10 +1641,12 @@ const personaMapRoyal: PersonaMap = {
             "Ice Amp": 67
         },
         "stats": [40, 44, 43, 29, 34],
-        "trait": "Frigid Bloodline"
+        "trait": "Frigid Bloodline",
+        "area": "Sheriruth",
+        "floor": "L8, 11, 12, 13 (after Palace 7)"
     },
     "Kodama": {
-        "inherits": "ailment",
+        "inherits": "Ailment",
         "item": "Psy Ring",
         "itemr": "Spiral Psy Ring",
         "level": 11,
@@ -1572,11 +1662,13 @@ const personaMapRoyal: PersonaMap = {
             "Resist Fear": 17
         },
         "stats": [7, 11, 8, 10, 4],
-        "trait": "Skillful Combo"
+        "trait": "Skillful Combo",
+        "area": "Aiyatsbus",
+        "floor": "L1-3"
     },
     "Koh-i-Noor": {
         "rare": true,
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Koh-i-Noor",
         "itemr": "Koh-i-Noor R",
         "level": 25,
@@ -1596,11 +1688,13 @@ const personaMapRoyal: PersonaMap = {
             "Rare Antibody": 0
         },
         "stats": [25, 25, 25, 25, 25],
-        "trait": "Ultimate Vessel"
+        "trait": "Ultimate Vessel",
+        "area": "Adyeshach",
+        "floor": "L1-4, 6-8, 10-12"
     },
     "Kohryu": {
         "special": true,
-        "inherits": "psy",
+        "inherits": "Psy",
         "item": "Spiral Mystic Ring",
         "itemr": "Dragon's Heart",
         "level": 76,
@@ -1620,7 +1714,7 @@ const personaMapRoyal: PersonaMap = {
         "max": true
     },
     "Koppa Tengu": {
-        "inherits": "wind",
+        "inherits": "Wind",
         "item": "Breeze Ring",
         "itemr": "Spiral Breeze Ring",
         "level": 11,
@@ -1628,10 +1722,12 @@ const personaMapRoyal: PersonaMap = {
         "elems": ["-", "-", "-", "wk", "-", "rs", "-", "-", "wk", "-"],
         "skills": {"Garu": 0, "Sukukaja": 0, "Growth 1": 12, "Taunt": 13, "Rage Boost": 14, "Wage War": 15},
         "stats": [7, 8, 8, 11, 6],
-        "trait": "Intense Focus"
+        "trait": "Intense Focus",
+        "area": "Chemdah",
+        "floor": "L6 & 7"
     },
     "Koropokkuru": {
-        "inherits": "ice",
+        "inherits": "Ice",
         "item": "Bufu",
         "itemr": "Mabufu",
         "skillCard": true,
@@ -1648,10 +1744,12 @@ const personaMapRoyal: PersonaMap = {
             "Climate Decorum": 15
         },
         "stats": [5, 8, 6, 9, 6],
-        "trait": "Foul Odor"
+        "trait": "Foul Odor",
+        "area": "Chemdah",
+        "floor": "L2 & 3"
     },
     "Koumokuten": {
-        "inherits": "phys",
+        "inherits": "Physical",
         "item": "Regenerate 2",
         "itemr": "Regenerate 3",
         "skillCard": true,
@@ -1671,7 +1769,7 @@ const personaMapRoyal: PersonaMap = {
         "trait": "Gluttonmouth"
     },
     "Kumbhanda": {
-        "inherits": "ailment",
+        "inherits": "Ailment",
         "item": "Terror Claw",
         "itemr": "Bloodbath",
         "skillCard": true,
@@ -1688,10 +1786,12 @@ const personaMapRoyal: PersonaMap = {
             "Revolution": 47
         },
         "stats": [25, 30, 25, 27, 26],
-        "trait": "Rare Antibody"
+        "trait": "Rare Antibody",
+        "area": "Sheriruth",
+        "floor": "L8, 9, 11-13 (before Palace 7) / L4 & 5 (after Palace 7)"
     },
     "Kurama Tengu": {
-        "inherits": "wind",
+        "inherits": "Wind",
         "item": "Wind Ring",
         "itemr": "Spiral Wind Ring",
         "level": 31,
@@ -1699,10 +1799,12 @@ const personaMapRoyal: PersonaMap = {
         "elems": ["-", "-", "-", "nu", "-", "rp", "-", "-", "rs", "rs"],
         "skills": {"Double Shot": 0, "Masukunda": 0, "Magarula": 0, "Wind Boost": 32, "Brain Jack": 34, "Growth 2": 36},
         "stats": [20, 19, 21, 24, 16],
-        "trait": "Skillful Combo"
+        "trait": "Skillful Combo",
+        "area": "Sheriruth",
+        "floor": "L11 (after Palace 7)"
     },
     "Kushinada": {
-        "inherits": "healing",
+        "inherits": "Healing",
         "item": "Cure Charm",
         "itemr": "Spiral Cure Charm",
         "level": 42,
@@ -1719,10 +1821,12 @@ const personaMapRoyal: PersonaMap = {
             "Null Ice": 48
         },
         "stats": [24, 30, 26, 28, 25],
-        "trait": "Savior Bloodline"
+        "trait": "Savior Bloodline",
+        "area": "Sheriruth",
+        "floor": "L5, 7-9 (before Palace 7) / L3 & 4 (after Palace 7)"
     },
     "Kushi Mitama": {
-        "inherits": "healing",
+        "inherits": "Healing",
         "item": "Aid Charm",
         "itemr": "Spiral Aid Charm",
         "level": 12,
@@ -1733,7 +1837,7 @@ const personaMapRoyal: PersonaMap = {
         "trait": "Gluttonmouth"
     },
     "Lachesis": {
-        "inherits": "ice",
+        "inherits": "Ice",
         "item": "Snow Ring",
         "itemr": "Spiral Snow Ring",
         "level": 35,
@@ -1752,7 +1856,7 @@ const personaMapRoyal: PersonaMap = {
         "trait": "Internal Hypnosis"
     },
     "Lakshmi": {
-        "inherits": "healing",
+        "inherits": "Healing",
         "item": "Amrita Charm",
         "itemr": "Spiral Amrita Charm",
         "level": 69,
@@ -1772,7 +1876,7 @@ const personaMapRoyal: PersonaMap = {
         "max": true
     },
     "Lamia": {
-        "inherits": "fire",
+        "inherits": "Fire",
         "item": "Rakukaja",
         "itemr": "Marakukaja",
         "skillCard": true,
@@ -1789,21 +1893,26 @@ const personaMapRoyal: PersonaMap = {
             "Despair Boost": 31
         },
         "stats": [21, 15, 18, 19, 12],
-        "trait": "Foul Odor"
+        "trait": "Foul Odor",
+        "area": "Akzeriyyuth",
+        "floor": "L3, 5-7, 9-11"
     },
     "Leanan Sidhe": {
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Mudo",
         "itemr": "Mamudo",
+        "skillCard": true,
         "level": 19,
         "arcana": "Lovers",
         "elems": ["-", "-", "wk", "-", "-", "rs", "rs", "-", "-", "-"],
         "skills": {"Rakunda": 0, "Psio": 0, "Marin Karin": 20, "Mamudo": 21, "Mapsi": 22, "Eiga": 23},
         "stats": [9, 17, 12, 16, 10],
-        "trait": "Skillful Technique"
+        "trait": "Skillful Technique",
+        "area": "Kaitul",
+        "floor": "L3-5"
     },
     "Legion": {
-        "inherits": "psy",
+        "inherits": "Psy",
         "item": "Foul Breath",
         "itemr": "Stagnant Air",
         "skillCard": true,
@@ -1820,10 +1929,12 @@ const personaMapRoyal: PersonaMap = {
             "Eigaon": 45
         },
         "stats": [24, 24, 30, 23, 20],
-        "trait": "Draining Mouth"
+        "trait": "Draining Mouth",
+        "area": "Adyeshach",
+        "floor": "L1-4"
     },
     "Lilim": {
-        "inherits": "ice",
+        "inherits": "Ice",
         "item": "Ice Boost",
         "itemr": "Ice Amp",
         "skillCard": true,
@@ -1840,10 +1951,12 @@ const personaMapRoyal: PersonaMap = {
             "Mabufula": 37
         },
         "stats": [17, 23, 18, 25, 20],
-        "trait": "Cold-Blooded"
+        "trait": "Cold-Blooded",
+        "area": "Adyeshach",
+        "floor": "L6-8, 10-12"
     },
     "Lilith": {
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Null Nuke",
         "itemr": "Repel Nuke",
         "skillCard": true,
@@ -1860,10 +1973,12 @@ const personaMapRoyal: PersonaMap = {
             "Nuke Amp": 65
         },
         "stats": [33, 43, 37, 39, 35],
-        "trait": "Mighty Gaze"
+        "trait": "Mighty Gaze",
+        "area": "Da'at",
+        "floor": "All"
     },
     "Loa": {
-        "inherits": "curse",
+        "inherits": "Curse",
         "item": "Ominous Words",
         "itemr": "Abysmal Surge",
         "skillCard": true,
@@ -1885,7 +2000,7 @@ const personaMapRoyal: PersonaMap = {
     },
     "Lucifer": {
         "special": true,
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Tyrant Pistol",
         "itemr": "Tyrant Pistol EX",
         "level": 93,
@@ -1906,7 +2021,7 @@ const personaMapRoyal: PersonaMap = {
         "max": true
     },
     "Macabre": {
-        "inherits": "curse",
+        "inherits": "Curse",
         "item": "Bloodbath",
         "itemr": "Death Scythe",
         "skillCard": true,
@@ -1927,7 +2042,7 @@ const personaMapRoyal: PersonaMap = {
         "note": "Only available after 1/12"
     },
     "Mada": {
-        "inherits": "fire",
+        "inherits": "Fire",
         "item": "Spiral Inferno Ring",
         "itemr": "Dark Flame Band",
         "level": 90,
@@ -1948,7 +2063,7 @@ const personaMapRoyal: PersonaMap = {
         "max": true
     },
     "Makami": {
-        "inherits": "nuke",
+        "inherits": "Nuclear",
         "item": "Frei",
         "itemr": "Mafrei",
         "skillCard": true,
@@ -1965,10 +2080,12 @@ const personaMapRoyal: PersonaMap = {
             "Dodge Elec": 20
         },
         "stats": [13, 12, 8, 11, 8],
-        "trait": "Skillful Technique"
+        "trait": "Skillful Technique",
+        "area": "Chemdah",
+        "floor": "L6 & 7"
     },
     "Mandrake": {
-        "inherits": "elec",
+        "inherits": "Electric",
         "item": "Sukunda",
         "itemr": "Masukunda",
         "skillCard": true,
@@ -1977,10 +2094,12 @@ const personaMapRoyal: PersonaMap = {
         "elems": ["-", "-", "wk", "-", "rs", "-", "-", "-", "-", "-"],
         "skills": {"Pulinpa": 0, "Energy Drop": 0, "Lunge": 4, "Sukunda": 5},
         "stats": [2, 3, 3, 4, 4],
-        "trait": "Savior Bloodline"
+        "trait": "Savior Bloodline",
+        "area": "Qimranut / Aiyatsbus",
+        "floor": "All / L1"
     },
     "Mara": {
-        "inherits": "psy",
+        "inherits": "Psy",
         "item": "Mapsiodyne",
         "itemr": "Psycho Force",
         "skillCard": true,
@@ -1997,10 +2116,12 @@ const personaMapRoyal: PersonaMap = {
             "Psycho Force": 78
         },
         "stats": [51, 43, 43, 45, 44],
-        "trait": "Mighty Gaze"
+        "trait": "Mighty Gaze",
+        "area": "Da'at",
+        "floor": "All"
     },
     "Maria": {
-        "inherits": "healing",
+        "inherits": "Healing",
         "item": "Spiral Heal Charm",
         "itemr": "Rosary of Purity",
         "level": 93,
@@ -2020,7 +2141,7 @@ const personaMapRoyal: PersonaMap = {
         "max": true
     },
     "Matador": {
-        "inherits": "psy",
+        "inherits": "Psy",
         "item": "Blood Red Capote",
         "itemr": "Bloodied Capote",
         "level": 17,
@@ -2031,7 +2152,7 @@ const personaMapRoyal: PersonaMap = {
         "trait": "Potent Hypnosis"
     },
     "Melchizedek": {
-        "inherits": "bless",
+        "inherits": "Bless",
         "item": "Hamaon",
         "itemr": "Mahamaon",
         "skillCard": true,
@@ -2048,11 +2169,13 @@ const personaMapRoyal: PersonaMap = {
             "God's Hand": 65
         },
         "stats": [37, 32, 40, 39, 33],
-        "trait": "Deathly Illness"
+        "trait": "Deathly Illness",
+        "area": "Da'at",
+        "floor": "All"
     },
     "Metatron": {
         "special": true,
-        "inherits": "bless",
+        "inherits": "Bless",
         "item": "Nataraja",
         "itemr": "Nataraja EX",
         "level": 89,
@@ -2073,7 +2196,7 @@ const personaMapRoyal: PersonaMap = {
     },
     "Michael": {
         "special": true,
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Judge of Hell",
         "itemr": "Judge End",
         "level": 87,
@@ -2092,7 +2215,7 @@ const personaMapRoyal: PersonaMap = {
         "trait": "Potent Hypnosis"
     },
     "Mishaguji": {
-        "inherits": "ailment",
+        "inherits": "Ailment",
         "item": "Spiral Karma Ring",
         "itemr": "Mystic Ring",
         "level": 52,
@@ -2110,8 +2233,8 @@ const personaMapRoyal: PersonaMap = {
         "stats": [32, 32, 32, 32, 35],
         "trait": "Ailment Hunter"
     },
-    "Mithra": {
-        "inherits": "bless",
+    "Mitra": {
+        "inherits": "Bless",
         "item": "Death Contract",
         "itemr": "Death Promise",
         "level": 33,
@@ -2130,7 +2253,7 @@ const personaMapRoyal: PersonaMap = {
         "trait": "Blessed Bloodline"
     },
     "Mithras": {
-        "inherits": "nuke",
+        "inherits": "Nuclear",
         "item": "Nuke Boost",
         "itemr": "Nuke Amp",
         "skillCard": true,
@@ -2147,10 +2270,12 @@ const personaMapRoyal: PersonaMap = {
             "Freidyne": 45
         },
         "stats": [27, 25, 27, 25, 20],
-        "trait": "Skillful Technique"
+        "trait": "Skillful Technique",
+        "area": "Adyeshach",
+        "floor": "L11 & 12"
     },
     "Mokoi": {
-        "inherits": "ailment",
+        "inherits": "Ailment",
         "item": "Dekunda",
         "itemr": "Dekaja",
         "skillCard": true,
@@ -2166,10 +2291,12 @@ const personaMapRoyal: PersonaMap = {
             "Dekunda": 14
         },
         "stats": [9, 5, 6, 10, 4],
-        "trait": "Gloomy Child"
+        "trait": "Gloomy Child",
+        "area": "Chemdah",
+        "floor": "L1-4"
     },
     "Moloch": {
-        "inherits": "fire",
+        "inherits": "Fire",
         "item": "Inferno Ring",
         "itemr": "Spiral Inferno Ring",
         "level": 60,
@@ -2185,10 +2312,12 @@ const personaMapRoyal: PersonaMap = {
             "Fire Amp": 65
         },
         "stats": [32, 45, 42, 31, 37],
-        "trait": "Immunity"
+        "trait": "Immunity",
+        "area": "Da'at",
+        "floor": "All"
     },
     "Mot": {
-        "inherits": "ailment",
+        "inherits": "Ailment",
         "item": "Null Elec",
         "itemr": "Repel Elec",
         "skillCard": true,
@@ -2204,10 +2333,12 @@ const personaMapRoyal: PersonaMap = {
             "Repel Elec": 77
         },
         "stats": [43, 51, 48, 42, 39],
-        "trait": "Mighty Gaze"
+        "trait": "Mighty Gaze",
+        "area": "Da'at",
+        "floor": "All"
     },
     "Mother Harlot": {
-        "inherits": "ice",
+        "inherits": "Ice",
         "item": "Claiomh Solais",
         "itemr": "Claiomh Solais R",
         "level": 85,
@@ -2227,7 +2358,7 @@ const personaMapRoyal: PersonaMap = {
         "max": true
     },
     "Mothman": {
-        "inherits": "elec",
+        "inherits": "Electric",
         "item": "Skull Cracker",
         "itemr": "Mind Slice",
         "skillCard": true,
@@ -2244,10 +2375,12 @@ const personaMapRoyal: PersonaMap = {
             "Ziodyne": 38
         },
         "stats": [21, 24, 16, 24, 21],
-        "trait": "Static Electricity"
+        "trait": "Static Electricity",
+        "area": "Adyeshach",
+        "floor": "L3, 4, 7, 8, 10"
     },
     "Naga": {
-        "inherits": "elec",
+        "inherits": "Electric",
         "item": "Counter",
         "itemr": "Counterstrike",
         "skillCard": true,
@@ -2264,10 +2397,12 @@ const personaMapRoyal: PersonaMap = {
             "Marakukaja": 29
         },
         "stats": [15, 17, 15, 17, 15],
-        "trait": "Striking Weight"
+        "trait": "Striking Weight",
+        "area": "Akzeriyyuth",
+        "floor": "L2, 3, 5-7, 9"
     },
     "Narcissus": {
-        "inherits": "ailment",
+        "inherits": "Ailment",
         "item": "Dazzler",
         "itemr": "Nocturnal Flash",
         "skillCard": true,
@@ -2284,10 +2419,12 @@ const personaMapRoyal: PersonaMap = {
             "Ambient Aid": 53
         },
         "stats": [27, 31, 29, 33, 31],
-        "trait": "Gluttonmouth"
+        "trait": "Gluttonmouth",
+        "area": "Sheriruth",
+        "floor": "L7 & 8 (after Palace 7)"
     },
     "Nebiros": {
-        "inherits": "curse",
+        "inherits": "Curse",
         "item": "Marin Karin",
         "itemr": "Brain Jack",
         "skillCard": true,
@@ -2308,7 +2445,7 @@ const personaMapRoyal: PersonaMap = {
     },
     "Neko Shogun": {
         "special": true,
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Catnap",
         "itemr": "Cat Buster",
         "level": 30,
@@ -2327,7 +2464,7 @@ const personaMapRoyal: PersonaMap = {
         "trait": "Pinch Anchor"
     },
     "Nekomata": {
-        "inherits": "ailment",
+        "inherits": "Ailment",
         "item": "Pawzooka",
         "itemr": "Paw-omber",
         "level": 17,
@@ -2343,10 +2480,12 @@ const personaMapRoyal: PersonaMap = {
             "Dodge Elec": 22
         },
         "stats": [13, 10, 12, 15, 8],
-        "trait": "Foul Odor"
+        "trait": "Foul Odor",
+        "area": "Kaitul",
+        "floor": "L2-4"
     },
     "Nigi Mitama": {
-        "inherits": "healing",
+        "inherits": "Healing",
         "item": "Prayer Ring",
         "itemr": "Spiral Prayer Ring",
         "level": 22,
@@ -2357,7 +2496,7 @@ const personaMapRoyal: PersonaMap = {
         "trait": "Relief Bloodline"
     },
     "Norn": {
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Recarm",
         "itemr": "Samarecarm",
         "skillCard": true,
@@ -2374,10 +2513,12 @@ const personaMapRoyal: PersonaMap = {
             "Samarecarm": 57
         },
         "stats": [30, 38, 33, 34, 28],
-        "trait": "Intense Focus"
+        "trait": "Intense Focus",
+        "area": "Sheriruth",
+        "floor": "L11-13 (before Palace 7) / L5 (after Palace 7)"
     },
     "Nue": {
-        "inherits": "curse",
+        "inherits": "Curse",
         "item": "Maeiha",
         "itemr": "Eiga",
         "skillCard": true,
@@ -2394,10 +2535,12 @@ const personaMapRoyal: PersonaMap = {
             "Curse Boost": 26
         },
         "stats": [16, 10, 17, 14, 10],
-        "trait": "Mighty Gaze"
+        "trait": "Mighty Gaze",
+        "area": "Chemdah",
+        "floor": "L4"
     },
     "Obariyon": {
-        "inherits": "phys",
+        "inherits": "Physical",
         "item": "Lucky Punch",
         "itemr": "Miracle Punch",
         "skillCard": true,
@@ -2406,10 +2549,12 @@ const personaMapRoyal: PersonaMap = {
         "elems": ["rs", "-", "-", "-", "wk", "-", "-", "-", "-", "-"],
         "skills": {"Snap": 0, "Sukunda": 0, "Lucky Punch": 9, "Resist Fear": 10, "Dekaja": 12},
         "stats": [7, 3, 9, 8, 4],
-        "trait": "Striking Weight"
+        "trait": "Striking Weight",
+        "area": "Aiyatsbus",
+        "floor": "L3, 5 & 6"
     },
     "Oberon": {
-        "inherits": "elec",
+        "inherits": "Electric",
         "item": "Heat Wave",
         "itemr": "Vorpal Blade",
         "skillCard": true,
@@ -2427,10 +2572,12 @@ const personaMapRoyal: PersonaMap = {
             "Elec Amp": 72
         },
         "stats": [40, 45, 42, 43, 35],
-        "trait": "Static Electricity"
+        "trait": "Static Electricity",
+        "area": "Sheriruth",
+        "floor": "L13 (after Palace 7)"
     },
     "Odin": {
-        "inherits": "elec",
+        "inherits": "Electric",
         "item": "Wild Hunt",
         "itemr": "Gungnir",
         "level": 84,
@@ -2450,7 +2597,7 @@ const personaMapRoyal: PersonaMap = {
         "max": true
     },
     "Okuninushi": {
-        "inherits": "psy",
+        "inherits": "Psy",
         "item": "Official's Robe",
         "itemr": "Official's Robe R",
         "level": 54,
@@ -2470,7 +2617,7 @@ const personaMapRoyal: PersonaMap = {
     },
     "Ongyo-Ki": {
         "special": true,
-        "inherits": "phys",
+        "inherits": "Physical",
         "item": "Myriad Slash Belt",
         "itemr": "Sword Dance Belt",
         "level": 89,
@@ -2490,7 +2637,7 @@ const personaMapRoyal: PersonaMap = {
         "max": true
     },
     "Oni": {
-        "inherits": "phys",
+        "inherits": "Physical",
         "item": "Rampage",
         "itemr": "Kill Rush",
         "skillCard": true,
@@ -2499,10 +2646,12 @@ const personaMapRoyal: PersonaMap = {
         "elems": ["rs", "rs", "-", "-", "-", "-", "-", "-", "-", "-"],
         "skills": {"Rampage": 0, "Counter": 0, "Snap": 0, "Giant Slice": 22, "Sharp Student": 23, "Memory Blow": 24},
         "stats": [19, 9, 17, 12, 10],
-        "trait": "Retaliating Body"
+        "trait": "Retaliating Body",
+        "area": "Kaitul",
+        "floor": "L3-5, 8, 9"
     },
     "Onmoraki": {
-        "inherits": "curse",
+        "inherits": "Curse",
         "item": "Grudge Ring",
         "itemr": "Spiral Grudge Ring",
         "level": 12,
@@ -2510,11 +2659,13 @@ const personaMapRoyal: PersonaMap = {
         "elems": ["-", "-", "rs", "wk", "-", "-", "-", "-", "wk", "nu"],
         "skills": {"Eiha": 0, "Ice Wall": 0, "Agi": 13, "Evil Touch": 14, "Pulinpa": 15, "Confuse Boost": 17},
         "stats": [9, 12, 7, 10, 5],
-        "trait": "Intense Focus"
+        "trait": "Intense Focus",
+        "area": "Chemdah",
+        "floor": "L3 & 4"
     },
     "Orichalcum": {
         "rare": true,
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Orichalcum",
         "itemr": "Orichalcum R",
         "level": 60,
@@ -2538,7 +2689,7 @@ const personaMapRoyal: PersonaMap = {
     },
     "Orlov": {
         "rare": true,
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Orlov",
         "itemr": "Orlov R",
         "level": 30,
@@ -2558,10 +2709,12 @@ const personaMapRoyal: PersonaMap = {
             "Atomic Bloodline": 0
         },
         "stats": [30, 30, 30, 30, 30],
-        "trait": "Ultimate Vessel"
+        "trait": "Ultimate Vessel",
+        "area": "Sheriruth",
+        "floor": "Any (before Palace 7) / L1-5 (after Palace 7)"
     },
     "Orobas": {
-        "inherits": "fire",
+        "inherits": "Fire",
         "item": "Rakunda",
         "itemr": "Marakunda",
         "skillCard": true,
@@ -2570,10 +2723,12 @@ const personaMapRoyal: PersonaMap = {
         "elems": ["-", "-", "-", "wk", "-", "rs", "-", "-", "-", "rs"],
         "skills": {"Maragi": 0, "Sukukaja": 0, "Dekaja": 0, "Marakunda": 19, "Fire Break": 20, "Makajamaon": 21},
         "stats": [11, 14, 15, 12, 6],
-        "trait": "Mighty Gaze"
+        "trait": "Mighty Gaze",
+        "area": "Kaitul",
+        "floor": "L1-3"
     },
     "Orthrus": {
-        "inherits": "fire",
+        "inherits": "Fire",
         "item": "Agilao",
         "itemr": "Maragion",
         "skillCard": true,
@@ -2589,10 +2744,12 @@ const personaMapRoyal: PersonaMap = {
             "Matarukaja": 26
         },
         "stats": [16, 14, 14, 19, 7],
-        "trait": "Thermal Conduct"
+        "trait": "Thermal Conduct",
+        "area": "Kaitul",
+        "floor": "L4, 5, 7-9"
     },
     "Ose": {
-        "inherits": "ailment",
+        "inherits": "Ailment",
         "item": "Counterstrike",
         "itemr": "High Counter",
         "skillCard": true,
@@ -2608,10 +2765,12 @@ const personaMapRoyal: PersonaMap = {
             "Heat Wave": 47
         },
         "stats": [32, 24, 25, 31, 21],
-        "trait": "Retaliating Body"
+        "trait": "Retaliating Body",
+        "area": "Sheriruth",
+        "floor": "L1-5, 9 (before Palace 7) / L1-4 (after Palace 7)"
     },
     "Pale Rider": {
-        "inherits": "curse",
+        "inherits": "Curse",
         "item": "Hex Ring",
         "itemr": "Spiral Hex Ring",
         "level": 54,
@@ -2630,7 +2789,7 @@ const personaMapRoyal: PersonaMap = {
         "trait": "Foul Stench"
     },
     "Parvati": {
-        "inherits": "psy",
+        "inherits": "Psy",
         "item": "Null Ice",
         "itemr": "Repel Ice",
         "skillCard": true,
@@ -2647,10 +2806,12 @@ const personaMapRoyal: PersonaMap = {
             "Null Ice": 61
         },
         "stats": [33, 39, 33, 39, 31],
-        "trait": "Skillful Technique"
+        "trait": "Skillful Technique",
+        "area": "Sheriruth",
+        "floor": "L9, 11, 12 (after Palace 7)"
     },
     "Pazuzu": {
-        "inherits": "curse",
+        "inherits": "Curse",
         "item": "Spiral Curse Ring",
         "itemr": "Hex Ring",
         "level": 45,
@@ -2669,7 +2830,7 @@ const personaMapRoyal: PersonaMap = {
         "trait": "Cursed Bloodline"
     },
     "Phoenix": {
-        "inherits": "nuke",
+        "inherits": "Nuclear",
         "item": "Heavensent Dress",
         "itemr": "Godsent Dress",
         "level": 21,
@@ -2680,7 +2841,7 @@ const personaMapRoyal: PersonaMap = {
         "trait": "Atomic Bloodline"
     },
     "Pisaca": {
-        "inherits": "curse",
+        "inherits": "Curse",
         "item": "Headhunter Ladle",
         "itemr": "Headhunter Ladle EX",
         "level": 28,
@@ -2696,10 +2857,12 @@ const personaMapRoyal: PersonaMap = {
             "Mudoon": 33
         },
         "stats": [19, 21, 21, 16, 14],
-        "trait": "Rare Antibody"
+        "trait": "Rare Antibody",
+        "area": "Akzeriyyuth",
+        "floor": "L5-7, 9-11"
     },
     "Pixie": {
-        "inherits": "elec",
+        "inherits": "Electric",
         "item": "Static Ring",
         "itemr": "Spiral Static Ring",
         "level": 2,
@@ -2707,10 +2870,12 @@ const personaMapRoyal: PersonaMap = {
         "elems": ["-", "wk", "-", "wk", "rs", "-", "-", "-", "rs", "wk"],
         "skills": {"Zio": 0, "Dia": 0, "Patra": 3, "Tarukaja": 5, "Resist Confuse": 6},
         "stats": [1, 3, 3, 4, 2],
-        "trait": "Static Electricity"
+        "trait": "Static Electricity",
+        "area": "Qimranut / Aiyatsbus",
+        "floor": "Any / L1 & 3"
     },
     "Power": {
-        "inherits": "bless",
+        "inherits": "Bless",
         "item": "Bless Boost",
         "itemr": "Bless Amp",
         "skillCard": true,
@@ -2727,10 +2892,12 @@ const personaMapRoyal: PersonaMap = {
             "Null Curse": 46
         },
         "stats": [30, 26, 28, 25, 21],
-        "trait": "Internal Hypnosis"
+        "trait": "Internal Hypnosis",
+        "area": "Sheriruth",
+        "floor": "L1-5, 7 (before Palace 7) / L1-3 (after Palace 7)"
     },
     "Principality": {
-        "inherits": "bless",
+        "inherits": "Bless",
         "item": "Blessing Ring",
         "itemr": "Spiral Blessing Ring",
         "level": 29,
@@ -2749,7 +2916,7 @@ const personaMapRoyal: PersonaMap = {
         "trait": "Blessed Bloodline"
     },
     "Queen Mab": {
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Masquerade Ribbon",
         "itemr": "Masquerade Ribbon R",
         "level": 43,
@@ -2765,11 +2932,13 @@ const personaMapRoyal: PersonaMap = {
             "Concentrate": 48
         },
         "stats": [23, 35, 26, 30, 22],
-        "trait": "Static Electricity"
+        "trait": "Static Electricity",
+        "area": "Sheriruth",
+        "floor": "L5, 7-9 (before Palace 7) / L3 & 4 (after Palace 7)"
     },
     "Queen's Necklace": {
         "rare": true,
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Queen's Necklace",
         "itemr": "Queen's Necklace R",
         "level": 15,
@@ -2789,10 +2958,12 @@ const personaMapRoyal: PersonaMap = {
             "Savior Bloodline": 0
         },
         "stats": [15, 15, 15, 15, 15],
-        "trait": "Ultimate Vessel"
+        "trait": "Ultimate Vessel",
+        "area": "Kaitul",
+        "floor": "L1-5, 7-9"
     },
     "Quetzalcoatl": {
-        "inherits": "wind",
+        "inherits": "Wind",
         "item": "Magarudyne",
         "itemr": "Panta Rhei",
         "skillCard": true,
@@ -2812,7 +2983,7 @@ const personaMapRoyal: PersonaMap = {
         "trait": "Wind Bloodline"
     },
     "Raja Naga": {
-        "inherits": "elec",
+        "inherits": "Electric",
         "item": "Thunder Ring",
         "itemr": "Spiral Thunder Ring",
         "level": 55,
@@ -2831,7 +3002,7 @@ const personaMapRoyal: PersonaMap = {
         "trait": "Electric Bloodline"
     },
     "Rakshasa": {
-        "inherits": "phys",
+        "inherits": "Physical",
         "item": "Regenerate 1",
         "itemr": "Regenerate 2",
         "skillCard": true,
@@ -2848,10 +3019,13 @@ const personaMapRoyal: PersonaMap = {
             "Adverse Resolve": 30
         },
         "stats": [20, 15, 18, 17, 9],
-        "trait": "Skillful Combo"
+        "trait": "Skillful Combo",
+        "personality": "Irritable",
+        "area": "Kaitul",
+        "floor": "L5, 7-9"
     },
     "Rangda": {
-        "inherits": "curse",
+        "inherits": "Curse",
         "item": "Maeiga",
         "itemr": "Eigaon",
         "skillCard": true,
@@ -2860,10 +3034,12 @@ const personaMapRoyal: PersonaMap = {
         "elems": ["rp", "rp", "nu", "-", "wk", "-", "-", "-", "wk", "nu"],
         "skills": {"Swift Strike": 0, "Bloodbath": 0, "Counterstrike": 0, "Eigaon": 49, "Matarunda": 51, "Mudoon": 53},
         "stats": [28, 34, 30, 33, 26],
-        "trait": "Cursed Bloodline"
+        "trait": "Cursed Bloodline",
+        "area": "Sheriruth",
+        "floor": "L11-13 (before Palace 7) / L5 (after Palace 7)"
     },
     "Raphael": {
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Null Bless",
         "itemr": "Repel Bless",
         "skillCard": true,
@@ -2883,7 +3059,7 @@ const personaMapRoyal: PersonaMap = {
         "trait": "Pinch Anchor"
     },
     "Red Rider": {
-        "inherits": "psy",
+        "inherits": "Psy",
         "item": "Karma Ring",
         "itemr": "Spiral Karma Ring",
         "level": 41,
@@ -2903,7 +3079,7 @@ const personaMapRoyal: PersonaMap = {
     },
     "Regent": {
         "rare": true,
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Regent",
         "itemr": "Regent R",
         "level": 10,
@@ -2923,10 +3099,12 @@ const personaMapRoyal: PersonaMap = {
             "Skillful Combo": 0
         },
         "stats": [10, 10, 10, 10, 10],
-        "trait": "Ultimate Vessel"
+        "trait": "Ultimate Vessel",
+        "area": "Qimranut / Aiyatsbus / Chemdah",
+        "floor": "Any / L1-3, 5 & 6 / L1-4, 6 & 7"
     },
     "Saki Mitama": {
-        "inherits": "healing",
+        "inherits": "Healing",
         "item": "Energy Charm",
         "itemr": "Spiral Energy Charm",
         "level": 6,
@@ -2937,7 +3115,7 @@ const personaMapRoyal: PersonaMap = {
         "trait": "Internal Hypnosis"
     },
     "Sandalphon": {
-        "inherits": "bless",
+        "inherits": "Bless",
         "item": "Sword of Sinai",
         "itemr": "Sword of Sinai II",
         "level": 75,
@@ -2957,7 +3135,7 @@ const personaMapRoyal: PersonaMap = {
         "max": true
     },
     "Sandman": {
-        "inherits": "wind",
+        "inherits": "Wind",
         "item": "Dormina",
         "itemr": "Lullaby",
         "skillCard": true,
@@ -2974,10 +3152,12 @@ const personaMapRoyal: PersonaMap = {
             "Sleep Boost": 28
         },
         "stats": [11, 13, 14, 17, 21],
-        "trait": "Foul Odor"
+        "trait": "Foul Odor",
+        "area": "Akzeriyyuth",
+        "floor": "L1-3"
     },
     "Sarasvati": {
-        "inherits": "healing",
+        "inherits": "Healing",
         "item": "Mediarama",
         "itemr": "Diarahan",
         "skillCard": true,
@@ -2994,10 +3174,12 @@ const personaMapRoyal: PersonaMap = {
             "Diarahan": 54
         },
         "stats": [30, 35, 32, 33, 27],
-        "trait": "Relief Bloodline"
+        "trait": "Relief Bloodline",
+        "area": "Sheriruth",
+        "floor": "L7-9. 12 (after Palace 7)"
     },
     "Satan": {
-        "inherits": "ice",
+        "inherits": "Ice",
         "item": "Tantric Oath",
         "itemr": "Tantric Oath R",
         "level": 92,
@@ -3019,7 +3201,7 @@ const personaMapRoyal: PersonaMap = {
     },
     "Satanael": {
         "special": true,
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Paradise Lost",
         "itemr": "Paradise Lost R",
         "level": 95,
@@ -3040,7 +3222,7 @@ const personaMapRoyal: PersonaMap = {
         "note": "Only available on NG+"
     },
     "Scathach": {
-        "inherits": "wind",
+        "inherits": "Wind",
         "item": "Makarakarn",
         "itemr": "Tetrakarn",
         "skillCard": true,
@@ -3057,10 +3239,12 @@ const personaMapRoyal: PersonaMap = {
             "Attack Master": 82
         },
         "stats": [48, 52, 46, 48, 44],
-        "trait": "Skillful Technique"
+        "trait": "Skillful Technique",
+        "area": "Adyeshach",
+        "floor": "L10-12"
     },
     "Seiryu": {
-        "inherits": "ice",
+        "inherits": "Ice",
         "item": "Blizzard Ring",
         "itemr": "Spiral Blizzard Ring",
         "level": 62,
@@ -3079,7 +3263,7 @@ const personaMapRoyal: PersonaMap = {
         "trait": "Relentless"
     },
     "Setanta": {
-        "inherits": "phys",
+        "inherits": "Physical",
         "item": "Rebellion Anklet",
         "itemr": "Revolution Anklet",
         "level": 25,
@@ -3091,7 +3275,7 @@ const personaMapRoyal: PersonaMap = {
     },
     "Seth": {
         "special": true,
-        "inherits": "fire",
+        "inherits": "Fire",
         "item": "Triple Shot Belt",
         "itemr": "Special Shot Belt",
         "level": 51,
@@ -3109,7 +3293,7 @@ const personaMapRoyal: PersonaMap = {
         "trait": "Potent Hypnosis"
     },
     "Shiisaa": {
-        "inherits": "elec",
+        "inherits": "Electric",
         "item": "Double Fangs",
         "itemr": "Cornered Fang",
         "skillCard": true,
@@ -3128,7 +3312,7 @@ const personaMapRoyal: PersonaMap = {
         "trait": "Atomic Bloodline"
     },
     "Shiki-Ouji": {
-        "inherits": "psy",
+        "inherits": "Psy",
         "item": "Double Shot",
         "itemr": "Triple Down",
         "skillCard": true,
@@ -3145,11 +3329,13 @@ const personaMapRoyal: PersonaMap = {
             "Oni Kagura": 24
         },
         "stats": [16, 14, 12, 9, 10],
-        "trait": "Psychic Bloodline"
+        "trait": "Psychic Bloodline",
+        "area": "Chemdah",
+        "floor": "L6 & 7"
     },
     "Shiva": {
         "special": true,
-        "inherits": "psy",
+        "inherits": "Psy",
         "item": "Megido Fire",
         "itemr": "Megido Blaster",
         "level": 82,
@@ -3168,7 +3354,7 @@ const personaMapRoyal: PersonaMap = {
         "trait": "Psychic Bloodline"
     },
     "Siegfried": {
-        "inherits": "phys",
+        "inherits": "Physical",
         "item": "Vorpal Blade Belt",
         "itemr": "Brave Belt",
         "level": 84,
@@ -3187,7 +3373,7 @@ const personaMapRoyal: PersonaMap = {
         "trait": "Retaliating Body"
     },
     "Silky": {
-        "inherits": "healing",
+        "inherits": "Healing",
         "item": "Silk Dress",
         "itemr": "Fine Silk Dress",
         "level": 6,
@@ -3195,10 +3381,12 @@ const personaMapRoyal: PersonaMap = {
         "elems": ["-", "-", "wk", "rs", "wk", "-", "-", "-", "-", "-"],
         "skills": {"Dormina": 0, "Bufu": 0, "Dia": 7, "Patra": 9, "Sharp Student": 10},
         "stats": [4, 7, 4, 5, 5],
-        "trait": "Intense Focus"
+        "trait": "Intense Focus",
+        "area": "Aiyatsbus",
+        "floor": "L2, 3, 5 & 6"
     },
     "Skadi": {
-        "inherits": "ice",
+        "inherits": "Ice",
         "item": "Snow Queen's Whip",
         "itemr": "Snow Queen's Whip II",
         "level": 53,
@@ -3214,10 +3402,12 @@ const personaMapRoyal: PersonaMap = {
             "Spirit Drain": 58
         },
         "stats": [33, 39, 32, 34, 28],
-        "trait": "Bloodstained Eyes"
+        "trait": "Bloodstained Eyes",
+        "area": "Sheriruth",
+        "floor": "L12 & 13 (before Palace 7) / L5 (after Palace 7)"
     },
     "Slime": {
-        "inherits": "curse",
+        "inherits": "Curse",
         "item": "Tarunda",
         "itemr": "Matarunda",
         "skillCard": true,
@@ -3226,11 +3416,13 @@ const personaMapRoyal: PersonaMap = {
         "elems": ["rs", "rs", "wk", "-", "-", "wk", "-", "-", "-", "-"],
         "skills": {"Lunge": 0, "Evil Touch": 0, "Tarunda": 11, "Fire Wall": 13, "Headbutt": 14},
         "stats": [9, 6, 11, 6, 5],
-        "trait": "Rare Antibody"
+        "trait": "Rare Antibody",
+        "area": "Qimranut / Aiyatsbus",
+        "floor": "Any / L1, 2, 3, 6"
     },
     "Sraosha": {
         "special": true,
-        "inherits": "bless",
+        "inherits": "Bless",
         "item": "Archangel Bra",
         "itemr": "High Archangel Bra",
         "level": 80,
@@ -3250,7 +3442,7 @@ const personaMapRoyal: PersonaMap = {
     },
     "Stone of Scone": {
         "rare": true,
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Stone of Scone",
         "itemr": "Stone of Scone R",
         "level": 20,
@@ -3270,10 +3462,12 @@ const personaMapRoyal: PersonaMap = {
             "Intense Focus": 0
         },
         "stats": [20, 20, 20, 20, 20],
-        "trait": "Ultimate Vessel"
+        "trait": "Ultimate Vessel",
+        "area": "Akzeriyyuth",
+        "floor": "L1-3, 5-7, 9-11"
     },
     "Succubus": {
-        "inherits": "curse",
+        "inherits": "Curse",
         "item": "Brain Shot",
         "itemr": "Pink Buster",
         "level": 7,
@@ -3281,10 +3475,12 @@ const personaMapRoyal: PersonaMap = {
         "elems": ["-", "-", "rs", "-", "-", "wk", "-", "-", "wk", "nu"],
         "skills": {"Dormina": 0, "Rebellion": 0, "Agi": 8, "Dekaja": 10, "Sleep Boost": 11, "Mudo": 12},
         "stats": [4, 7, 5, 8, 4],
-        "trait": "Foul Odor"
+        "trait": "Foul Odor",
+        "area": "Aiyatsbus",
+        "floor": "L5 & 6"
     },
     "Sudama": {
-        "inherits": "psy",
+        "inherits": "Psy",
         "item": "Mapsi",
         "itemr": "Psio",
         "skillCard": true,
@@ -3301,10 +3497,12 @@ const personaMapRoyal: PersonaMap = {
             "Psio": 23
         },
         "stats": [9, 14, 12, 13, 10],
-        "trait": "Gloomy Child"
+        "trait": "Gloomy Child",
+        "area": "Chemdah",
+        "floor": "L6 & 7"
     },
     "Sui-Ki": {
-        "inherits": "ice",
+        "inherits": "Ice",
         "item": "Bufula",
         "itemr": "Mabufula",
         "skillCard": true,
@@ -3321,10 +3519,12 @@ const personaMapRoyal: PersonaMap = {
             "Dodge Fire": 29
         },
         "stats": [16, 15, 15, 18, 15],
-        "trait": "Frigid Bloodline"
+        "trait": "Frigid Bloodline",
+        "area": "Kaitul",
+        "floor": "L7-9"
     },
     "Surt": {
-        "inherits": "fire",
+        "inherits": "Fire",
         "item": "Maragidyne",
         "itemr": "Inferno",
         "skillCard": true,
@@ -3344,7 +3544,7 @@ const personaMapRoyal: PersonaMap = {
         "trait": "Heated Bloodline"
     },
     "Suzaku": {
-        "inherits": "nuke",
+        "inherits": "Nuclear",
         "item": "Atom Ring",
         "itemr": "Spiral Atom Ring",
         "level": 16,
@@ -3363,7 +3563,7 @@ const personaMapRoyal: PersonaMap = {
         "trait": "Gluttonmouth"
     },
     "Take-Minakata": {
-        "inherits": "elec",
+        "inherits": "Electric",
         "item": "Zionga",
         "itemr": "Mazionga",
         "skillCard": true,
@@ -3380,11 +3580,13 @@ const personaMapRoyal: PersonaMap = {
             "Shock Boost": 32
         },
         "stats": [17, 19, 18, 16, 15],
-        "trait": "Electric Bloodline"
+        "trait": "Electric Bloodline",
+        "area": "Kaitul",
+        "floor": "L7-9"
     },
     "Tam Lin": {
         "special": true,
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Fairy Knight Armor",
         "itemr": "Fairy Hero Armor",
         "level": 27,
@@ -3403,7 +3605,7 @@ const personaMapRoyal: PersonaMap = {
         "trait": "Gluttonmouth"
     },
     "Thor": {
-        "inherits": "elec",
+        "inherits": "Electric",
         "item": "Mjolnir",
         "itemr": "Imprisoned Mjolnir",
         "level": 64,
@@ -3419,10 +3621,12 @@ const personaMapRoyal: PersonaMap = {
             "Wild Thunder": 71
         },
         "stats": [44, 39, 43, 38, 35],
-        "trait": "Intense Focus"
+        "trait": "Intense Focus",
+        "area": "Da'at",
+        "floor": "All"
     },
     "Thoth": {
-        "inherits": "nuke",
+        "inherits": "Nuclear",
         "item": "Mafreila",
         "itemr": "Freidyne",
         "skillCard": true,
@@ -3439,10 +3643,12 @@ const personaMapRoyal: PersonaMap = {
             "Growth 2": 42
         },
         "stats": [21, 28, 21, 24, 21],
-        "trait": "Skillful Technique"
+        "trait": "Skillful Technique",
+        "area": "Akzeriyyuth",
+        "floor": "L6, 7, 9-11"
     },
     "Throne": {
-        "inherits": "bless",
+        "inherits": "Bless",
         "item": "Spiral Divine Ring",
         "itemr": "Judgement Cross",
         "level": 72,
@@ -3458,10 +3664,12 @@ const personaMapRoyal: PersonaMap = {
             "Inferno": 78
         },
         "stats": [42, 49, 43, 46, 43],
-        "trait": "Crisis Control"
+        "trait": "Crisis Control",
+        "area": "Da'at",
+        "floor": "All"
     },
     "Thunderbird": {
-        "inherits": "elec",
+        "inherits": "Electric",
         "item": "Elec Boost",
         "itemr": "Elec Amp",
         "skillCard": true,
@@ -3481,7 +3689,7 @@ const personaMapRoyal: PersonaMap = {
         "trait": "Electric Bloodline"
     },
     "Titania": {
-        "inherits": "nuke",
+        "inherits": "Nuclear",
         "item": "Freidyne",
         "itemr": "Mafreidyne",
         "skillCard": true,
@@ -3490,11 +3698,13 @@ const personaMapRoyal: PersonaMap = {
         "elems": ["-", "-", "-", "-", "-", "-", "wk", "rs", "rs", "rs"],
         "skills": {"Freidyne": 0, "Ziodyne": 0, "Lullaby": 0, "Concentrate": 59, "Nuke Amp": 60, "Mediarahan": 61},
         "stats": [32, 40, 35, 38, 30],
-        "trait": "Foul Stench"
+        "trait": "Foul Stench",
+        "area": "Sheriruth",
+        "floor": "L8, 9, 11-13 (after Palace 7)"
     },
     "Trumpeter": {
         "special": true,
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Reactor Ring",
         "itemr": "Spiral Reactor Ring",
         "level": 59,
@@ -3513,7 +3723,7 @@ const personaMapRoyal: PersonaMap = {
         "trait": "Relentless"
     },
     "Unicorn": {
-        "inherits": "bless",
+        "inherits": "Bless",
         "item": "Mahama",
         "itemr": "Hamaon",
         "skillCard": true,
@@ -3530,10 +3740,12 @@ const personaMapRoyal: PersonaMap = {
             "Hamaon": 44
         },
         "stats": [20, 27, 25, 28, 24],
-        "trait": "Blessed Bloodline"
+        "trait": "Blessed Bloodline",
+        "area": "Sheriruth",
+        "floor": "L1-4 (before Palace 7) / L1 & 2 (after Palace 7)"
     },
     "Uriel": {
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Heaven's Gate",
         "itemr": "Providence",
         "level": 81,
@@ -3552,7 +3764,7 @@ const personaMapRoyal: PersonaMap = {
         "trait": "Mouth of Savoring"
     },
     "Valkyrie": {
-        "inherits": "phys",
+        "inherits": "Physical",
         "item": "Rising Slash",
         "itemr": "Deadly Fury",
         "skillCard": true,
@@ -3568,11 +3780,13 @@ const personaMapRoyal: PersonaMap = {
             "Dodge Phys": 49
         },
         "stats": [33, 24, 28, 29, 25],
-        "trait": "Skillful Combo"
+        "trait": "Skillful Combo",
+        "area": "Sheriruth",
+        "floor": "L3-5, 7-9 (before Palace 7) / L2-4 (after Palace 7)"
     },
     "Vasuki": {
         "special": true,
-        "inherits": "ailment",
+        "inherits": "Ailment",
         "item": "Kuzuryu Gouhou",
         "itemr": "Kuzuryu Gouhou EX",
         "level": 68,
@@ -3591,7 +3805,7 @@ const personaMapRoyal: PersonaMap = {
         "trait": "Foul Stench"
     },
     "Vishnu": {
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Sudarshana",
         "itemr": "Sudarshana EX",
         "level": 83,
@@ -3612,7 +3826,7 @@ const personaMapRoyal: PersonaMap = {
         "max": true
     },
     "Vohu Manah": {
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Doomsday",
         "itemr": "Ancient Day",
         "level": 80,
@@ -3632,7 +3846,7 @@ const personaMapRoyal: PersonaMap = {
         "max": true
     },
     "White Rider": {
-        "inherits": "curse",
+        "inherits": "Curse",
         "item": "Gun Boost",
         "itemr": "Gun Amp",
         "skillCard": true,
@@ -3653,7 +3867,7 @@ const personaMapRoyal: PersonaMap = {
         "trait": "Bloodstained Eyes"
     },
     "Yaksini": {
-        "inherits": "ice",
+        "inherits": "Ice",
         "item": "Hysterical Slap",
         "itemr": "Oni Kagura",
         "skillCard": true,
@@ -3669,10 +3883,12 @@ const personaMapRoyal: PersonaMap = {
             "Vicious Strike": 24
         },
         "stats": [14, 11, 13, 16, 13],
-        "trait": "Foul Odor"
+        "trait": "Foul Odor",
+        "area": "Kaitul",
+        "floor": "L3-5, 7"
     },
     "Yamata-no-Orochi": {
-        "inherits": "ice",
+        "inherits": "Ice",
         "item": "Triple Down",
         "itemr": "One-shot Kill",
         "skillCard": true,
@@ -3688,10 +3904,12 @@ const personaMapRoyal: PersonaMap = {
             "Diamond Dust": 69
         },
         "stats": [44, 38, 48, 36, 33],
-        "trait": "Cold-Blooded"
+        "trait": "Cold-Blooded",
+        "area": "Da'at",
+        "floor": "All"
     },
     "Yatagarasu": {
-        "inherits": "fire",
+        "inherits": "Fire",
         "item": "Black Wing Robe",
         "itemr": "Black Wing Robe R",
         "level": 57,
@@ -3711,7 +3929,7 @@ const personaMapRoyal: PersonaMap = {
     },
     "Yoshitsune": {
         "special": true,
-        "inherits": "phys",
+        "inherits": "Physical",
         "item": "Usumidori",
         "itemr": "Usumidori R",
         "level": 87,
@@ -3730,7 +3948,7 @@ const personaMapRoyal: PersonaMap = {
         "trait": "Retaliating Body"
     },
     "Yurlungur": {
-        "inherits": "elec",
+        "inherits": "Electric",
         "item": "Mirrirmina",
         "itemr": "Mirrirmina EX",
         "level": 43,
@@ -3749,7 +3967,7 @@ const personaMapRoyal: PersonaMap = {
         "trait": "Mouth of Savoring"
     },
     "Zaou-Gongen": {
-        "inherits": "fire",
+        "inherits": "Fire",
         "item": "God's Hand Belt",
         "itemr": "Gigantomachia Belt",
         "level": 80,
@@ -3769,7 +3987,7 @@ const personaMapRoyal: PersonaMap = {
         "max": true
     },
     "Zouchouten": {
-        "inherits": "elec",
+        "inherits": "Electric",
         "item": "Spark Ring",
         "itemr": "Spiral Spark Ring",
         "level": 31,
@@ -3788,7 +4006,7 @@ const personaMapRoyal: PersonaMap = {
         "trait": "Electric Bloodline"
     },
     "Ariadne": {
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Red String",
         "itemr": "Red String R",
         "level": 30,
@@ -3808,7 +4026,7 @@ const personaMapRoyal: PersonaMap = {
         "dlc": true
     },
     "Ariadne Picaro": {
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Auto-Mataru",
         "itemr": "Auto-Maraku",
         "skillCard": true,
@@ -3829,7 +4047,7 @@ const personaMapRoyal: PersonaMap = {
         "dlc": true
     },
     "Asterius": {
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Blazing Horns",
         "itemr": "Inferno Horns",
         "level": 56,
@@ -3849,7 +4067,7 @@ const personaMapRoyal: PersonaMap = {
         "dlc": true
     },
     "Asterius Picaro": {
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Gigantomachia",
         "itemr": "Agneyastra",
         "skillCard": true,
@@ -3870,14 +4088,14 @@ const personaMapRoyal: PersonaMap = {
         "dlc": true
     },
     "Athena": {
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Kugelbein",
         "itemr": "Kugelbein R",
         "level": 46,
         "arcana": "Chariot",
         "elems": ["rs", "nu", "-", "-", "wk", "-", "-", "-", "-", "-"],
         "skills": {
-            "Akasha Arts": 0,
+            "Akashic Arts": 0,
             "Marakukaja": 0,
             "Rising Slash": 0,
             "Diarahan": 47,
@@ -3891,7 +4109,7 @@ const personaMapRoyal: PersonaMap = {
         "dlc": true
     },
     "Athena Picaro": {
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Charge",
         "itemr": "Concentrate",
         "skillCard": true,
@@ -3899,7 +4117,7 @@ const personaMapRoyal: PersonaMap = {
         "arcana": "Chariot",
         "elems": ["rs", "nu", "-", "-", "wk", "-", "-", "-", "-", "-"],
         "skills": {
-            "Akasha Arts": 0,
+            "Akashic Arts": 0,
             "Matarukaja": 0,
             "Rising Slash": 0,
             "Diarahan": 51,
@@ -3913,7 +4131,7 @@ const personaMapRoyal: PersonaMap = {
         "dlc": true
     },
     "Izanagi": {
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "White Headband",
         "itemr": "White Headband R",
         "level": 20,
@@ -3933,7 +4151,7 @@ const personaMapRoyal: PersonaMap = {
         "dlc": true
     },
     "Izanagi Picaro": {
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Growth 2",
         "itemr": "Growth 3",
         "skillCard": true,
@@ -3955,7 +4173,7 @@ const personaMapRoyal: PersonaMap = {
     },
     "Izanagi-no-Okami": {
         "special": true,
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Shiny Belt",
         "itemr": "Shiny Belt R",
         "level": 80,
@@ -3977,7 +4195,7 @@ const personaMapRoyal: PersonaMap = {
     },
     "Izanagi-no-Okami Picaro": {
         "special": true,
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Mediarahan",
         "itemr": "Salvation",
         "skillCard": true,
@@ -3999,7 +4217,7 @@ const personaMapRoyal: PersonaMap = {
         "dlc": true
     },
     "Kaguya": {
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Moonlight Robe",
         "itemr": "Moonlight Robe R",
         "level": 16,
@@ -4019,7 +4237,7 @@ const personaMapRoyal: PersonaMap = {
         "dlc": true
     },
     "Kaguya Picaro": {
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Diarahan",
         "itemr": "Mediarahan",
         "skillCard": true,
@@ -4040,7 +4258,7 @@ const personaMapRoyal: PersonaMap = {
         "dlc": true
     },
     "Magatsu-Izanagi": {
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Black Headband",
         "itemr": "Black Headband R",
         "level": 44,
@@ -4060,7 +4278,7 @@ const personaMapRoyal: PersonaMap = {
         "dlc": true
     },
     "Magatsu-Izanagi Picaro": {
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Heat Riser",
         "itemr": "Debilitate",
         "skillCard": true,
@@ -4081,7 +4299,7 @@ const personaMapRoyal: PersonaMap = {
         "dlc": true
     },
     "Messiah": {
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Sirius Armor",
         "itemr": "Sirius Armor EX",
         "level": 81,
@@ -4102,7 +4320,7 @@ const personaMapRoyal: PersonaMap = {
         "dlc": true
     },
     "Messiah Picaro": {
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Insta-Heal",
         "itemr": "Firm Stance",
         "skillCard": true,
@@ -4124,7 +4342,7 @@ const personaMapRoyal: PersonaMap = {
         "dlc": true
     },
     "Orpheus": {
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Hades Harp",
         "itemr": "Hades Harp R",
         "level": 26,
@@ -4144,7 +4362,7 @@ const personaMapRoyal: PersonaMap = {
         "dlc": true
     },
     "Orpheus F": {
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Graceful Harp",
         "itemr": "Graceful Harp R",
         "level": 11,
@@ -4164,7 +4382,7 @@ const personaMapRoyal: PersonaMap = {
         "dlc": true
     },
     "Orpheus F Picaro": {
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Endure",
         "itemr": "Enduring Soul",
         "skillCard": true,
@@ -4185,7 +4403,7 @@ const personaMapRoyal: PersonaMap = {
         "dlc": true
     },
     "Orpheus Picaro": {
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Agidyne",
         "itemr": "Maragidyne",
         "skillCard": true,
@@ -4206,7 +4424,7 @@ const personaMapRoyal: PersonaMap = {
         "dlc": true
     },
     "Raoul": {
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Picaresque Hat",
         "itemr": "Picaresque Crown",
         "level": 76,
@@ -4227,7 +4445,7 @@ const personaMapRoyal: PersonaMap = {
         "dlc": true
     },
     "Thanatos": {
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Darkness Ring",
         "itemr": "Darkness Ring R",
         "level": 65,
@@ -4247,7 +4465,7 @@ const personaMapRoyal: PersonaMap = {
         "dlc": true
     },
     "Thanatos Picaro": {
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Maeigaon",
         "itemr": "Demonic Decree",
         "skillCard": true,
@@ -4268,7 +4486,7 @@ const personaMapRoyal: PersonaMap = {
         "dlc": true
     },
     "Tsukiyomi": {
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Black Moon",
         "itemr": "Black Moon R",
         "level": 50,
@@ -4288,7 +4506,7 @@ const personaMapRoyal: PersonaMap = {
         "dlc": true
     },
     "Tsukiyomi Picaro": {
-        "inherits": "almighty",
+        "inherits": "Almighty",
         "item": "Spell Master",
         "itemr": "Arms Master",
         "skillCard": true,

--- a/data/SkillData.js
+++ b/data/SkillData.js
@@ -80,7 +80,7 @@ var skillMap = {
     },
     "Agi": {
         "cost": 400,
-        "effect": "Deal weak Fire damage to 1 foe.",
+        "effect": "Deal light Fire damage to 1 foe.",
         "element": "fire",
         "personas": {
             "Hua Po": 0,
@@ -128,7 +128,7 @@ var skillMap = {
     },
     "Agneyastra": {
         "cost": 24,
-        "effect": "Deal 1 to 3 times medium Phys damage to all foes.",
+        "effect": "Deal medium Phys damage to all foes 1 to 3 times.",
         "element": "phys",
         "fuse": "Ardha",
         "personas": {
@@ -470,7 +470,7 @@ var skillMap = {
     },
     "Bufu": {
         "cost": 400,
-        "effect": "Deal weak Ice damage to 1 foe.",
+        "effect": "Deal light Ice damage to 1 foe.",
         "element": "ice",
         "fuse": "Koropokguru",
         "personas": {
@@ -539,7 +539,7 @@ var skillMap = {
     },
     "Cleave": {
         "cost": 6,
-        "effect": "Deal weak Phys damage to 1 foe.",
+        "effect": "Deal light Phys damage to 1 foe.",
         "element": "phys",
         "fuse": "Berith",
         "personas": {
@@ -598,7 +598,7 @@ var skillMap = {
     "Cross Slash": {
         "cost": 20,
         "dlc": true,
-        "effect": "Deal 2 times heavy Phys damage to 1 foe. High accuracy.",
+        "effect": "Deal heavy Phys damage to 1 foe 2 times. High accuracy.",
         "element": "phys",
         "personas": {
             "Izanagi": 0,
@@ -664,7 +664,7 @@ var skillMap = {
     },
     "Deathbound": {
         "cost": 22,
-        "effect": "Deal 1 to 2 times medium Phys damage to all foes.",
+        "effect": "Deal medium Phys damage to all foes 1 to 2 times.",
         "element": "phys",
         "fuse": "Dakini",
         "personas": {
@@ -990,7 +990,7 @@ var skillMap = {
     },
     "Double Fangs": {
         "cost": 10,
-        "effect": "Deal 2 times medium Phys damage to 1 foe.",
+        "effect": "Deal medium Phys damage to 1 foe 2 times.",
         "element": "phys",
         "personas": {
             "Berith": 10,
@@ -1042,7 +1042,7 @@ var skillMap = {
     },
     "Eiha": {
         "cost": 400,
-        "effect": "Deal weak Curse damage to 1 foe.",
+        "effect": "Deal light Curse damage to 1 foe.",
         "element": "curse",
         "personas": {
             "Arsène": 1,
@@ -1358,7 +1358,7 @@ var skillMap = {
     },
     "Frei": {
         "cost": 400,
-        "effect": "Deal weak Nuclear damage to 1 foe.",
+        "effect": "Deal light Nuclear damage to 1 foe.",
         "element": "nuclear",
         "personas": {
             "Makami": 0,
@@ -1393,7 +1393,7 @@ var skillMap = {
     },
     "Garu": {
         "cost": 300,
-        "effect": "Deal weak Wind damage to 1 foe.",
+        "effect": "Deal light Wind damage to 1 foe.",
         "element": "wind",
         "fuse": "Bicorn",
         "personas": {
@@ -1565,7 +1565,7 @@ var skillMap = {
     },
     "Hassou Tobi": {
         "cost": 25,
-        "effect": "Deal 8 times weak Phys damage to all foes.",
+        "effect": "Deal light Phys damage to all foes 8 times.",
         "element": "phys",
         "personas": {
             "Yoshitsune": 86
@@ -1795,7 +1795,7 @@ var skillMap = {
     },
     "Kouha": {
         "cost": 400,
-        "effect": "Deal weak Bless damage to 1 foe.",
+        "effect": "Deal light Bless damage to 1 foe.",
         "element": "bless",
         "personas": {
             "Angel": 13
@@ -1826,7 +1826,7 @@ var skillMap = {
     },
     "Lunge": {
         "cost": 5,
-        "effect": "Deal weak Phys damage to 1 foe.",
+        "effect": "Deal light Phys damage to 1 foe.",
         "element": "phys",
         "personas": {
             "Agathion": 4,
@@ -1849,7 +1849,7 @@ var skillMap = {
     },
     "Mabufu": {
         "cost": 1000,
-        "effect": "Deal weak Ice damage to all foes.",
+        "effect": "Deal light Ice damage to all foes.",
         "element": "ice",
         "fuse": "Sui-Ki",
         "personas": {
@@ -1927,7 +1927,7 @@ var skillMap = {
     },
     "Maeiha": {
         "cost": 1000,
-        "effect": "Deal weak Curse damage to all foes.",
+        "effect": "Deal light Curse damage to all foes.",
         "element": "curse",
         "fuse": "Choronzon",
         "personas": {
@@ -1938,7 +1938,7 @@ var skillMap = {
     },
     "Mafrei": {
         "cost": 1000,
-        "effect": "Deal weak Nuclear damage to all foes.",
+        "effect": "Deal light Nuclear damage to all foes.",
         "element": "nuclear",
         "fuse": "Suzaku",
         "personas": {
@@ -2143,7 +2143,7 @@ var skillMap = {
     },
     "Makouha": {
         "cost": 1000,
-        "effect": "Deal weak Bless damage to all foes.",
+        "effect": "Deal light Bless damage to all foes.",
         "element": "bless",
         "fuse": "Anubis",
         "personas": {
@@ -2183,7 +2183,7 @@ var skillMap = {
     },
     "Mapsi": {
         "cost": 1000,
-        "effect": "Deal weak Psy damage to all foes.",
+        "effect": "Deal light Psy damage to all foes.",
         "element": "psy",
         "personas": {
             "Leanan Sidhe": 22,
@@ -2219,7 +2219,7 @@ var skillMap = {
     },
     "Maragi": {
         "cost": 1000,
-        "effect": "Deal weak Fire damage to all foes.",
+        "effect": "Deal light Fire damage to all foes.",
         "element": "fire",
         "fuse": "Orobas",
         "personas": {
@@ -2378,7 +2378,7 @@ var skillMap = {
     },
     "Mazio": {
         "cost": 1000,
-        "effect": "Deal weak Electric damage to all foes.",
+        "effect": "Deal light Electric damage to all foes.",
         "element": "electric",
         "fuse": "Shiisaa",
         "personas": {
@@ -2901,7 +2901,7 @@ var skillMap = {
     },
     "Psi": {
         "cost": 400,
-        "effect": "Deal weak Psy damage to 1 foe.",
+        "effect": "Deal light Psy damage to 1 foe.",
         "element": "psy",
         "personas": {
             "Archangel": 0,
@@ -3030,7 +3030,7 @@ var skillMap = {
     },
     "Myriad Slashes": {
         "cost": 20,
-        "effect": "Deal 2 to 3 times medium Phys damage to 1 foe.",
+        "effect": "Deal medium Phys damage to 1 foe 2 to 3 times.",
         "element": "phys",
         "fuse": "Ongyo-Ki",
         "personas": {
@@ -3089,7 +3089,7 @@ var skillMap = {
     },
     "Rampage": {
         "cost": 13,
-        "effect": "Deal 1 to 3 times weak Phys damage to all foes.",
+        "effect": "Deal light Phys damage to all foes 1 to 3 times.",
         "element": "phys",
         "fuse": "Oni",
         "personas": {
@@ -3457,7 +3457,7 @@ var skillMap = {
     "Shining Arrows": {
         "cost": 2200,
         "dlc": true,
-        "effect": "Deal 4 to 8 times weak Bless damage to all foes.",
+        "effect": "Deal light Bless damage to all foes 4 to 8 times.",
         "element": "bless",
         "personas": {
             "Kaguya": 0,
@@ -3633,7 +3633,7 @@ var skillMap = {
     },
     "Swift Strike": {
         "cost": 17,
-        "effect": "Deal 3 to 4 times weak Phys damage to all foes.",
+        "effect": "Deal weak Phys damage to all foes 3 to 4 times.",
         "element": "phys",
         "fuse": "Byakko",
         "personas": {
@@ -3698,7 +3698,7 @@ var skillMap = {
     },
     "Tempest Slash": {
         "cost": 17,
-        "effect": "Deal 3 to 5 times minuscule Phys damage to 1 foe.",
+        "effect": "Deal minuscule Phys damage to 1 foe 3 to 5 times.",
         "element": "phys",
         "fuse": "Scathach",
         "personas": {
@@ -3797,7 +3797,7 @@ var skillMap = {
     },
     "Ayamur": {
         "cost": 25,
-        "effect": "Deal 3 times medium Phys damage to 1 foe. High critical rate.",
+        "effect": "Deal medium Phys damage to 1 foe 3 times. High critical rate.",
         "element": "phys",
         "personas": {
             "Baal": 80
@@ -3835,7 +3835,7 @@ var skillMap = {
     },
     "Triple Down": {
         "cost": 16,
-        "effect": "Deal 3 times small Gun damage to all foes.",
+        "effect": "Deal light Gun damage to all foes 3 times.",
         "element": "gun",
         "fuse": "White Rider",
         "personas": {
@@ -3982,7 +3982,7 @@ var skillMap = {
     },
     "Zio": {
         "cost": 400,
-        "effect": "Deal weak Electric damage to 1 foe.",
+        "effect": "Deal light Electric damage to 1 foe.",
         "element": "electric",
         "fuse": "Agathion",
         "personas": {

--- a/data/SkillData.ts
+++ b/data/SkillData.ts
@@ -109,7 +109,7 @@ const skillMap: SkillMap = {
     },
     "Agi": {
         "cost": 400,
-        "effect": "Deal weak Fire damage to 1 foe.",
+        "effect": "Deal light Fire damage to 1 foe.",
         "element": "fire",
         "personas": {
             "Hua Po": 0,
@@ -157,7 +157,7 @@ const skillMap: SkillMap = {
     },
     "Agneyastra": {
         "cost": 24,
-        "effect": "Deal 1 to 3 times medium Phys damage to all foes.",
+        "effect": "Deal medium Phys damage to all foes 1 to 3 times.",
         "element": "phys",
         "fuse": "Ardha",
         "personas": {
@@ -499,7 +499,7 @@ const skillMap: SkillMap = {
     },
     "Bufu": {
         "cost": 400,
-        "effect": "Deal weak Ice damage to 1 foe.",
+        "effect": "Deal light Ice damage to 1 foe.",
         "element": "ice",
         "fuse": "Koropokguru",
         "personas": {
@@ -568,7 +568,7 @@ const skillMap: SkillMap = {
     },
     "Cleave": {
         "cost": 6,
-        "effect": "Deal weak Phys damage to 1 foe.",
+        "effect": "Deal light Phys damage to 1 foe.",
         "element": "phys",
         "fuse": "Berith",
         "personas": {
@@ -627,7 +627,7 @@ const skillMap: SkillMap = {
     "Cross Slash": {
         "cost": 20,
         "dlc": true,
-        "effect": "Deal 2 times heavy Phys damage to 1 foe. High accuracy.",
+        "effect": "Deal heavy Phys damage to 1 foe 2 times. High accuracy.",
         "element": "phys",
         "personas": {
             "Izanagi": 0,
@@ -693,7 +693,7 @@ const skillMap: SkillMap = {
     },
     "Deathbound": {
         "cost": 22,
-        "effect": "Deal 1 to 2 times medium Phys damage to all foes.",
+        "effect": "Deal medium Phys damage to all foes 1 to 2 times.",
         "element": "phys",
         "fuse": "Dakini",
         "personas": {
@@ -1019,7 +1019,7 @@ const skillMap: SkillMap = {
     },
     "Double Fangs": {
         "cost": 10,
-        "effect": "Deal 2 times medium Phys damage to 1 foe.",
+        "effect": "Deal medium Phys damage to 1 foe 2 times.",
         "element": "phys",
         "personas": {
             "Berith": 10,
@@ -1071,7 +1071,7 @@ const skillMap: SkillMap = {
     },
     "Eiha": {
         "cost": 400,
-        "effect": "Deal weak Curse damage to 1 foe.",
+        "effect": "Deal light Curse damage to 1 foe.",
         "element": "curse",
         "personas": {
             "Arsène": 1,
@@ -1387,7 +1387,7 @@ const skillMap: SkillMap = {
     },
     "Frei": {
         "cost": 400,
-        "effect": "Deal weak Nuclear damage to 1 foe.",
+        "effect": "Deal light Nuclear damage to 1 foe.",
         "element": "nuclear",
         "personas": {
             "Makami": 0,
@@ -1422,7 +1422,7 @@ const skillMap: SkillMap = {
     },
     "Garu": {
         "cost": 300,
-        "effect": "Deal weak Wind damage to 1 foe.",
+        "effect": "Deal light Wind damage to 1 foe.",
         "element": "wind",
         "fuse": "Bicorn",
         "personas": {
@@ -1594,7 +1594,7 @@ const skillMap: SkillMap = {
     },
     "Hassou Tobi": {
         "cost": 25,
-        "effect": "Deal 8 times weak Phys damage to all foes.",
+        "effect": "Deal light Phys damage to all foes 8 times.",
         "element": "phys",
         "personas": {
             "Yoshitsune": 86
@@ -1824,7 +1824,7 @@ const skillMap: SkillMap = {
     },
     "Kouha": {
         "cost": 400,
-        "effect": "Deal weak Bless damage to 1 foe.",
+        "effect": "Deal light Bless damage to 1 foe.",
         "element": "bless",
         "personas": {
             "Angel": 13
@@ -1855,7 +1855,7 @@ const skillMap: SkillMap = {
     },
     "Lunge": {
         "cost": 5,
-        "effect": "Deal weak Phys damage to 1 foe.",
+        "effect": "Deal light Phys damage to 1 foe.",
         "element": "phys",
         "personas": {
             "Agathion": 4,
@@ -1878,7 +1878,7 @@ const skillMap: SkillMap = {
     },
     "Mabufu": {
         "cost": 1000,
-        "effect": "Deal weak Ice damage to all foes.",
+        "effect": "Deal light Ice damage to all foes.",
         "element": "ice",
         "fuse": "Sui-Ki",
         "personas": {
@@ -1956,7 +1956,7 @@ const skillMap: SkillMap = {
     },
     "Maeiha": {
         "cost": 1000,
-        "effect": "Deal weak Curse damage to all foes.",
+        "effect": "Deal light Curse damage to all foes.",
         "element": "curse",
         "fuse": "Choronzon",
         "personas": {
@@ -1967,7 +1967,7 @@ const skillMap: SkillMap = {
     },
     "Mafrei": {
         "cost": 1000,
-        "effect": "Deal weak Nuclear damage to all foes.",
+        "effect": "Deal light Nuclear damage to all foes.",
         "element": "nuclear",
         "fuse": "Suzaku",
         "personas": {
@@ -2172,7 +2172,7 @@ const skillMap: SkillMap = {
     },
     "Makouha": {
         "cost": 1000,
-        "effect": "Deal weak Bless damage to all foes.",
+        "effect": "Deal light Bless damage to all foes.",
         "element": "bless",
         "fuse": "Anubis",
         "personas": {
@@ -2212,7 +2212,7 @@ const skillMap: SkillMap = {
     },
     "Mapsi": {
         "cost": 1000,
-        "effect": "Deal weak Psy damage to all foes.",
+        "effect": "Deal light Psy damage to all foes.",
         "element": "psy",
         "personas": {
             "Leanan Sidhe": 22,
@@ -2248,7 +2248,7 @@ const skillMap: SkillMap = {
     },
     "Maragi": {
         "cost": 1000,
-        "effect": "Deal weak Fire damage to all foes.",
+        "effect": "Deal light Fire damage to all foes.",
         "element": "fire",
         "fuse": "Orobas",
         "personas": {
@@ -2407,7 +2407,7 @@ const skillMap: SkillMap = {
     },
     "Mazio": {
         "cost": 1000,
-        "effect": "Deal weak Electric damage to all foes.",
+        "effect": "Deal light Electric damage to all foes.",
         "element": "electric",
         "fuse": "Shiisaa",
         "personas": {
@@ -2930,7 +2930,7 @@ const skillMap: SkillMap = {
     },
     "Psi": {
         "cost": 400,
-        "effect": "Deal weak Psy damage to 1 foe.",
+        "effect": "Deal light Psy damage to 1 foe.",
         "element": "psy",
         "personas": {
             "Archangel": 0,
@@ -3059,7 +3059,7 @@ const skillMap: SkillMap = {
     },
     "Myriad Slashes": {
         "cost": 20,
-        "effect": "Deal 2 to 3 times medium Phys damage to 1 foe.",
+        "effect": "Deal medium Phys damage to 1 foe 2 to 3 times.",
         "element": "phys",
         "fuse": "Ongyo-Ki",
         "personas": {
@@ -3118,7 +3118,7 @@ const skillMap: SkillMap = {
     },
     "Rampage": {
         "cost": 13,
-        "effect": "Deal 1 to 3 times weak Phys damage to all foes.",
+        "effect": "Deal light Phys damage to all foes 1 to 3 times.",
         "element": "phys",
         "fuse": "Oni",
         "personas": {
@@ -3486,7 +3486,7 @@ const skillMap: SkillMap = {
     "Shining Arrows": {
         "cost": 2200,
         "dlc": true,
-        "effect": "Deal 4 to 8 times weak Bless damage to all foes.",
+        "effect": "Deal light Bless damage to all foes 4 to 8 times.",
         "element": "bless",
         "personas": {
             "Kaguya": 0,
@@ -3662,7 +3662,7 @@ const skillMap: SkillMap = {
     },
     "Swift Strike": {
         "cost": 17,
-        "effect": "Deal 3 to 4 times weak Phys damage to all foes.",
+        "effect": "Deal weak Phys damage to all foes 3 to 4 times.",
         "element": "phys",
         "fuse": "Byakko",
         "personas": {
@@ -3727,7 +3727,7 @@ const skillMap: SkillMap = {
     },
     "Tempest Slash": {
         "cost": 17,
-        "effect": "Deal 3 to 5 times minuscule Phys damage to 1 foe.",
+        "effect": "Deal minuscule Phys damage to 1 foe 3 to 5 times.",
         "element": "phys",
         "fuse": "Scathach",
         "personas": {
@@ -3826,7 +3826,7 @@ const skillMap: SkillMap = {
     },
     "Ayamur": {
         "cost": 25,
-        "effect": "Deal 3 times medium Phys damage to 1 foe. High critical rate.",
+        "effect": "Deal medium Phys damage to 1 foe 3 times. High critical rate.",
         "element": "phys",
         "personas": {
             "Baal": 80
@@ -3864,7 +3864,7 @@ const skillMap: SkillMap = {
     },
     "Triple Down": {
         "cost": 16,
-        "effect": "Deal 3 times small Gun damage to all foes.",
+        "effect": "Deal light Gun damage to all foes 3 times.",
         "element": "gun",
         "fuse": "White Rider",
         "personas": {
@@ -4011,7 +4011,7 @@ const skillMap: SkillMap = {
     },
     "Zio": {
         "cost": 400,
-        "effect": "Deal weak Electric damage to 1 foe.",
+        "effect": "Deal light Electric damage to 1 foe.",
         "element": "electric",
         "fuse": "Agathion",
         "personas": {

--- a/data/SkillDataRoyal.js
+++ b/data/SkillDataRoyal.js
@@ -68,14 +68,14 @@ var skillMapRoyal = {
         "unique": "Necronomicon"
     },
     "Adverse Resolve": {
-        "effect": "Increase critical rate when being ambushed.",
+        "effect": "Increase critical rate when surrounded.",
         "element": "passive",
         "personas": { "Arsène": 7, "Jikokuten": 28, "Rakshasa": 30, "Raphael": 82, "Thanatos Picaro": 73 },
         "talk": "Battle Fiend (Rakshasa)"
     },
     "Agi": {
         "cost": 400,
-        "effect": "Deal weak Fire damage to 1 foe.",
+        "effect": "Deal light Fire damage to 1 foe.",
         "element": "fire",
         "personas": { "Cait Sith": 0, "Hua Po": 0, "Jack-o'-Lantern": 0, "Onmoraki": 13, "Succubus": 8, "Orpheus F": 0 },
         "talk": "Crypt-Dwelling Pyromaniac (Jack-o'-Lantern)"
@@ -116,7 +116,7 @@ var skillMapRoyal = {
     },
     "Agneyastra": {
         "cost": 24,
-        "effect": "Deal 1 to 3 times medium Phys damage to all foes.",
+        "effect": "Deal medium Phys damage to all foes 1 to 3 times.",
         "element": "phys",
         "fuse": ["Asterius Picaro"],
         "personas": { "Ardha": 87, "Ongyo-Ki": 95, "Messiah Picaro": 0 }
@@ -131,9 +131,9 @@ var skillMapRoyal = {
         "element": "trait",
         "personas": { "Crystal Skull": 0, "Fafnir": 0, "Macabre": 0, "Mishaguji": 0, "Red Rider": 0 }
     },
-    "Akasha Arts": {
+    "Akashic Arts": {
         "cost": 20,
-        "effect": "Deal 1-2 times severe Phys damage to all foes.",
+        "effect": "Deal severe Phys damage to all foes 1-2 times.",
         "element": "phys",
         "unique": "Athena",
         "personas": { "Athena": 0, "Athena Picaro": 0 }
@@ -301,7 +301,7 @@ var skillMapRoyal = {
     "Ave Maria": { "effect": "Reduces costs of Support spells by 75%", "element": "trait", "personas": { "Maria": 0 } },
     "Ayamur": {
         "cost": 25,
-        "effect": "Deal 3 times medium Phys damage to 1 foe. High accuracy.",
+        "effect": "Deal medium Phys damage to 1 foe 3 times. High accuracy.",
         "element": "phys",
         "unique": "Baal",
         "personas": { "Baal": 84 }
@@ -321,7 +321,7 @@ var skillMapRoyal = {
     "Bargain Bolts": { "effect": "Reduces costs of Elec skills by 75%", "element": "trait", "personas": { "Odin": 0 } },
     "Beast Weaver": {
         "cost": 20,
-        "effect": "Deal grave Phys damage to 1 foe and user is debuffed with Tarunda.",
+        "effect": "Deal colossal Phys damage to 1 foe and user is debuffed with Tarunda.",
         "element": "phys",
         "unique": "Ariadne",
         "personas": { "Ariadne": 0, "Ariadne Picaro": 0 }
@@ -355,7 +355,7 @@ var skillMapRoyal = {
     "Bless Boost": {
         "effect": "Strengthen (non instant death) Bless attacks by 25%.",
         "element": "passive",
-        "personas": { "Daisoujou": 42, "Mithra": 36, "Power": 44, "Principality": 34 }
+        "personas": { "Daisoujou": 42, "Mitra": 36, "Power": 44, "Principality": 34 }
     },
     "Blessed Bloodline": {
         "effect": "Halves costs of Bless skills",
@@ -363,7 +363,7 @@ var skillMapRoyal = {
         "personas": {
             "Barong": 0,
             "Dominion": 0,
-            "Mithra": 0,
+            "Mitra": 0,
             "Orichalcum": 0,
             "Principality": 0,
             "Sraosha": 0,
@@ -438,7 +438,7 @@ var skillMapRoyal = {
     },
     "Brave Blade": {
         "cost": 24,
-        "effect": "Deal grave Phys damage to 1 foe.",
+        "effect": "Deal colossal Phys damage to 1 foe.",
         "element": "phys",
         "personas": {
             "Atavaka": 70,
@@ -460,7 +460,7 @@ var skillMapRoyal = {
     },
     "Bufu": {
         "cost": 400,
-        "effect": "Deal weak Ice damage to 1 foe.",
+        "effect": "Deal light Ice damage to 1 foe.",
         "element": "ice",
         "personas": { "Apsaras": 0, "Genbu": 0, "Jack Frost": 0, "Koropokkuru": 0, "Saki Mitama": 0, "Silky": 0 },
         "talk": "Mocking Snowman (Jack Frost)"
@@ -554,7 +554,7 @@ var skillMapRoyal = {
     },
     "Cleave": {
         "cost": 6,
-        "effect": "Deal weak Phys damage to 1 foe.",
+        "effect": "Deal light Phys damage to 1 foe.",
         "element": "phys",
         "personas": { "Arsène": 2, "Berith": 0, "Cait Sith": 0 },
         "talk": "Hunting Puss in Boots (Cait Sith)"
@@ -617,7 +617,7 @@ var skillMapRoyal = {
     },
     "Cornered Fang": {
         "cost": 10,
-        "effect": "Deal medium Phys damage to 1 foe. More powerful when being ambushed.",
+        "effect": "Deal medium Phys damage to 1 foe. More powerful when surrounded.",
         "element": "phys",
         "fuse": ["Shiisaa"],
         "personas": { "Flauros": 23, "Neko Shogun": 33, "Orthrus": 24 }
@@ -653,7 +653,7 @@ var skillMapRoyal = {
     },
     "Cross Slash": {
         "cost": 20,
-        "effect": "Deal 2 times heavy Phys damage to 1 foe. High accuracy.",
+        "effect": "Deal heavy Phys damage to 1 foe 2 times. High accuracy.",
         "element": "phys",
         "unique": "Izanagi",
         "personas": { "Izanagi": 0, "Izanagi Picaro": 0 }
@@ -696,7 +696,7 @@ var skillMapRoyal = {
     },
     "Deathbound": {
         "cost": 22,
-        "effect": "Deal 1 to 2 times medium Phys damage to all foes.",
+        "effect": "Deal medium Phys damage to all foes 1 to 2 times.",
         "element": "phys",
         "fuse": ["Girimehkala"],
         "personas": {
@@ -762,7 +762,7 @@ var skillMapRoyal = {
         "cost": 1000,
         "effect": "Negate all -nda debuff effects of party.",
         "element": "support",
-        "personas": { "Angel": 12, "Anubis": 37, "Mithra": 35, "Mokoi": 14, "Suzaku": 18, "Unicorn": 0, "Yatagarasu": 0 }
+        "personas": { "Angel": 12, "Anubis": 37, "Mitra": 35, "Mokoi": 14, "Suzaku": 18, "Unicorn": 0, "Yatagarasu": 0 }
     },
     "Demon's Bite": { "effect": "Doubles own HP recovery", "element": "trait", "personas": { "Ongyo-Ki": 0 } },
     "Demonic Decree": {
@@ -821,7 +821,7 @@ var skillMapRoyal = {
             "High Pixie": 19,
             "Horus": 0,
             "Isis": 0,
-            "Mithra": 0,
+            "Mitra": 0,
             "Neko Shogun": 0,
             "Nigi Mitama": 0,
             "Parvati": 0,
@@ -930,14 +930,14 @@ var skillMapRoyal = {
     },
     "Double Fangs": {
         "cost": 10,
-        "effect": "Deal 2 times medium Phys damage to 1 foe.",
+        "effect": "Deal medium Phys damage to 1 foe 2 times.",
         "element": "phys",
         "personas": { "Eligor": 18, "Makami": 0, "Orthrus": 0, "Shiisaa": 0 },
         "talk": "Twin-Headed Guardian (Orthrus)"
     },
     "Double Shot": {
         "cost": 12,
-        "effect": "Deal 2 times light Gun damage to 1 foe.",
+        "effect": "Deal light Gun damage to 1 foe 2 times.",
         "element": "gun",
         "personas": { "Kurama Tengu": 0, "Matador": 20, "Shiki-Ouji": 0 },
         "talk": "Bringer of Misfortune (Shiki-Ouji)"
@@ -949,7 +949,7 @@ var skillMapRoyal = {
     },
     "Dream Needle": {
         "cost": 8,
-        "effect": "Deal weak Gun damage and inflict Sleep (medium odds) to 1 foe.",
+        "effect": "Deal light Gun damage and inflict Sleep (medium odds) to 1 foe.",
         "element": "gun",
         "personas": { "Arsène": 5, "Incubus": 0, "Inugami": 15, "Phoenix": 0, "Pisaca": 0 }
     },
@@ -986,7 +986,7 @@ var skillMapRoyal = {
     },
     "Eiha": {
         "cost": 400,
-        "effect": "Deal weak Curse damage to 1 foe.",
+        "effect": "Deal light Curse damage to 1 foe.",
         "element": "curse",
         "personas": { "Arsène": 0, "Onmoraki": 0 }
     },
@@ -1289,7 +1289,7 @@ var skillMapRoyal = {
     "Frei": {
         "card": "CJ Theater",
         "cost": 400,
-        "effect": "Deal weak Nuclear damage to 1 foe.",
+        "effect": "Deal light Nuclear damage to 1 foe.",
         "element": "nuclear",
         "personas": { "Makami": 0, "Shiisaa": 0, "Suzaku": 0 },
         "talk": "Rooftop Lion (Shiisaa)"
@@ -1345,7 +1345,7 @@ var skillMapRoyal = {
     },
     "Garu": {
         "cost": 300,
-        "effect": "Deal weak Wind damage to 1 foe.",
+        "effect": "Deal light Wind damage to 1 foe.",
         "element": "wind",
         "personas": { "Bicorn": 6, "High Pixie": 0, "Kelpie": 0, "Kodama": 0, "Koppa Tengu": 0 },
         "talk": "Mad Marsh Horse (Kelpie)"
@@ -1365,9 +1365,9 @@ var skillMapRoyal = {
         "personas": { "Anzu": 0, "Fuu-Ki": 0, "Sandman": 0, "Stone of Scone": 0 },
         "talk": "Tornado Devil (Fuu-Ki)"
     },
-    "Gattling Blows": {
+    "Gatling Blows": {
         "cost": 16,
-        "effect": "Deal 3 to 4 times light Phys damage to 1 foe.",
+        "effect": "Deal light Phys damage to 1 foe 3 to 4 times.",
         "element": "phys",
         "personas": { "Hecatoncheires": 49 }
     },
@@ -1399,7 +1399,7 @@ var skillMapRoyal = {
     },
     "Gigantomachia": {
         "cost": 25,
-        "effect": "Deal grave Phys damage to all foes.",
+        "effect": "Deal colossal Phys damage to all foes.",
         "element": "phys",
         "personas": {
             "Abaddon": 81,
@@ -1440,7 +1440,7 @@ var skillMapRoyal = {
     },
     "God's Hand": {
         "cost": 25,
-        "effect": "Deal grave Phys damage to 1 foe.",
+        "effect": "Deal colossal Phys damage to 1 foe.",
         "element": "phys",
         "fuse": ["Cerberus"],
         "personas": { "Ardha": 0, "Bishamonten": 73, "Melchizedek": 65, "Zaou-Gongen": 0, "Messiah": 0 }
@@ -1524,7 +1524,7 @@ var skillMapRoyal = {
     },
     "Hassou Tobi": {
         "cost": 25,
-        "effect": "Deal 8 times weak Phys damage to all foes.",
+        "effect": "Deal light Phys damage to all foes 8 times.",
         "element": "phys",
         "unique": "Yoshitsune",
         "personas": { "Yoshitsune": 94 }
@@ -1766,7 +1766,7 @@ var skillMapRoyal = {
     "Just Die": { "effect": "Reduces costs of instant death skills to 0", "element": "trait", "personas": { "Alice": 0 } },
     "Kill Rush": {
         "cost": 14,
-        "effect": "Deal 1-3 times light Phys damage to 1 foe.",
+        "effect": "Deal light Phys damage to 1 foe 1-3 times.",
         "element": "phys",
         "fuse": ["Oni"],
         "personas": { "Jikokuten": 24, "Zouchouten": 0 }
@@ -1775,7 +1775,7 @@ var skillMapRoyal = {
         "cost": 800,
         "effect": "Deal medium Bless damage to 1 foe.",
         "element": "bless",
-        "personas": { "Mithra": 0, "Stone of Scone": 0 },
+        "personas": { "Mitra": 0, "Stone of Scone": 0 },
         "talk": "Expressionless Beast (Unicorn)"
     },
     "Kougaon": {
@@ -1787,7 +1787,7 @@ var skillMapRoyal = {
     },
     "Kouha": {
         "cost": 400,
-        "effect": "Deal weak Bless damage to 1 foe.",
+        "effect": "Deal light Bless damage to 1 foe.",
         "element": "bless",
         "personas": { "Angel": 0 },
         "talk": "Heavenly Punisher (Archangel)"
@@ -1795,7 +1795,7 @@ var skillMapRoyal = {
     "Kuzunoha's Order": { "effect": "Reduces skill costs by 25%", "element": "passive" },
     "Laevateinn": { "cost": 25, "effect": "Colossal damage to 1 foe", "element": "phys", "unique": "Loki" },
     "Last Stand": {
-        "effect": "Reduces enemy hit rate by 2/3 when ambushed",
+        "effect": "Reduces enemy hit rate by 2/3 when surrounded",
         "element": "passive",
         "personas": { "Ongyo-Ki": 0, "Red Rider": 46, "Yatagarasu": 60, "Yoshitsune": 89 }
     },
@@ -1841,7 +1841,7 @@ var skillMapRoyal = {
     },
     "Lunge": {
         "cost": 5,
-        "effect": "Deal weak Phys damage to 1 foe.",
+        "effect": "Deal light Phys damage to 1 foe.",
         "element": "phys",
         "personas": { "Agathion": 4, "Bicorn": 0, "Kelpie": 0, "Mandrake": 4, "Slime": 0 },
         "talk": "Dirty Two-Horned Beast (Bicorn)"
@@ -1855,7 +1855,7 @@ var skillMapRoyal = {
     "Mabufu": {
         "card": "CJ BBB",
         "cost": 1000,
-        "effect": "Deal weak Ice damage to all foes.",
+        "effect": "Deal light Ice damage to all foes.",
         "element": "ice",
         "fuse": ["Koropokkuru"],
         "personas": { "Genbu": 10, "Jack Frost": 12, "Koropokkuru": 14, "Regent": 0, "Sui-Ki": 0 },
@@ -1918,13 +1918,13 @@ var skillMapRoyal = {
     },
     "Maeiha": {
         "cost": 1000,
-        "effect": "Deal weak Curse damage to all foes.",
+        "effect": "Deal light Curse damage to all foes.",
         "element": "curse",
         "personas": { "Choronzon": 29, "Nue": 0, "Regent": 0 }
     },
     "Mafrei": {
         "cost": 1000,
-        "effect": "Deal weak Nuclear damage to all foes.",
+        "effect": "Deal light Nuclear damage to all foes.",
         "element": "nuclear",
         "fuse": ["Makami"],
         "personas": { "Makami": 17, "Regent": 0, "Suzaku": 19 },
@@ -2000,7 +2000,7 @@ var skillMapRoyal = {
         "cost": 1400,
         "element": "bless",
         "fuse": ["Archangel"],
-        "personas": { "Clotho": 0, "Isis": 0, "Mithra": 0, "Unicorn": 0 },
+        "personas": { "Clotho": 0, "Isis": 0, "Mitra": 0, "Unicorn": 0 },
         "talk": "She of Life and Death (Isis)"
     },
     "Mahamaon": {
@@ -2077,7 +2077,7 @@ var skillMapRoyal = {
         "effect": "Deal medium Bless damage to all foes.",
         "element": "bless",
         "fuse": ["Isis"],
-        "personas": { "Anubis": 0, "Daisoujou": 0, "Isis": 0, "Mithra": 34, "Orlov": 0, "Power": 43, "Principality": 0 },
+        "personas": { "Anubis": 0, "Daisoujou": 0, "Isis": 0, "Mitra": 34, "Orlov": 0, "Power": 43, "Principality": 0 },
         "talk": "Divine Warrior (Power)"
     },
     "Makougaon": {
@@ -2097,7 +2097,7 @@ var skillMapRoyal = {
     },
     "Makouha": {
         "cost": 1000,
-        "effect": "Deal weak Bless damage to all foes.",
+        "effect": "Deal light Bless damage to all foes.",
         "element": "bless",
         "fuse": ["Angel"],
         "personas": { "Nigi Mitama": 0, "Regent": 0 }
@@ -2130,7 +2130,7 @@ var skillMapRoyal = {
     },
     "Mapsi": {
         "cost": 1000,
-        "effect": "Deal weak Psy damage to all foes.",
+        "effect": "Deal light Psy damage to all foes.",
         "element": "psy",
         "personas": { "Leanan Sidhe": 22, "Matador": 18, "Regent": 0, "Shiki-Ouji": 19, "Sudama": 0 }
     },
@@ -2151,7 +2151,7 @@ var skillMapRoyal = {
     "Maragi": {
         "card": "CJ BBB",
         "cost": 1000,
-        "effect": "Deal weak Fire damage to all foes.",
+        "effect": "Deal light Fire damage to all foes.",
         "element": "fire",
         "fuse": ["Cait Sith"],
         "personas": { "Eligor": 0, "Hua Po": 13, "Orobas": 0, "Orthrus": 0, "Regent": 0, "Orpheus F Picaro": 0 }
@@ -2296,7 +2296,7 @@ var skillMapRoyal = {
     },
     "Mazio": {
         "cost": 1000,
-        "effect": "Deal weak Electric damage to all foes.",
+        "effect": "Deal light Electric damage to all foes.",
         "element": "electric",
         "fuse": ["Agathion"],
         "personas": { "Ame-no-Uzume": 0, "Regent": 0 }
@@ -2540,7 +2540,7 @@ var skillMapRoyal = {
     },
     "Myriad Slashes": {
         "cost": 20,
-        "effect": "Deal 2 to 3 times medium Phys damage to 1 foe.",
+        "effect": "Deal medium Phys damage to 1 foe 2 to 3 times.",
         "element": "phys",
         "fuse": ["Dakini"],
         "personas": {
@@ -2800,7 +2800,7 @@ var skillMapRoyal = {
     "Psi": {
         "card": "CJ Theater",
         "cost": 400,
-        "effect": "Deal weak Psy damage to 1 foe.",
+        "effect": "Deal light Psy damage to 1 foe.",
         "element": "psy",
         "personas": { "Kodama": 12, "Matador": 0 },
         "talk": "Hanging Tree Spirit (Kodama)"
@@ -2916,7 +2916,7 @@ var skillMapRoyal = {
     },
     "Rampage": {
         "cost": 13,
-        "effect": "Deal 1 to 3 times weak Phys damage to all foes.",
+        "effect": "Deal light Phys damage to all foes 1 to 3 times.",
         "element": "phys",
         "personas": { "Choronzon": 0, "Ippon-Datara": 15, "Oni": 0, "Pisaca": 0, "Shiisaa": 17 },
         "talk": "Chivalrous Fiend (Oni)"
@@ -3200,7 +3200,7 @@ var skillMapRoyal = {
     },
     "Shining Arrows": {
         "cost": 2200,
-        "effect": "Deal 4 to 8 times weak Bless damage to all foes.",
+        "effect": "Deal light Bless damage to all foes 4 to 8 times.",
         "element": "bless",
         "unique": "Kaguya",
         "personas": { "Kaguya": 0, "Kaguya Picaro": 0 }
@@ -3390,7 +3390,7 @@ var skillMapRoyal = {
     },
     "Swift Strike": {
         "cost": 17,
-        "effect": "Deal 2 to 4 times weak Phys damage to all foes.",
+        "effect": "Deal miniscule Phys damage to all foes 2-4 times.",
         "element": "phys",
         "personas": {
             "Byakko": 0,
@@ -3406,7 +3406,7 @@ var skillMapRoyal = {
     },
     "Sword Dance": {
         "cost": 21,
-        "effect": "Deal grave Phys damage to 1 foe with high critical.",
+        "effect": "Deal colossal Phys damage to 1 foe with high critical.",
         "element": "phys",
         "fuse": ["Atavaka"],
         "personas": { "Metatron": 0, "Michael": 89, "Raphael": 0, "Sandalphon": 79 }
@@ -3472,7 +3472,7 @@ var skillMapRoyal = {
     },
     "Tempest Slash": {
         "cost": 17,
-        "effect": "Deal 3 to 5 times minuscule Phys damage to 1 foe.",
+        "effect": "Deal minuscule Phys damage to 1 foe 3 to 5 times .",
         "element": "phys",
         "personas": { "Ganesha": 0, "Hanuman": 0, "Kumbhanda": 43, "Ose": 43 },
         "talk": "Nimble Monkey King (Hanuman)"
@@ -3528,9 +3528,9 @@ var skillMapRoyal = {
     },
     "Thermopylae": {
         "cost": 3000,
-        "effect": "Increase party's Attack, Defense and Agility for 3 turns. Only usable if the party is being ambushed.",
+        "effect": "Increase party's Attack, Defense and Agility for 3 turns. Only usable if the party is surrounded.",
         "element": "support",
-        "personas": { "Attis": 0, "Dionysus": 72, "Mithra": 38 }
+        "personas": { "Attis": 0, "Dionysus": 72, "Mitra": 38 }
     },
     "Thunder Reign": {
         "cost": 4800,
@@ -3568,7 +3568,7 @@ var skillMapRoyal = {
     },
     "Triple Down": {
         "cost": 16,
-        "effect": "Deal 3 times small Gun damage to all foes.",
+        "effect": "Deal light Gun damage to all foes 3 times.",
         "element": "gun",
         "fuse": ["Shiki-Ouji"],
         "personas": { "Bugs": 52, "Vasuki": 0, "White Rider": 0 }
@@ -3743,7 +3743,7 @@ var skillMapRoyal = {
     },
     "Zio": {
         "cost": 400,
-        "effect": "Deal weak Electric damage to 1 foe.",
+        "effect": "Deal light Electric damage to 1 foe.",
         "element": "electric",
         "personas": { "Agathion": 7, "Pixie": 0 }
     },

--- a/data/SkillDataRoyal.js
+++ b/data/SkillDataRoyal.js
@@ -133,7 +133,7 @@ var skillMapRoyal = {
     },
     "Akashic Arts": {
         "cost": 20,
-        "effect": "Deal severe Phys damage to all foes 1-2 times.",
+        "effect": "Deal severe Phys damage to all foes 1-2 times with high critical.",
         "element": "phys",
         "unique": "Athena",
         "personas": { "Athena": 0, "Athena Picaro": 0 }

--- a/data/SkillDataRoyal.ts
+++ b/data/SkillDataRoyal.ts
@@ -133,7 +133,7 @@ const skillMapRoyal: SkillMap = {
     },
     "Akashic Arts": {
         "cost": 20,
-        "effect": "Deal severe Phys damage to all foes 1-2 times.",
+        "effect": "Deal severe Phys damage to all foes 1-2 times with high critical.",
         "element": "phys",
         "unique": "Athena",
         "personas": { "Athena": 0, "Athena Picaro": 0 }

--- a/data/SkillDataRoyal.ts
+++ b/data/SkillDataRoyal.ts
@@ -2,36 +2,36 @@ const skillMapRoyal: SkillMap = {
     "Absorb Bless": {
         "effect": "Absorb Bless attacks.",
         "element": "passive",
-        "personas": {"Cybele": 87, "Vohu Manah": 82}
+        "personas": { "Cybele": 87, "Vohu Manah": 82 }
     },
     "Absorb Curse": {
         "effect": "Absorb Curse attacks.",
         "element": "passive",
         "fuse": ["Attis"],
-        "personas": {"Attis": 86, "Loa": 73, "Lucifer": 0, "Tsukiyomi": 0, "Tsukiyomi Picaro": 0}
+        "personas": { "Attis": 86, "Loa": 73, "Lucifer": 0, "Tsukiyomi": 0, "Tsukiyomi Picaro": 0 }
     },
-    "Absorb Elec": {"card": "Foggy Day ???", "effect": "Absorb Electric attacks.", "element": "passive"},
+    "Absorb Elec": { "card": "Foggy Day ???", "effect": "Absorb Electric attacks.", "element": "passive" },
     "Absorb Fire": {
         "card": "Full Moon ???",
         "effect": "Absorb Fire attacks.",
         "element": "passive",
         "fuse": ["Chimera"],
-        "personas": {"Moloch": 64}
+        "personas": { "Moloch": 64 }
     },
     "Absorb Ice": {
         "effect": "Absorb Ice attacks.",
         "element": "passive",
-        "personas": {"Satan": 98, "Yamata-no-Orochi": 66}
+        "personas": { "Satan": 98, "Yamata-no-Orochi": 66 }
     },
-    "Absorb Nuke": {"effect": "Absorb Nuclear attacks.", "element": "passive", "personas": {"Fafnir": 92}},
+    "Absorb Nuke": { "effect": "Absorb Nuclear attacks.", "element": "passive", "personas": { "Fafnir": 92 } },
     "Absorb Phys": {
         "effect": "Absorb Phys attacks.",
         "element": "passive",
         "fuse": ["Chi You"],
-        "personas": {"Abaddon": 80, "Lucifer": 99, "Messiah": 85}
+        "personas": { "Abaddon": 80, "Lucifer": 99, "Messiah": 85 }
     },
-    "Absorb Psy": {"effect": "Absorb Psy attacks.", "element": "passive", "personas": {"Chi You": 92}},
-    "Absorb Wind": {"effect": "Absorb Wind attacks.", "element": "passive", "personas": {"Ishtar": 0}},
+    "Absorb Psy": { "effect": "Absorb Psy attacks.", "element": "passive", "personas": { "Chi You": 92 } },
+    "Absorb Wind": { "effect": "Absorb Wind attacks.", "element": "passive", "personas": { "Ishtar": 0 } },
     "Abysmal Surge": {
         "cost": 800,
         "effect": "Inflict Despair (medium odds) to all foes.",
@@ -53,14 +53,14 @@ const skillMapRoyal: SkillMap = {
         "effect": "Deal severe Almighty damage to all foes.",
         "element": "almighty",
         "unique": "Hastur",
-        "personas": {"Hastur": 86}
+        "personas": { "Hastur": 86 }
     },
     "Abyssal Wings": {
         "cost": 3000,
         "effect": "Deal severe Curse damage to all foes.",
         "element": "curse",
         "unique": "Tsukiyomi",
-        "personas": {"Tsukiyomi": 0, "Tsukiyomi Picaro": 0}
+        "personas": { "Tsukiyomi": 0, "Tsukiyomi Picaro": 0 }
     },
     "Active Support": {
         "effect": "Moral Support may now Charge or recover SP.",
@@ -68,16 +68,16 @@ const skillMapRoyal: SkillMap = {
         "unique": "Necronomicon"
     },
     "Adverse Resolve": {
-        "effect": "Increase critical rate when being ambushed.",
+        "effect": "Increase critical rate when surrounded.",
         "element": "passive",
-        "personas": {"Arsène": 7, "Jikokuten": 28, "Rakshasa": 30, "Raphael": 82, "Thanatos Picaro": 73},
+        "personas": { "Arsène": 7, "Jikokuten": 28, "Rakshasa": 30, "Raphael": 82, "Thanatos Picaro": 73 },
         "talk": "Battle Fiend (Rakshasa)"
     },
     "Agi": {
         "cost": 400,
-        "effect": "Deal weak Fire damage to 1 foe.",
+        "effect": "Deal light Fire damage to 1 foe.",
         "element": "fire",
-        "personas": {"Cait Sith": 0, "Hua Po": 0, "Jack-o'-Lantern": 0, "Onmoraki": 13, "Succubus": 8, "Orpheus F": 0},
+        "personas": { "Cait Sith": 0, "Hua Po": 0, "Jack-o'-Lantern": 0, "Onmoraki": 13, "Succubus": 8, "Orpheus F": 0 },
         "talk": "Crypt-Dwelling Pyromaniac (Jack-o'-Lantern)"
     },
     "Agidyne": {
@@ -116,57 +116,57 @@ const skillMapRoyal: SkillMap = {
     },
     "Agneyastra": {
         "cost": 24,
-        "effect": "Deal 1 to 3 times medium Phys damage to all foes.",
+        "effect": "Deal medium Phys damage to all foes 1 to 3 times.",
         "element": "phys",
         "fuse": ["Asterius Picaro"],
-        "personas": {"Ardha": 87, "Ongyo-Ki": 95, "Messiah Picaro": 0}
+        "personas": { "Ardha": 87, "Ongyo-Ki": 95, "Messiah Picaro": 0 }
     },
     "Ailment Boost": {
         "effect": "Increase chance of inflicting all ailments.",
         "element": "passive",
-        "personas": {"Abaddon": 79, "Byakhee": 73, "Dionysus": 73, "Mishaguji": 57, "White Rider": 44}
+        "personas": { "Abaddon": 79, "Byakhee": 73, "Dionysus": 73, "Mishaguji": 57, "White Rider": 44 }
     },
     "Ailment Hunter": {
         "effect": "Damage +25% for each foe afflicted with an ailment",
         "element": "trait",
-        "personas": {"Crystal Skull": 0, "Fafnir": 0, "Macabre": 0, "Mishaguji": 0, "Red Rider": 0}
+        "personas": { "Crystal Skull": 0, "Fafnir": 0, "Macabre": 0, "Mishaguji": 0, "Red Rider": 0 }
     },
-    "Akasha Arts": {
+    "Akashic Arts": {
         "cost": 20,
-        "effect": "Deal 1-2 times severe Phys damage to all foes.",
+        "effect": "Deal severe Phys damage to all foes 1-2 times.",
         "element": "phys",
         "unique": "Athena",
-        "personas": {"Athena": 0, "Athena Picaro": 0}
+        "personas": { "Athena": 0, "Athena Picaro": 0 }
     },
     "Ali Dance": {
         "card": "Jazz 1/15 Foggy Day 50",
         "effect": "Half hit rate of all incoming attacks.",
         "element": "passive",
-        "personas": {"Gabriel": 79, "Macabre": 78, "Vishnu": 0, "Raoul": 0}
+        "personas": { "Gabriel": 79, "Macabre": 78, "Vishnu": 0, "Raoul": 0 }
     },
-    "All-out Attack Boost": {"effect": "Increases damage from All-out Attacks", "element": "passive"},
-    "Almighty Amp": {"card": "Network Fusion", "effect": "Strengthen Almighty attacks by 50%.", "element": "passive"},
+    "All-out Attack Boost": { "effect": "Increases damage from All-out Attacks", "element": "passive" },
+    "Almighty Amp": { "card": "Network Fusion", "effect": "Strengthen Almighty attacks by 50%.", "element": "passive" },
     "Allure of Wisdom": {
         "effect": "Reduces costs of magic skills by 75%",
         "element": "trait",
-        "personas": {"Lucifer": 0}
+        "personas": { "Lucifer": 0 }
     },
     "Almighty Boost": {
         "card": "Network Fusion",
         "effect": "Strengthen Almighty attacks by 25%.",
         "element": "passive",
-        "personas": {"Izanagi-no-Okami": 85, "Izanagi-no-Okami Picaro": 94, "Messiah": 87, "Messiah Picaro": 96}
+        "personas": { "Izanagi-no-Okami": 85, "Izanagi-no-Okami Picaro": 94, "Messiah": 87, "Messiah Picaro": 96 }
     },
     "Ambient Aid": {
         "effect": "Greatly increase inflicting rate of all status effects under rainy day or special weather warning.",
         "element": "passive",
-        "personas": {"Black Ooze": 20, "Black Rider": 60, "Mothman": 36, "Narcissus": 53, "Pazuzu": 47, "Sudama": 20}
+        "personas": { "Black Ooze": 20, "Black Rider": 60, "Mothman": 36, "Narcissus": 53, "Pazuzu": 47, "Sudama": 20 }
     },
     "Amrita Drop": {
         "cost": 600,
         "effect": "Cure all ailments of 1 ally except for unique status.",
         "element": "healing",
-        "personas": {"Fortuna": 50, "Norn": 55, "Seiryu": 66}
+        "personas": { "Fortuna": 50, "Norn": 55, "Seiryu": 66 }
     },
     "Amrita Shower": {
         "cost": 1200,
@@ -221,7 +221,7 @@ const skillMapRoyal: SkillMap = {
         "effect": "Half HP cost for physical skills.",
         "element": "passive",
         "fuse": ["Tsukiyomi Picaro"],
-        "personas": {"Ongyo-Ki": 91, "Raphael": 83, "Tsukiyomi": 56}
+        "personas": { "Ongyo-Ki": 91, "Raphael": 83, "Tsukiyomi": 56 }
     },
     "Assault Dive": {
         "cost": 13,
@@ -241,16 +241,16 @@ const skillMapRoyal: SkillMap = {
     "Atomic Bloodline": {
         "effect": "Halves costs of Nuke skills",
         "element": "trait",
-        "personas": {"Ananta": 0, "Ara Mitama": 0, "Orlov": 0, "Phoenix": 0, "Shiisaa": 0}
+        "personas": { "Ananta": 0, "Ara Mitama": 0, "Orlov": 0, "Phoenix": 0, "Shiisaa": 0 }
     },
     "Atomic Flare": {
         "cost": 4800,
         "effect": "Deal severe Nuclear damage to 1 foe.",
         "element": "nuclear",
         "fuse": ["Bishamonten"],
-        "personas": {"Asura": 0, "Fafnir": 88, "Orichalcum": 0}
+        "personas": { "Asura": 0, "Fafnir": 88, "Orichalcum": 0 }
     },
-    "Atomic Hellscape": {"effect": "Reduces costs of Nuke skills by 75%", "element": "trait", "personas": {"Asura": 0}},
+    "Atomic Hellscape": { "effect": "Reduces costs of Nuke skills by 75%", "element": "trait", "personas": { "Asura": 0 } },
     "Attack Master": {
         "effect": "Automatic Tarukaja at the start of battle.",
         "element": "passive",
@@ -276,13 +276,13 @@ const skillMapRoyal: SkillMap = {
         "effect": "Automatic Marakukaja at the start of battle. (Overwrites Defense Master)",
         "element": "passive",
         "fuse": ["Ariadne Picaro"],
-        "personas": {"Alilat": 85, "Cybele": 86, "Futsunushi": 92, "Hope Diamond": 0, "Athena": 50}
+        "personas": { "Alilat": 85, "Cybele": 86, "Futsunushi": 92, "Hope Diamond": 0, "Athena": 50 }
     },
     "Auto-Masuku": {
         "effect": "Automatic Masukukaja at the start of battle. (Overwrites Speed Master)",
         "element": "passive",
         "fuse": ["Jatayu"],
-        "personas": {"Ardha": 88, "Hope Diamond": 0, "Macabre": 74, "Asterius Picaro": 63}
+        "personas": { "Ardha": 88, "Hope Diamond": 0, "Macabre": 74, "Asterius Picaro": 63 }
     },
     "Auto-Mataru": {
         "effect": "Automatic Matarukaja at the start of battle. (Overwrites Attack Master)",
@@ -298,46 +298,46 @@ const skillMapRoyal: SkillMap = {
             "Athena Picaro": 54
         }
     },
-    "Ave Maria": {"effect": "Reduces costs of Support spells by 75%", "element": "trait", "personas": {"Maria": 0}},
+    "Ave Maria": { "effect": "Reduces costs of Support spells by 75%", "element": "trait", "personas": { "Maria": 0 } },
     "Ayamur": {
         "cost": 25,
-        "effect": "Deal 3 times medium Phys damage to 1 foe. High accuracy.",
+        "effect": "Deal medium Phys damage to 1 foe 3 times. High accuracy.",
         "element": "phys",
         "unique": "Baal",
-        "personas": {"Baal": 84}
+        "personas": { "Baal": 84 }
     },
     "Bad Beat": {
         "cost": 21,
         "effect": "Deal medium Phys damage and inflict Despair (low odds) to all foes.",
         "element": "phys",
-        "personas": {"Dakini": 0, "Kin-Ki": 30}
+        "personas": { "Dakini": 0, "Kin-Ki": 30 }
     },
     "Baisudi": {
         "cost": 400,
         "effect": "Cure Burn/Freeze/Shock of 1 ally.",
         "element": "healing",
-        "personas": {"Agathion": 0, "Ame-no-Uzume": 16, "Angel": 10, "Jack Frost": 0, "Nigi Mitama": 0}
+        "personas": { "Agathion": 0, "Ame-no-Uzume": 16, "Angel": 10, "Jack Frost": 0, "Nigi Mitama": 0 }
     },
-    "Bargain Bolts": {"effect": "Reduces costs of Elec skills by 75%", "element": "trait", "personas": {"Odin": 0}},
+    "Bargain Bolts": { "effect": "Reduces costs of Elec skills by 75%", "element": "trait", "personas": { "Odin": 0 } },
     "Beast Weaver": {
         "cost": 20,
-        "effect": "Deal grave Phys damage to 1 foe and user is debuffed with Tarunda.",
+        "effect": "Deal colossal Phys damage to 1 foe and user is debuffed with Tarunda.",
         "element": "phys",
         "unique": "Ariadne",
-        "personas": {"Ariadne": 0, "Ariadne Picaro": 0}
+        "personas": { "Ariadne": 0, "Ariadne Picaro": 0 }
     },
     "Black Viper": {
         "cost": 4800,
         "effect": "Deal severe Almighty damage to 1 foe.",
         "element": "almighty",
         "unique": "Satan",
-        "personas": {"Satan": 94, "Satanael": 96}
+        "personas": { "Satan": 94, "Satanael": 96 }
     },
     "Blazing Hell": {
         "cost": 5400,
         "effect": "Deal severe Fire damage to all foes.",
         "element": "fire",
-        "personas": {"Attis": 88, "Mada": 92, "Surt": 0, "Zaou-Gongen": 86}
+        "personas": { "Attis": 88, "Mada": 92, "Surt": 0, "Zaou-Gongen": 86 }
     },
     "Bleeding Dry Brush": {
         "card": "Ring of Vanity",
@@ -350,12 +350,12 @@ const skillMapRoyal: SkillMap = {
         "effect": "Strengthen (non instant death) Bless attacks by 50%.",
         "element": "passive",
         "fuse": ["Power"],
-        "personas": {"Metatron": 94, "Vohu Manah": 0}
+        "personas": { "Metatron": 94, "Vohu Manah": 0 }
     },
     "Bless Boost": {
         "effect": "Strengthen (non instant death) Bless attacks by 25%.",
         "element": "passive",
-        "personas": {"Daisoujou": 42, "Mithra": 36, "Power": 44, "Principality": 34}
+        "personas": { "Daisoujou": 42, "Mitra": 36, "Power": 44, "Principality": 34 }
     },
     "Blessed Bloodline": {
         "effect": "Halves costs of Bless skills",
@@ -363,7 +363,7 @@ const skillMapRoyal: SkillMap = {
         "personas": {
             "Barong": 0,
             "Dominion": 0,
-            "Mithra": 0,
+            "Mitra": 0,
             "Orichalcum": 0,
             "Principality": 0,
             "Sraosha": 0,
@@ -392,19 +392,19 @@ const skillMapRoyal: SkillMap = {
     "Bloodstained Eyes": {
         "effect": "Raises evasion against foes afflicted with ailments",
         "element": "trait",
-        "personas": {"Belial": 0, "Forneus": 0, "Koh-i-Noor": 0, "Skadi": 0, "White Rider": 0}
+        "personas": { "Belial": 0, "Forneus": 0, "Koh-i-Noor": 0, "Skadi": 0, "White Rider": 0 }
     },
     "Bolstering Force": {
         "effect": "Damage dealt during 1 More +50%",
         "element": "trait",
         "unique": "Tsukiyomi",
-        "personas": {"Tsukiyomi": 0, "Tsukiyomi Picaro": 0}
+        "personas": { "Tsukiyomi": 0, "Tsukiyomi Picaro": 0 }
     },
     "Brain Buster": {
         "effect": "Deal heavy Phys damage and inflict Brainwash (low odds) to all foes.",
         "cost": 22,
         "element": "phys",
-        "personas": {"Mara": 76, "Tam Lin": 30, "Trumpeter": 0},
+        "personas": { "Mara": 76, "Tam Lin": 30, "Trumpeter": 0 },
         "talk": "Monk of the Valley (Kurama Tengu)"
     },
     "Brain Jack": {
@@ -428,17 +428,17 @@ const skillMapRoyal: SkillMap = {
         "cost": 9,
         "effect": "Deal medium Phys damage and inflict Brainwash (medium odds) to 1 foe.",
         "element": "phys",
-        "personas": {"Inugami": 18, "Pale Rider": 0, "Power": 0, "Tam Lin": 0},
+        "personas": { "Inugami": 18, "Pale Rider": 0, "Power": 0, "Tam Lin": 0 },
         "talk": "Possessive Dog Ghost (Inugami)"
     },
     "Brainwash Boost": {
         "effect": "Increase chance of inflicting Brainwash.",
         "element": "passive",
-        "personas": {"Nebiros": 77, "Tam Lin": 31, "Vasuki": 72}
+        "personas": { "Nebiros": 77, "Tam Lin": 31, "Vasuki": 72 }
     },
     "Brave Blade": {
         "cost": 24,
-        "effect": "Deal grave Phys damage to 1 foe.",
+        "effect": "Deal colossal Phys damage to 1 foe.",
         "element": "phys",
         "personas": {
             "Atavaka": 70,
@@ -460,9 +460,9 @@ const skillMapRoyal: SkillMap = {
     },
     "Bufu": {
         "cost": 400,
-        "effect": "Deal weak Ice damage to 1 foe.",
+        "effect": "Deal light Ice damage to 1 foe.",
         "element": "ice",
-        "personas": {"Apsaras": 0, "Genbu": 0, "Jack Frost": 0, "Koropokkuru": 0, "Saki Mitama": 0, "Silky": 0},
+        "personas": { "Apsaras": 0, "Genbu": 0, "Jack Frost": 0, "Koropokkuru": 0, "Saki Mitama": 0, "Silky": 0 },
         "talk": "Mocking Snowman (Jack Frost)"
     },
     "Bufudyne": {
@@ -486,7 +486,7 @@ const skillMapRoyal: SkillMap = {
         "cost": 800,
         "effect": "Deal medium Ice damage to 1 foe.",
         "element": "ice",
-        "personas": {"Lachesis": 0, "Lilim": 0, "Stone of Scone": 0, "Sui-Ki": 0},
+        "personas": { "Lachesis": 0, "Lilim": 0, "Stone of Scone": 0, "Sui-Ki": 0 },
         "talk": "Ambassador of Filth (Belphegor)"
     },
     "Burn Boost": {
@@ -508,7 +508,7 @@ const skillMapRoyal: SkillMap = {
         "effect": "Restore 50% HP of party and increase evasion rate.",
         "element": "healing",
         "unique": "Orpheus",
-        "personas": {"Orpheus": 0, "Orpheus Picaro": 0}
+        "personas": { "Orpheus": 0, "Orpheus Picaro": 0 }
     },
     "Champion's Cup": {
         "card": "Ring of Lust",
@@ -540,35 +540,35 @@ const skillMapRoyal: SkillMap = {
         },
         "talk": "Blood-Thirsty Demoness (Dakini)"
     },
-    "Checkmate": {"cost": 9000, "effect": "Matarunda + Marakunda + Masukunda", "element": "support", "unique": "Agnes"},
+    "Checkmate": { "cost": 9000, "effect": "Matarunda + Marakunda + Masukunda", "element": "support", "unique": "Agnes" },
     "Chi You's Blessing": {
         "effect": "Reduces costs of Psy skills by 75%",
         "element": "trait",
-        "personas": {"Chi You": 0}
+        "personas": { "Chi You": 0 }
     },
     "Circle of Sadness": {
         "effect": "Activates endure up to 4 times",
         "element": "trait",
         "unique": "Orpheus",
-        "personas": {"Orpheus": 0, "Orpheus F": 0, "Orpheus F Picaro": 0, "Orpheus Picaro": 0}
+        "personas": { "Orpheus": 0, "Orpheus F": 0, "Orpheus F Picaro": 0, "Orpheus Picaro": 0 }
     },
     "Cleave": {
         "cost": 6,
-        "effect": "Deal weak Phys damage to 1 foe.",
+        "effect": "Deal light Phys damage to 1 foe.",
         "element": "phys",
-        "personas": {"Arsène": 2, "Berith": 0, "Cait Sith": 0},
+        "personas": { "Arsène": 2, "Berith": 0, "Cait Sith": 0 },
         "talk": "Hunting Puss in Boots (Cait Sith)"
     },
     "Climate Decorum": {
         "effect": "Greatly increase evasion under rainy day or special weather warning.",
         "element": "passive",
-        "personas": {"Choronzon": 33, "Koropokkuru": 15, "Lakshmi": 71, "Nigi Mitama": 26}
+        "personas": { "Choronzon": 33, "Koropokkuru": 15, "Lakshmi": 71, "Nigi Mitama": 26 }
     },
-    "Cocytus": {"effect": "Reduces costs of Ice skills by 75%", "element": "trait", "personas": {"Satan": 0}},
+    "Cocytus": { "effect": "Reduces costs of Ice skills by 75%", "element": "trait", "personas": { "Satan": 0 } },
     "Cold-Blooded": {
         "effect": "Increases chance of inflicting Freeze during 1 More",
         "element": "trait",
-        "personas": {"Genbu": 0, "Lilim": 0, "Yamata-no-Orochi": 0}
+        "personas": { "Genbu": 0, "Lilim": 0, "Yamata-no-Orochi": 0 }
     },
     "Conceal": {
         "card": "Fusion Mutation",
@@ -608,7 +608,7 @@ const skillMapRoyal: SkillMap = {
     "Confuse Boost": {
         "effect": "Increase chance of inflicting Confuse.",
         "element": "passive",
-        "personas": {"Inugami": 19, "Onmoraki": 17}
+        "personas": { "Inugami": 19, "Onmoraki": 17 }
     },
     "Cool Customer": {
         "effect": "Reduces ailment susceptibility by 50% for all allies",
@@ -617,74 +617,74 @@ const skillMapRoyal: SkillMap = {
     },
     "Cornered Fang": {
         "cost": 10,
-        "effect": "Deal medium Phys damage to 1 foe. More powerful when being ambushed.",
+        "effect": "Deal medium Phys damage to 1 foe. More powerful when surrounded.",
         "element": "phys",
         "fuse": ["Shiisaa"],
-        "personas": {"Flauros": 23, "Neko Shogun": 33, "Orthrus": 24}
+        "personas": { "Flauros": 23, "Neko Shogun": 33, "Orthrus": 24 }
     },
     "Cosmic Flare": {
         "cost": 5400,
         "effect": "Deal severe Nuclear damage to all foes.",
         "element": "nuclear",
-        "personas": {"Ardha": 0, "Fafnir": 0, "Michael": 92}
+        "personas": { "Ardha": 0, "Fafnir": 0, "Michael": 92 }
     },
     "Counter": {
         "effect": "10% chance of reflecting Phys attacks.",
         "element": "passive",
-        "personas": {"Ippon-Datara": 18, "Jikokuten": 25, "Naga": 27, "Oni": 0, "Setanta": 0, "Yaksini": 0}
+        "personas": { "Ippon-Datara": 18, "Jikokuten": 25, "Naga": 27, "Oni": 0, "Setanta": 0, "Yaksini": 0 }
     },
     "Counterstrike": {
         "effect": "15% chance of reflecting Phys attacks.",
         "element": "passive",
         "fuse": ["Naga"],
-        "personas": {"Byakko": 0, "Kin-Ki": 31, "Ose": 0, "Rakshasa": 28, "Rangda": 0, "Valkyrie": 0, "Kaguya": 0},
+        "personas": { "Byakko": 0, "Kin-Ki": 31, "Ose": 0, "Rakshasa": 28, "Rangda": 0, "Valkyrie": 0, "Kaguya": 0 },
         "talk": "Funerary Warrior (Valkyrie)"
     },
     "Country Maker": {
         "effect": "Scales damage dealt and received against Compendium completion rate",
         "element": "trait",
         "unique": "Izanagi-no-Okami",
-        "personas": {"Izanagi-no-Okami": 0, "Izanagi-no-Okami Picaro": 0}
+        "personas": { "Izanagi-no-Okami": 0, "Izanagi-no-Okami Picaro": 0 }
     },
     "Crisis Control": {
         "effect": "Reduces damage taken when weakness struck",
         "element": "trait",
-        "personas": {"Berith": 0, "Chernobog": 0, "Koh-i-Noor": 0, "Throne": 0}
+        "personas": { "Berith": 0, "Chernobog": 0, "Koh-i-Noor": 0, "Throne": 0 }
     },
     "Cross Slash": {
         "cost": 20,
-        "effect": "Deal 2 times heavy Phys damage to 1 foe. High accuracy.",
+        "effect": "Deal heavy Phys damage to 1 foe 2 times. High accuracy.",
         "element": "phys",
         "unique": "Izanagi",
-        "personas": {"Izanagi": 0, "Izanagi Picaro": 0}
+        "personas": { "Izanagi": 0, "Izanagi Picaro": 0 }
     },
     "Curse Amp": {
         "effect": "Strengthen (non instant death) Curse attacks by 50%.",
         "element": "passive",
-        "personas": {"Beelzebub": 88, "Belial": 0, "Raoul": 80, "Thanatos": 66, "Tsukiyomi": 53, "Tsukiyomi Picaro": 58}
+        "personas": { "Beelzebub": 88, "Belial": 0, "Raoul": 80, "Thanatos": 66, "Tsukiyomi": 53, "Tsukiyomi Picaro": 58 }
     },
     "Curse Boost": {
         "effect": "Strengthen (non instant death) Curse attacks by 25%.",
         "element": "passive",
-        "personas": {"Choronzon": 32, "Nue": 26, "Pale Rider": 55}
+        "personas": { "Choronzon": 32, "Nue": 26, "Pale Rider": 55 }
     },
     "Cursed Bloodline": {
         "effect": "Halves costs of Curse skills",
         "element": "trait",
-        "personas": {"Crystal Skull": 0, "Girimehkala": 0, "Pazuzu": 0, "Rangda": 0}
+        "personas": { "Crystal Skull": 0, "Girimehkala": 0, "Pazuzu": 0, "Rangda": 0 }
     },
     "Dazzler": {
         "cost": 300,
         "effect": "Inflict Dizzy (high odds) to 1 foe.",
         "element": "ailment",
-        "personas": {"Archangel": 0, "Jack-o'-Lantern": 5, "Mokoi": 0, "Narcissus": 0}
+        "personas": { "Archangel": 0, "Jack-o'-Lantern": 5, "Mokoi": 0, "Narcissus": 0 }
     },
     "Deadly Fury": {
         "cost": 18,
         "effect": "Deal severe Phys damage to 1 foe. More powerful under Baton Pass.",
         "element": "phys",
         "fuse": ["Valkyrie"],
-        "personas": {"Bishamonten": 0, "Koumokuten": 55, "Skadi": 0},
+        "personas": { "Bishamonten": 0, "Koumokuten": 55, "Skadi": 0 },
         "talk": "Quaking Lady of Shadow (Skadi)"
     },
     "Death Scythe": {
@@ -692,11 +692,11 @@ const skillMapRoyal: SkillMap = {
         "effect": "Deal severe Phys damage and inflict Fear (medium odds) to 1 foe.",
         "element": "phys",
         "fuse": ["Macabre"],
-        "personas": {"Byakhee": 0, "Macabre": 0}
+        "personas": { "Byakhee": 0, "Macabre": 0 }
     },
     "Deathbound": {
         "cost": 22,
-        "effect": "Deal 1 to 2 times medium Phys damage to all foes.",
+        "effect": "Deal medium Phys damage to all foes 1 to 2 times.",
         "element": "phys",
         "fuse": ["Girimehkala"],
         "personas": {
@@ -714,7 +714,7 @@ const skillMapRoyal: SkillMap = {
     "Deathly Illness": {
         "effect": "Increases success rate of instant death skills",
         "element": "trait",
-        "personas": {"Anubis": 0, "Melchizedek": 0}
+        "personas": { "Anubis": 0, "Melchizedek": 0 }
     },
     "Debilitate": {
         "card": "Jazz 12/11",
@@ -737,7 +737,7 @@ const skillMapRoyal: SkillMap = {
     "Defense Master": {
         "effect": "Automatic Rakukaja at the start of battle.",
         "element": "passive",
-        "personas": {"Ananta": 0, "Arahabaki": 39, "Genbu": 12, "Jikokuten": 0, "Neko Shogun": 35, "Take-Minakata": 0}
+        "personas": { "Ananta": 0, "Arahabaki": 39, "Genbu": 12, "Jikokuten": 0, "Neko Shogun": 35, "Take-Minakata": 0 }
     },
     "Dekaja": {
         "card": "CJ Maid Cafe",
@@ -762,26 +762,26 @@ const skillMapRoyal: SkillMap = {
         "cost": 1000,
         "effect": "Negate all -nda debuff effects of party.",
         "element": "support",
-        "personas": {"Angel": 12, "Anubis": 37, "Mithra": 35, "Mokoi": 14, "Suzaku": 18, "Unicorn": 0, "Yatagarasu": 0}
+        "personas": { "Angel": 12, "Anubis": 37, "Mitra": 35, "Mokoi": 14, "Suzaku": 18, "Unicorn": 0, "Yatagarasu": 0 }
     },
-    "Demon's Bite": {"effect": "Doubles own HP recovery", "element": "trait", "personas": {"Ongyo-Ki": 0}},
+    "Demon's Bite": { "effect": "Doubles own HP recovery", "element": "trait", "personas": { "Ongyo-Ki": 0 } },
     "Demonic Decree": {
         "effect": "Half remaining HP of 1 foe.",
         "cost": 3800,
         "element": "curse",
         "fuse": ["Belial", "Thanatos Picaro"],
-        "personas": {"Beelzebub": 90, "Belial": 88, "Orichalcum": 0}
+        "personas": { "Beelzebub": 90, "Belial": 88, "Orichalcum": 0 }
     },
     "Despair Boost": {
         "effect": "Increase chance of inflicting Despair.",
         "element": "passive",
-        "personas": {"Lamia": 31, "Pisaca": 32, "Red Rider": 44}
+        "personas": { "Lamia": 31, "Pisaca": 32, "Red Rider": 44 }
     },
     "Dia": {
         "cost": 300,
         "effect": "Slightly restore 1 ally's HP.",
         "element": "healing",
-        "personas": {"Agathion": 0, "Angel": 0, "Kushi Mitama": 0, "Pixie": 0, "Silky": 7},
+        "personas": { "Agathion": 0, "Angel": 0, "Kushi Mitama": 0, "Pixie": 0, "Silky": 7 },
         "talk": "Beguiling Girl (Pixie)"
     },
     "Diamond Dust": {
@@ -789,7 +789,7 @@ const skillMapRoyal: SkillMap = {
         "effect": "Deal severe Ice damage to 1 foe.",
         "element": "ice",
         "fuse": ["Alilat"],
-        "personas": {"Alilat": 0, "Black Frost": 72, "Orichalcum": 0, "Satan": 0, "Yamata-no-Orochi": 69}
+        "personas": { "Alilat": 0, "Black Frost": 72, "Orichalcum": 0, "Satan": 0, "Yamata-no-Orochi": 69 }
     },
     "Diarahan": {
         "cost": 1800,
@@ -821,7 +821,7 @@ const skillMapRoyal: SkillMap = {
             "High Pixie": 19,
             "Horus": 0,
             "Isis": 0,
-            "Mithra": 0,
+            "Mitra": 0,
             "Neko Shogun": 0,
             "Nigi Mitama": 0,
             "Parvati": 0,
@@ -834,34 +834,34 @@ const skillMapRoyal: SkillMap = {
         "cost": 4000,
         "element": "curse",
         "unique": "Alice",
-        "personas": {"Alice": 85}
+        "personas": { "Alice": 85 }
     },
     "Divine Grace": {
         "effect": "Effects of healing magic are increased by 50%.",
         "element": "passive",
-        "personas": {"Ame-no-Uzume": 18, "Kikuri-Hime": 45, "Nigi Mitama": 24, "Kaguya": 17, "Kaguya Picaro": 26}
+        "personas": { "Ame-no-Uzume": 18, "Kikuri-Hime": 45, "Nigi Mitama": 24, "Kaguya": 17, "Kaguya Picaro": 26 }
     },
     "Divine Judgement": {
         "effect": "Half remaining HP of 1 foe.",
         "cost": 3800,
         "element": "bless",
         "fuse": ["Dominion"],
-        "personas": {"Gabriel": 78, "Metatron": 95, "Michael": 0, "Orichalcum": 0, "Vohu Manah": 0}
+        "personas": { "Gabriel": 78, "Metatron": 95, "Michael": 0, "Orichalcum": 0, "Vohu Manah": 0 }
     },
     "Dizzy Boost": {
         "effect": "Increase chance of inflicting Dizzy.",
         "element": "passive",
-        "personas": {"Hariti": 45, "Jatayu": 52, "Narcissus": 51}
+        "personas": { "Hariti": 45, "Jatayu": 52, "Narcissus": 51 }
     },
     "Dodge Bless": {
         "effect": "Double evasion rate against (non instant death) Bless attacks.",
         "element": "passive",
-        "personas": {"Koh-i-Noor": 0, "Lilim": 35}
+        "personas": { "Koh-i-Noor": 0, "Lilim": 35 }
     },
     "Dodge Curse": {
         "effect": "Double evasion rate against (non instant death) Curse attacks.",
         "element": "passive",
-        "personas": {"Angel": 11, "Incubus": 9, "Koh-i-Noor": 0, "Shiisaa": 16, "Orpheus F": 15, "Orpheus F Picaro": 17}
+        "personas": { "Angel": 11, "Incubus": 9, "Koh-i-Noor": 0, "Shiisaa": 16, "Orpheus F": 15, "Orpheus F Picaro": 17 }
     },
     "Dodge Elec": {
         "effect": "Double evasion rate against Electric attacks.",
@@ -879,82 +879,82 @@ const skillMapRoyal: SkillMap = {
     "Dodge Fire": {
         "effect": "Double evasion rate against Fire attacks.",
         "element": "passive",
-        "personas": {"Belphegor": 39, "Berith": 11, "Koh-i-Noor": 0, "Sui-Ki": 29}
+        "personas": { "Belphegor": 39, "Berith": 11, "Koh-i-Noor": 0, "Sui-Ki": 29 }
     },
     "Dodge Ice": {
         "card": "Trial 20",
         "effect": "Double evasion rate against Ice attacks.",
         "element": "passive",
-        "personas": {"Koh-i-Noor": 0, "Koropokkuru": 11}
+        "personas": { "Koh-i-Noor": 0, "Koropokkuru": 11 }
     },
     "Dodge Nuke": {
         "effect": "Double evasion rate against Nuclear attacks.",
         "element": "passive",
-        "personas": {"Koh-i-Noor": 0}
+        "personas": { "Koh-i-Noor": 0 }
     },
     "Dodge Phys": {
         "effect": "Doubles evasion rate against Phys attacks",
         "element": "passive",
-        "personas": {"Flauros": 20, "Valkyrie": 49, "Izanagi": 22}
+        "personas": { "Flauros": 20, "Valkyrie": 49, "Izanagi": 22 }
     },
     "Dodge Psy": {
         "effect": "Double evasion rate against Psy attacks.",
         "element": "passive",
-        "personas": {"Kin-Ki": 27, "Koh-i-Noor": 0}
+        "personas": { "Kin-Ki": 27, "Koh-i-Noor": 0 }
     },
     "Dodge Wind": {
         "effect": "Double evasion rate against Wind attacks.",
         "element": "passive",
-        "personas": {"Koh-i-Noor": 0}
+        "personas": { "Koh-i-Noor": 0 }
     },
     "Door of Hades": {
         "cost": 3200,
         "effect": "Deal heavy Almighty damage to all foes with medium chance of instant kill.",
         "element": "almighty",
         "unique": "Thanatos",
-        "personas": {"Thanatos": 0, "Thanatos Picaro": 0}
+        "personas": { "Thanatos": 0, "Thanatos Picaro": 0 }
     },
     "Dormin Rush": {
         "cost": 16,
         "effect": "Deal medium Phys damage and inflict Sleep (low odds) to all foes.",
         "element": "phys",
         "fuse": ["Incubus"],
-        "personas": {"Flauros": 0, "Sandman": 0, "Setanta": 0}
+        "personas": { "Flauros": 0, "Sandman": 0, "Setanta": 0 }
     },
     "Dormina": {
         "cost": 300,
         "effect": "Inflict Sleep (high odds) to 1 foe.",
         "element": "ailment",
-        "personas": {"High Pixie": 0, "Hua Po": 0, "Incubus": 7, "Sandman": 0, "Silky": 0, "Succubus": 0},
+        "personas": { "High Pixie": 0, "Hua Po": 0, "Incubus": 7, "Sandman": 0, "Silky": 0, "Succubus": 0 },
         "talk": "Envoy of Slumber (Sandman)"
     },
     "Double Fangs": {
         "cost": 10,
-        "effect": "Deal 2 times medium Phys damage to 1 foe.",
+        "effect": "Deal medium Phys damage to 1 foe 2 times.",
         "element": "phys",
-        "personas": {"Eligor": 18, "Makami": 0, "Orthrus": 0, "Shiisaa": 0},
+        "personas": { "Eligor": 18, "Makami": 0, "Orthrus": 0, "Shiisaa": 0 },
         "talk": "Twin-Headed Guardian (Orthrus)"
     },
     "Double Shot": {
         "cost": 12,
-        "effect": "Deal 2 times light Gun damage to 1 foe.",
+        "effect": "Deal light Gun damage to 1 foe 2 times.",
         "element": "gun",
-        "personas": {"Kurama Tengu": 0, "Matador": 20, "Shiki-Ouji": 0},
+        "personas": { "Kurama Tengu": 0, "Matador": 20, "Shiki-Ouji": 0 },
         "talk": "Bringer of Misfortune (Shiki-Ouji)"
     },
     "Draining Mouth": {
         "effect": "Doubles effectiveness of absorption skills",
         "element": "trait",
-        "personas": {"Choronzon": 0, "Daisoujou": 0, "Incubus": 0, "Legion": 0, "Loa": 0}
+        "personas": { "Choronzon": 0, "Daisoujou": 0, "Incubus": 0, "Legion": 0, "Loa": 0 }
     },
     "Dream Needle": {
         "cost": 8,
-        "effect": "Deal weak Gun damage and inflict Sleep (medium odds) to 1 foe.",
+        "effect": "Deal light Gun damage and inflict Sleep (medium odds) to 1 foe.",
         "element": "gun",
-        "personas": {"Arsène": 5, "Incubus": 0, "Inugami": 15, "Phoenix": 0, "Pisaca": 0}
+        "personas": { "Arsène": 5, "Incubus": 0, "Inugami": 15, "Phoenix": 0, "Pisaca": 0 }
     },
-    "Drunken Passion": {"effect": "Reduces costs of Fire skills by 75%", "element": "trait", "personas": {"Mada": 0}},
-    "EXP Boost": {"effect": "EXP +15% after battle", "element": "passive"},
+    "Drunken Passion": { "effect": "Reduces costs of Fire skills by 75%", "element": "trait", "personas": { "Mada": 0 } },
+    "EXP Boost": { "effect": "EXP +15% after battle", "element": "passive" },
     "Eccentric Temper": {
         "effect": "Low chance to strengthen Phys attacks by 80% for all allies",
         "element": "trait",
@@ -965,7 +965,7 @@ const skillMapRoyal: SkillMap = {
         "effect": "Deal medium Curse damage to 1 foe.",
         "element": "curse",
         "fuse": ["Nue"],
-        "personas": {"Choronzon": 31, "Leanan Sidhe": 23, "Stone of Scone": 0},
+        "personas": { "Choronzon": 31, "Leanan Sidhe": 23, "Stone of Scone": 0 },
         "talk": "Gathering Devil (Choronzon)"
     },
     "Eigaon": {
@@ -986,32 +986,32 @@ const skillMapRoyal: SkillMap = {
     },
     "Eiha": {
         "cost": 400,
-        "effect": "Deal weak Curse damage to 1 foe.",
+        "effect": "Deal light Curse damage to 1 foe.",
         "element": "curse",
-        "personas": {"Arsène": 0, "Onmoraki": 0}
+        "personas": { "Arsène": 0, "Onmoraki": 0 }
     },
     "Elec Amp": {
         "effect": "Strengthen Electric attacks by 50%.",
         "element": "passive",
         "fuse": ["Thunderbird"],
-        "personas": {"Oberon": 72, "Odin": 89, "Thor": 66, "Yoshitsune": 92}
+        "personas": { "Oberon": 72, "Odin": 89, "Thor": 66, "Yoshitsune": 92 }
     },
     "Elec Boost": {
         "effect": "Strengthen Electric attacks by 25%.",
         "element": "passive",
-        "personas": {"Atropos": 42, "Take-Minakata": 29, "Thunderbird": 38, "Yurlungur": 49}
+        "personas": { "Atropos": 42, "Take-Minakata": 29, "Thunderbird": 38, "Yurlungur": 49 }
     },
     "Elec Break": {
         "cost": 600,
         "effect": "Negate Electric resistances of all foes.",
         "element": "support",
-        "personas": {"Atropos": 0, "Barong": 54, "Raja Naga": 0, "Yurlungur": 46}
+        "personas": { "Atropos": 0, "Barong": 54, "Raja Naga": 0, "Yurlungur": 46 }
     },
     "Elec Wall": {
         "cost": 1800,
         "effect": "Create a shield on 1 ally to reduce damage of Electric attacks for 3 turns.",
         "element": "support",
-        "personas": {"Ananta": 0, "Apsaras": 14, "Lachesis": 37, "Nekomata": 21},
+        "personas": { "Ananta": 0, "Apsaras": 14, "Lachesis": 37, "Nekomata": 21 },
         "talk": "Waterside Nymph (Apsaras)"
     },
     "Electric Bloodline": {
@@ -1070,63 +1070,63 @@ const skillMapRoyal: SkillMap = {
         "cost": 400,
         "effect": "Cure Confuse/Fear/Despair/Rage/Brainwash of 1 ally.",
         "element": "healing",
-        "personas": {"Kikuri-Hime": 0, "Makami": 0, "Mandrake": 0, "Narcissus": 0, "Saki Mitama": 0}
+        "personas": { "Kikuri-Hime": 0, "Makami": 0, "Mandrake": 0, "Narcissus": 0, "Saki Mitama": 0 }
     },
     "Energy Shower": {
         "cost": 800,
         "effect": "Cure Confuse/Fear/Despair/Rage/Brainwash of party.",
         "element": "healing",
         "fuse": ["Kikuri-Hime"],
-        "personas": {"Clotho": 31, "Hariti": 0, "Parvati": 57},
+        "personas": { "Clotho": 31, "Hariti": 0, "Parvati": 57 },
         "talk": "Destructive Beauty (Parvati)"
     },
     "Evade Bless": {
         "effect": "Triple evasion rate against (non instant death) Bless attacks.",
         "element": "passive",
-        "personas": {"Pale Rider": 58}
+        "personas": { "Pale Rider": 58 }
     },
     "Evade Curse": {
         "effect": "Triple evasion rate against (non instant death) Curse attacks.",
         "element": "passive",
-        "personas": {"Dominion": 74, "Gabriel": 80}
+        "personas": { "Dominion": 74, "Gabriel": 80 }
     },
     "Evade Elec": {
         "effect": "Triple evasion rate against Electric attacks.",
         "element": "passive",
-        "personas": {"Fortuna": 51, "Garuda": 55}
+        "personas": { "Fortuna": 51, "Garuda": 55 }
     },
     "Evade Fire": {
         "effect": "Triple evasion rate against Fire attacks.",
         "element": "passive",
-        "personas": {"Baphomet": 0, "Byakko": 49}
+        "personas": { "Baphomet": 0, "Byakko": 49 }
     },
-    "Evade Ice": {"effect": "Triple evasion rate against Ice attacks.", "element": "passive", "personas": {"Surt": 86}},
+    "Evade Ice": { "effect": "Triple evasion rate against Ice attacks.", "element": "passive", "personas": { "Surt": 86 } },
     "Evade Nuke": {
         "effect": "Triple evasion rate against Nuclear attacks.",
         "element": "passive",
-        "personas": {"Oberon": 70, "Okuninushi": 57}
+        "personas": { "Oberon": 70, "Okuninushi": 57 }
     },
     "Evade Phys": {
         "effect": "Triples evasion rate against Phys attacks",
         "element": "passive",
-        "personas": {"Bugs": 54, "Zaou-Gongen": 82, "Ariadne": 34, "Ariadne Picaro": 46}
+        "personas": { "Bugs": 54, "Zaou-Gongen": 82, "Ariadne": 34, "Ariadne Picaro": 46 }
     },
     "Evade Psy": {
         "effect": "Triple evasion rate against Psy attacks.",
         "element": "passive",
-        "personas": {"Forneus": 68}
+        "personas": { "Forneus": 68 }
     },
     "Evade Wind": {
         "effect": "Triple evasion rate against Wind attacks.",
         "element": "passive",
-        "personas": {"Raja Naga": 60}
+        "personas": { "Raja Naga": 60 }
     },
     "Evil Smile": {
         "cost": 800,
         "effect": "Inflict Fear (medium odds) to all foes.",
         "element": "ailment",
         "fuse": ["Andras"],
-        "personas": {"Beelzebub": 0, "Fafnir": 0, "Legion": 0, "Macabre": 0, "Moloch": 0, "Pazuzu": 48, "Skadi": 0}
+        "personas": { "Beelzebub": 0, "Fafnir": 0, "Legion": 0, "Macabre": 0, "Moloch": 0, "Pazuzu": 48, "Skadi": 0 }
     },
     "Evil Touch": {
         "cost": 300,
@@ -1156,12 +1156,12 @@ const skillMapRoyal: SkillMap = {
     "Fast Heal": {
         "effect": "Half the time needed to recover from ailments.",
         "element": "passive",
-        "personas": {"Bugs": 55, "Hope Diamond": 0, "Odin": 88, "Yoshitsune": 90}
+        "personas": { "Bugs": 55, "Hope Diamond": 0, "Odin": 88, "Yoshitsune": 90 }
     },
     "Fear Boost": {
         "effect": "Increase chance of inflicting Fear.",
         "element": "passive",
-        "personas": {"Andras": 29, "Belial": 85, "Chernobog": 66, "Kodama": 15, "Kumbhanda": 46, "Skadi": 0}
+        "personas": { "Andras": 29, "Belial": 85, "Chernobog": 66, "Kodama": 15, "Kumbhanda": 46, "Skadi": 0 }
     },
     "Fighting Spirit": {
         "cost": 8000,
@@ -1191,50 +1191,50 @@ const skillMapRoyal: SkillMap = {
     "Fire Boost": {
         "effect": "Strengthen Fire attacks by 25%.",
         "element": "passive",
-        "personas": {"Decarabia": 35, "Hell Biker": 39, "Orpheus": 32, "Orpheus Picaro": 35},
+        "personas": { "Decarabia": 35, "Hell Biker": 39, "Orpheus": 32, "Orpheus Picaro": 35 },
         "talk": "Midnight Queen (Queen Mab)"
     },
     "Fire Break": {
         "cost": 600,
         "effect": "Negate Fire resistances of all foes.",
         "element": "support",
-        "personas": {"Byakhee": 74, "Orobas": 20, "Seth": 54},
+        "personas": { "Byakhee": 74, "Orobas": 20, "Seth": 54 },
         "talk": "Equine Sage (Orobas)"
     },
     "Fire Wall": {
         "cost": 1800,
         "effect": "Create a shield on 1 ally to reduce damage of Fire attacks for 3 turns.",
         "element": "support",
-        "personas": {"Atropos": 0, "Koropokkuru": 13, "Slime": 13},
+        "personas": { "Atropos": 0, "Koropokkuru": 13, "Slime": 13 },
         "talk": "Leafy Old Man (Koropokkuru)"
     },
     "Firm Stance": {
         "effect": "Half all incoming damage by sacrificing evasion completely.",
         "element": "passive",
         "fuse": ["Messiah Picaro"],
-        "personas": {"Futsunushi": 91, "Ongyo-Ki": 93, "Messiah Picaro": 94}
+        "personas": { "Futsunushi": 91, "Ongyo-Ki": 93, "Messiah Picaro": 94 }
     },
     "Flash Bomb": {
         "cost": 19,
         "effect": "Deal medium Phys damage and inflict Dizzy (low odds) to all foes.",
         "element": "phys",
         "fuse": ["Ippon-Datara"],
-        "personas": {"Abaddon": 78, "Arahabaki": 38, "Black Ooze": 24, "Black Rider": 0, "Horus": 49}
+        "personas": { "Abaddon": 78, "Arahabaki": 38, "Black Ooze": 24, "Black Rider": 0, "Horus": 49 }
     },
     "Forget Boost": {
         "effect": "Increase chance of inflicting Forget.",
         "element": "passive",
-        "personas": {"Kaiwan": 37, "Kushi Mitama": 16, "Principality": 32}
+        "personas": { "Kaiwan": 37, "Kushi Mitama": 16, "Principality": 32 }
     },
     "Fortified Moxy": {
         "effect": "Increase critical rate when beginning battle with preemptive turn.",
         "element": "passive",
-        "personas": {"Ardha": 89, "Hecatoncheires": 46, "Neko Shogun": 36, "Ariadne": 32, "Thanatos": 69}
+        "personas": { "Ardha": 89, "Hecatoncheires": 46, "Neko Shogun": 36, "Ariadne": 32, "Thanatos": 69 }
     },
     "Fortify Spirit": {
         "effect": "Reduce susceptibilities to all ailments.",
         "element": "passive",
-        "personas": {"Chi You": 90, "Loa": 75, "Mada": 91, "Satan": 96, "Seth": 56, "Trumpeter": 61, "Vohu Manah": 83}
+        "personas": { "Chi You": 90, "Loa": 75, "Mada": 91, "Satan": 96, "Seth": 56, "Trumpeter": 61, "Vohu Manah": 83 }
     },
     "Foul Breath": {
         "cost": 800,
@@ -1268,7 +1268,7 @@ const skillMapRoyal: SkillMap = {
     "Foul Stench": {
         "effect": "Increases chance of inflicting ailments",
         "element": "trait",
-        "personas": {"Chimera": 0, "Crystal Skull": 0, "Pale Rider": 0, "Titania": 0, "Vasuki": 0}
+        "personas": { "Chimera": 0, "Crystal Skull": 0, "Pale Rider": 0, "Titania": 0, "Vasuki": 0 }
     },
     "Freeze Boost": {
         "effect": "Increase chance of inflicting Freeze.",
@@ -1289,9 +1289,9 @@ const skillMapRoyal: SkillMap = {
     "Frei": {
         "card": "CJ Theater",
         "cost": 400,
-        "effect": "Deal weak Nuclear damage to 1 foe.",
+        "effect": "Deal light Nuclear damage to 1 foe.",
         "element": "nuclear",
-        "personas": {"Makami": 0, "Shiisaa": 0, "Suzaku": 0},
+        "personas": { "Makami": 0, "Shiisaa": 0, "Suzaku": 0 },
         "talk": "Rooftop Lion (Shiisaa)"
     },
     "Freidyne": {
@@ -1299,20 +1299,20 @@ const skillMapRoyal: SkillMap = {
         "effect": "Deal heavy Nuclear damage to 1 foe.",
         "element": "nuclear",
         "fuse": ["Thoth"],
-        "personas": {"Ananta": 49, "Bishamonten": 0, "Emperor's Amulet": 0, "Lilith": 0, "Mithras": 45, "Titania": 0},
+        "personas": { "Ananta": 49, "Bishamonten": 0, "Emperor's Amulet": 0, "Lilith": 0, "Mithras": 45, "Titania": 0 },
         "talk": "Scandalous Queen (Titania)"
     },
     "Freila": {
         "cost": 800,
         "effect": "Deal medium Nuclear damage to 1 foe.",
         "element": "nuclear",
-        "personas": {"Ara Mitama": 0, "Phoenix": 0, "Stone of Scone": 0, "Thoth": 0}
+        "personas": { "Ara Mitama": 0, "Phoenix": 0, "Stone of Scone": 0, "Thoth": 0 }
     },
     "Frenzied Bull": {
         "effect": "Scales damage dealt against lost HP under 50%",
         "element": "trait",
         "unique": "Asterius",
-        "personas": {"Asterius": 0, "Asterius Picaro": 0}
+        "personas": { "Asterius": 0, "Asterius Picaro": 0 }
     },
     "Frigid Bloodline": {
         "effect": "Halves costs of Ice skills",
@@ -1345,16 +1345,16 @@ const skillMapRoyal: SkillMap = {
     },
     "Garu": {
         "cost": 300,
-        "effect": "Deal weak Wind damage to 1 foe.",
+        "effect": "Deal light Wind damage to 1 foe.",
         "element": "wind",
-        "personas": {"Bicorn": 6, "High Pixie": 0, "Kelpie": 0, "Kodama": 0, "Koppa Tengu": 0},
+        "personas": { "Bicorn": 6, "High Pixie": 0, "Kelpie": 0, "Kodama": 0, "Koppa Tengu": 0 },
         "talk": "Mad Marsh Horse (Kelpie)"
     },
     "Garudyne": {
         "cost": 1000,
         "effect": "Deal heavy Wind damage to 1 foe.",
         "element": "wind",
-        "personas": {"Emperor's Amulet": 0, "Fortuna": 47, "Garuda": 0, "Jatayu": 0, "Norn": 0, "Quetzalcoatl": 0},
+        "personas": { "Emperor's Amulet": 0, "Fortuna": 47, "Garuda": 0, "Jatayu": 0, "Norn": 0, "Quetzalcoatl": 0 },
         "talk": "Haughty Vulture (Jatayu)"
     },
     "Garula": {
@@ -1362,14 +1362,14 @@ const skillMapRoyal: SkillMap = {
         "effect": "Deal medium Wind damage to 1 foe.",
         "element": "wind",
         "fuse": ["High Pixie"],
-        "personas": {"Anzu": 0, "Fuu-Ki": 0, "Sandman": 0, "Stone of Scone": 0},
+        "personas": { "Anzu": 0, "Fuu-Ki": 0, "Sandman": 0, "Stone of Scone": 0 },
         "talk": "Tornado Devil (Fuu-Ki)"
     },
-    "Gattling Blows": {
+    "Gatling Blows": {
         "cost": 16,
-        "effect": "Deal 3 to 4 times light Phys damage to 1 foe.",
+        "effect": "Deal light Phys damage to 1 foe 3 to 4 times.",
         "element": "phys",
-        "personas": {"Hecatoncheires": 49}
+        "personas": { "Hecatoncheires": 49 }
     },
     "Ghastly Wail": {
         "cost": 2800,
@@ -1389,17 +1389,17 @@ const skillMapRoyal: SkillMap = {
     "Ghost Nest": {
         "effect": "Increases chance of inflicting ailments on downed foes",
         "element": "trait",
-        "personas": {"Mother Harlot": 0}
+        "personas": { "Mother Harlot": 0 }
     },
     "Giant Slice": {
         "cost": 9,
         "effect": "Deal medium Phys damage to 1 foe.",
         "element": "phys",
-        "personas": {"Archangel": 0, "Flauros": 0, "Inugami": 0, "Oni": 22, "Rakshasa": 0, "Setanta": 0}
+        "personas": { "Archangel": 0, "Flauros": 0, "Inugami": 0, "Oni": 22, "Rakshasa": 0, "Setanta": 0 }
     },
     "Gigantomachia": {
         "cost": 25,
-        "effect": "Deal grave Phys damage to all foes.",
+        "effect": "Deal colossal Phys damage to all foes.",
         "element": "phys",
         "personas": {
             "Abaddon": 81,
@@ -1415,7 +1415,7 @@ const skillMapRoyal: SkillMap = {
     "Gloomy Child": {
         "effect": "Activates all equipped special weather passives",
         "element": "trait",
-        "personas": {"Black Rider": 0, "Mokoi": 0, "Sudama": 0}
+        "personas": { "Black Rider": 0, "Mokoi": 0, "Sudama": 0 }
     },
     "Gluttonmouth": {
         "effect": "Strengthens own HP recovery by 50%",
@@ -1436,43 +1436,43 @@ const skillMapRoyal: SkillMap = {
         "effect": "Increases chance of ally traits activating",
         "element": "trait",
         "unique": "Izanagi",
-        "personas": {"Izanagi": 0, "Izanagi Picaro": 0}
+        "personas": { "Izanagi": 0, "Izanagi Picaro": 0 }
     },
     "God's Hand": {
         "cost": 25,
-        "effect": "Deal grave Phys damage to 1 foe.",
+        "effect": "Deal colossal Phys damage to 1 foe.",
         "element": "phys",
         "fuse": ["Cerberus"],
-        "personas": {"Ardha": 0, "Bishamonten": 73, "Melchizedek": 65, "Zaou-Gongen": 0, "Messiah": 0}
+        "personas": { "Ardha": 0, "Bishamonten": 73, "Melchizedek": 65, "Zaou-Gongen": 0, "Messiah": 0 }
     },
     "Grace of Mother": {
         "effect": "Reduces costs of Recovery skills by 75%",
         "element": "trait",
-        "personas": {"Ishtar": 0}
+        "personas": { "Ishtar": 0 }
     },
     "Grace of the Olive": {
         "effect": "Reduces costs of skills to 0 during 1 More",
         "element": "trait",
         "unique": "Athena",
-        "personas": {"Athena": 0, "Athena Picaro": 0}
+        "personas": { "Athena": 0, "Athena Picaro": 0 }
     },
-    "Great Aim": {"effect": "Gun hit rate +5%", "element": "passive"},
+    "Great Aim": { "effect": "Gun hit rate +5%", "element": "passive" },
     "Growth 1": {
         "effect": "Persona gains 1/4 EXP while inactive.",
         "element": "passive",
-        "personas": {"Koppa Tengu": 12, "Saki Mitama": 7}
+        "personas": { "Koppa Tengu": 12, "Saki Mitama": 7 }
     },
     "Growth 2": {
         "card": "CJ Beach",
         "effect": "Persona gains 1/2 EXP while inactive.",
         "element": "passive",
-        "personas": {"Ananta": 47, "Kurama Tengu": 36, "Lachesis": 0, "Thoth": 42}
+        "personas": { "Ananta": 47, "Kurama Tengu": 36, "Lachesis": 0, "Thoth": 42 }
     },
     "Growth 3": {
         "effect": "Persona gains full EXP even while inactive.",
         "element": "passive",
         "fuse": ["Izanagi Picaro"],
-        "personas": {"Narcissus": 50, "Quetzalcoatl": 68, "Raphael": 81, "Izanagi": 25, "Izanagi Picaro": 28}
+        "personas": { "Narcissus": 50, "Quetzalcoatl": 68, "Raphael": 81, "Izanagi": 25, "Izanagi Picaro": 28 }
     },
     "Guiding Tendril": {
         "card": "Ring of Sorrow",
@@ -1485,25 +1485,25 @@ const skillMapRoyal: SkillMap = {
         "effect": "Gun damage +50%",
         "element": "passive",
         "fuse": ["White Rider"],
-        "personas": {"Seth": 53, "Trumpeter": 62, "Zaou-Gongen": 84}
+        "personas": { "Seth": 53, "Trumpeter": 62, "Zaou-Gongen": 84 }
     },
-    "Gun Boost": {"effect": "Gun damage +25%", "element": "passive", "personas": {"White Rider": 40}},
+    "Gun Boost": { "effect": "Gun damage +25%", "element": "passive", "personas": { "White Rider": 40 } },
     "Hallowed Spirit": {
         "effect": "Doubles own HP and SP recovery",
         "element": "trait",
         "unique": "Messiah",
-        "personas": {"Messiah": 0, "Messiah Picaro": 0}
+        "personas": { "Messiah": 0, "Messiah Picaro": 0 }
     },
     "Hama": {
         "effect": "Small chance of instantly killing 1 foe.",
         "cost": 600,
         "element": "bless",
-        "personas": {"Archangel": 0}
+        "personas": { "Archangel": 0 }
     },
     "Hama Boost": {
         "effect": "Increase success rate of instant death by Bless skills.",
         "element": "passive",
-        "personas": {"Dominion": 71, "Horus": 52, "Isis": 30, "Melchizedek": 59, "Metatron": 92, "Sraosha": 0}
+        "personas": { "Dominion": 71, "Horus": 52, "Isis": 30, "Melchizedek": 59, "Metatron": 92, "Sraosha": 0 }
     },
     "Hamaon": {
         "effect": "Medium chance of instantly killing 1 foe.",
@@ -1524,22 +1524,22 @@ const skillMapRoyal: SkillMap = {
     },
     "Hassou Tobi": {
         "cost": 25,
-        "effect": "Deal 8 times weak Phys damage to all foes.",
+        "effect": "Deal light Phys damage to all foes 8 times.",
         "element": "phys",
         "unique": "Yoshitsune",
-        "personas": {"Yoshitsune": 94}
+        "personas": { "Yoshitsune": 94 }
     },
     "Hazy Presence": {
         "effect": "Increases chance of ally follow-up attacks",
         "element": "trait",
         "unique": "Raoul",
-        "personas": {"Raoul": 0}
+        "personas": { "Raoul": 0 }
     },
     "Headbutt": {
         "cost": 9,
         "effect": "Deal medium Phys damage and inflict Forget (medium odds) to 1 foe.",
         "element": "phys",
-        "personas": {"Black Ooze": 21, "Slime": 14}
+        "personas": { "Black Ooze": 21, "Slime": 14 }
     },
     "Heat Riser": {
         "card": "Jazz 12/4 CJ Underground Mall",
@@ -1563,18 +1563,18 @@ const skillMapRoyal: SkillMap = {
         "card": "Trial 50",
         "effect": "Recover 5% HP and 10 SP at the start of preemptive turn.",
         "element": "passive",
-        "personas": {"Flauros": 24, "Tam Lin": 32, "Thor": 68, "Ariadne Picaro": 44, "Izanagi-no-Okami": 83}
+        "personas": { "Flauros": 24, "Tam Lin": 32, "Thor": 68, "Ariadne Picaro": 44, "Izanagi-no-Okami": 83 }
     },
     "Heat Wave": {
         "cost": 20,
         "effect": "Deal heavy Phys damage to all foes.",
         "element": "phys",
-        "personas": {"Chimera": 0, "Kali": 0, "Mithras": 0, "Oberon": 0, "Okuninushi": 59, "Ose": 47}
+        "personas": { "Chimera": 0, "Kali": 0, "Mithras": 0, "Oberon": 0, "Okuninushi": 59, "Ose": 47 }
     },
     "Heated Bloodline": {
         "effect": "Halves costs of Fire skills",
         "element": "trait",
-        "personas": {"Byakhee": 0, "Cerberus": 0, "Decarabia": 0, "Orlov": 0, "Surt": 0}
+        "personas": { "Byakhee": 0, "Cerberus": 0, "Decarabia": 0, "Orlov": 0, "Surt": 0 }
     },
     "High Counter": {
         "card": "CJ Leblanc",
@@ -1604,26 +1604,26 @@ const skillMapRoyal: SkillMap = {
         "effect": "Damage +40% for each foe afflicted with an ailment",
         "element": "trait",
         "unique": "Magatsu-Izanagi",
-        "personas": {"Magatsu-Izanagi": 0, "Magatsu-Izanagi Picaro": 0}
+        "personas": { "Magatsu-Izanagi": 0, "Magatsu-Izanagi Picaro": 0 }
     },
     "Holy Benevolence": {
         "cost": 2600,
         "effect": "Revive all allies with 100% HP",
         "element": "healing",
         "unique": "Maria",
-        "personas": {"Maria": 0}
+        "personas": { "Maria": 0 }
     },
     "Holy Embrace": {
         "effect": "Recover 25% max HP each turn in battle",
         "element": "passive",
         "unique": "Maria",
-        "personas": {"Maria": 96}
+        "personas": { "Maria": 96 }
     },
     "Holy Whisper": {
         "effect": "Recover 15% max HP and 15 SP each turn in battle",
         "element": "passive",
         "unique": "Maria",
-        "personas": {"Maria": 98}
+        "personas": { "Maria": 98 }
     },
     "Hyakka Ryouran": {
         "cost": 9000,
@@ -1635,14 +1635,14 @@ const skillMapRoyal: SkillMap = {
         "cost": 9,
         "effect": "Deal medium Phys damage and inflict Rage (medium odds) to 1 foe.",
         "element": "phys",
-        "personas": {"Kushinada": 0, "Nekomata": 18, "Yaksini": 0},
+        "personas": { "Kushinada": 0, "Nekomata": 18, "Yaksini": 0 },
         "talk": "Life-Draining Spirit (Kumbhanda)"
     },
     "Ice Age": {
         "cost": 5400,
         "effect": "Deal severe Ice damage to all foes.",
         "element": "ice",
-        "personas": {"Alilat": 87, "Mother Harlot": 86, "Satan": 0}
+        "personas": { "Alilat": 87, "Mother Harlot": 86, "Satan": 0 }
     },
     "Ice Amp": {
         "effect": "Strengthen Ice attacks by 50%.",
@@ -1662,19 +1662,19 @@ const skillMapRoyal: SkillMap = {
     "Ice Boost": {
         "effect": "Strengthen Ice attacks by 25%.",
         "element": "passive",
-        "personas": {"Byakko": 47, "Lachesis": 41}
+        "personas": { "Byakko": 47, "Lachesis": 41 }
     },
     "Ice Break": {
         "cost": 600,
         "effect": "Negate Ice resistances of all foes.",
         "element": "support",
-        "personas": {"Belphegor": 0, "Byakko": 48, "Jack Frost": 0, "King Frost": 0}
+        "personas": { "Belphegor": 0, "Byakko": 48, "Jack Frost": 0, "King Frost": 0 }
     },
     "Ice Wall": {
         "cost": 1800,
         "effect": "Create a shield on 1 ally to reduce damage of Ice attacks for 3 turns.",
         "element": "support",
-        "personas": {"Apsaras": 0, "Bicorn": 7, "Koumokuten": 52, "Onmoraki": 0, "Sarasvati": 0}
+        "personas": { "Apsaras": 0, "Bicorn": 7, "Koumokuten": 52, "Onmoraki": 0, "Sarasvati": 0 }
     },
     "Icy Glare": {
         "effect": "Reduces ailment susceptibility by 25% for all allies",
@@ -1684,14 +1684,14 @@ const skillMapRoyal: SkillMap = {
     "Immunity": {
         "effect": "Nullifies ailments",
         "element": "trait",
-        "personas": {"Arahabaki": 0, "Moloch": 0, "Orichalcum": 0}
+        "personas": { "Arahabaki": 0, "Moloch": 0, "Orichalcum": 0 }
     },
     "Inferno": {
         "cost": 4800,
         "effect": "Deal severe Fire damage to 1 foe.",
         "element": "fire",
         "fuse": ["Surt"],
-        "personas": {"Mada": 0, "Orichalcum": 0, "Throne": 78}
+        "personas": { "Mada": 0, "Orichalcum": 0, "Throne": 78 }
     },
     "Infinite Scheme": {
         "effect": "Restores 100% after Futaba's All-Out Attack for all allies",
@@ -1706,7 +1706,7 @@ const skillMapRoyal: SkillMap = {
     "Insta-Heal": {
         "effect": "Recover from an ailment in 1 turn.",
         "element": "passive",
-        "personas": {"Ishtar": 87, "Lucifer": 98, "Messiah Picaro": 91}
+        "personas": { "Ishtar": 87, "Lucifer": 98, "Messiah Picaro": 91 }
     },
     "Intense Focus": {
         "effect": "Single-target magic damage +20%",
@@ -1739,43 +1739,43 @@ const skillMapRoyal: SkillMap = {
         "card": "Technician 30",
         "effect": "Recover 3 SP each turn in battle.",
         "element": "passive",
-        "personas": {"Clotho": 33, "Neko Shogun": 31}
+        "personas": { "Clotho": 33, "Neko Shogun": 31 }
     },
     "Invigorate 2": {
         "effect": "Recover 5 SP each turn in battle.",
         "element": "passive",
-        "personas": {"Barong": 0, "Hope Diamond": 0}
+        "personas": { "Barong": 0, "Hope Diamond": 0 }
     },
     "Invigorate 3": {
         "effect": "Recover 7 SP each turn in battle.",
         "element": "passive",
-        "personas": {"Ardha": 0, "Maria": 0, "Satan": 95, "Throne": 76, "Vohu Manah": 84, "Messiah": 84}
+        "personas": { "Ardha": 0, "Maria": 0, "Satan": 95, "Throne": 76, "Vohu Manah": 84, "Messiah": 84 }
     },
     "Inviolable Beauty": {
         "effect": "Triples damage dealt by Counter skills",
         "element": "trait",
         "unique": "Kaguya",
-        "personas": {"Kaguya": 0, "Kaguya Picaro": 0}
+        "personas": { "Kaguya": 0, "Kaguya Picaro": 0 }
     },
     "Iron Heart": {
         "effect": "Halves costs of SP skills after Baton Pass",
         "element": "trait",
         "unique": "Thanatos",
-        "personas": {"Thanatos": 0, "Thanatos Picaro": 0}
+        "personas": { "Thanatos": 0, "Thanatos Picaro": 0 }
     },
-    "Just Die": {"effect": "Reduces costs of instant death skills to 0", "element": "trait", "personas": {"Alice": 0}},
+    "Just Die": { "effect": "Reduces costs of instant death skills to 0", "element": "trait", "personas": { "Alice": 0 } },
     "Kill Rush": {
         "cost": 14,
-        "effect": "Deal 1-3 times light Phys damage to 1 foe.",
+        "effect": "Deal light Phys damage to 1 foe 1-3 times.",
         "element": "phys",
         "fuse": ["Oni"],
-        "personas": {"Jikokuten": 24, "Zouchouten": 0}
+        "personas": { "Jikokuten": 24, "Zouchouten": 0 }
     },
     "Kouga": {
         "cost": 800,
         "effect": "Deal medium Bless damage to 1 foe.",
         "element": "bless",
-        "personas": {"Mithra": 0, "Stone of Scone": 0},
+        "personas": { "Mitra": 0, "Stone of Scone": 0 },
         "talk": "Expressionless Beast (Unicorn)"
     },
     "Kougaon": {
@@ -1783,37 +1783,37 @@ const skillMapRoyal: SkillMap = {
         "effect": "Deal heavy Bless damage to 1 foe.",
         "element": "bless",
         "fuse": ["Anubis"],
-        "personas": {"Dominion": 0, "Emperor's Amulet": 0, "Horus": 0, "Sraosha": 0, "Unicorn": 43}
+        "personas": { "Dominion": 0, "Emperor's Amulet": 0, "Horus": 0, "Sraosha": 0, "Unicorn": 43 }
     },
     "Kouha": {
         "cost": 400,
-        "effect": "Deal weak Bless damage to 1 foe.",
+        "effect": "Deal light Bless damage to 1 foe.",
         "element": "bless",
-        "personas": {"Angel": 0},
+        "personas": { "Angel": 0 },
         "talk": "Heavenly Punisher (Archangel)"
     },
-    "Kuzunoha's Order": {"effect": "Reduces skill costs by 25%", "element": "passive"},
-    "Laevateinn": {"cost": 25, "effect": "Colossal damage to 1 foe", "element": "phys", "unique": "Loki"},
+    "Kuzunoha's Order": { "effect": "Reduces skill costs by 25%", "element": "passive" },
+    "Laevateinn": { "cost": 25, "effect": "Colossal damage to 1 foe", "element": "phys", "unique": "Loki" },
     "Last Stand": {
-        "effect": "Reduces enemy hit rate by 2/3 when ambushed",
+        "effect": "Reduces enemy hit rate by 2/3 when surrounded",
         "element": "passive",
-        "personas": {"Ongyo-Ki": 0, "Red Rider": 46, "Yatagarasu": 60, "Yoshitsune": 89}
+        "personas": { "Ongyo-Ki": 0, "Red Rider": 46, "Yatagarasu": 60, "Yoshitsune": 89 }
     },
     "Life Aid": {
         "card": "Trial 80",
         "effect": "Recover 8% HP and SP after a successful battle.",
         "element": "passive",
-        "personas": {"Kohryu": 78, "Lakshmi": 74, "Trumpeter": 63, "Messiah Picaro": 93, "Raoul": 82}
+        "personas": { "Kohryu": 78, "Lakshmi": 74, "Trumpeter": 63, "Messiah Picaro": 93, "Raoul": 82 }
     },
-    "Life Boost": {"effect": "All Stats +3, SP +20", "element": "passive"},
+    "Life Boost": { "effect": "All Stats +3, SP +20", "element": "passive" },
     "Life Drain": {
         "cost": 300,
         "effect": "Drains HP from 1 foe.",
         "element": "almighty",
-        "personas": {"Choronzon": 0, "Incubus": 0, "Legion": 0, "Loa": 0, "Tsukiyomi": 0},
+        "personas": { "Choronzon": 0, "Incubus": 0, "Legion": 0, "Loa": 0, "Tsukiyomi": 0 },
         "talk": "Bedside Brute (Incubus)"
     },
-    "Life Leech": {"effect": "Drains 150 HP from 1 foe.", "element": "almighty", "unique": "Enemies"},
+    "Life Leech": { "effect": "Drains 150 HP from 1 foe.", "element": "almighty", "unique": "Enemies" },
     "Life Wall": {
         "cost": 9500,
         "effect": "Repels next non-Almighty attack for all allies",
@@ -1823,42 +1823,42 @@ const skillMapRoyal: SkillMap = {
     "Linked Bloodline": {
         "effect": "Greatly raises damage dealt after Baton Pass",
         "element": "trait",
-        "personas": {"Cybele": 0}
+        "personas": { "Cybele": 0 }
     },
     "Lucky Punch": {
         "effect": "Deal minuscule Phys damage to 1 foe. High critical rate.",
         "cost": 3,
         "element": "phys",
-        "personas": {"Inugami": 17, "Obariyon": 9, "Sudama": 0}
+        "personas": { "Inugami": 17, "Obariyon": 9, "Sudama": 0 }
     },
     "Lullaby": {
         "cost": 800,
         "effect": "Inflict Sleep (medium odds) to all foes.",
         "element": "ailment",
         "fuse": ["Sandman"],
-        "personas": {"Kikuri-Hime": 0, "Lakshmi": 0, "Lilim": 0, "Titania": 0},
+        "personas": { "Kikuri-Hime": 0, "Lakshmi": 0, "Lilim": 0, "Titania": 0 },
         "talk": "Woman who brings Ruin (Lilim)"
     },
     "Lunge": {
         "cost": 5,
-        "effect": "Deal weak Phys damage to 1 foe.",
+        "effect": "Deal light Phys damage to 1 foe.",
         "element": "phys",
-        "personas": {"Agathion": 4, "Bicorn": 0, "Kelpie": 0, "Mandrake": 4, "Slime": 0},
+        "personas": { "Agathion": 4, "Bicorn": 0, "Kelpie": 0, "Mandrake": 4, "Slime": 0 },
         "talk": "Dirty Two-Horned Beast (Bicorn)"
     },
     "Mabaisudi": {
         "cost": 800,
         "effect": "Cure Burn/Freeze/Shock of party.",
         "element": "healing",
-        "personas": {"Hariti": 0, "Lachesis": 0, "Mithras": 43, "Principality": 35}
+        "personas": { "Hariti": 0, "Lachesis": 0, "Mithras": 43, "Principality": 35 }
     },
     "Mabufu": {
         "card": "CJ BBB",
         "cost": 1000,
-        "effect": "Deal weak Ice damage to all foes.",
+        "effect": "Deal light Ice damage to all foes.",
         "element": "ice",
         "fuse": ["Koropokkuru"],
-        "personas": {"Genbu": 10, "Jack Frost": 12, "Koropokkuru": 14, "Regent": 0, "Sui-Ki": 0},
+        "personas": { "Genbu": 10, "Jack Frost": 12, "Koropokkuru": 14, "Regent": 0, "Sui-Ki": 0 },
         "talk": "Raging Water Demon (Sui-Ki)"
     },
     "Mabufudyne": {
@@ -1889,13 +1889,13 @@ const skillMapRoyal: SkillMap = {
         "effect": "Deal medium Ice damage to all foes.",
         "element": "ice",
         "fuse": ["Sui-Ki"],
-        "personas": {"Belphegor": 0, "Byakko": 0, "Lachesis": 39, "Lilim": 37, "Orlov": 0, "Sui-Ki": 28}
+        "personas": { "Belphegor": 0, "Byakko": 0, "Lachesis": 39, "Lilim": 37, "Orlov": 0, "Sui-Ki": 28 }
     },
     "Maeiga": {
         "cost": 1600,
         "effect": "Deal medium Curse damage to all foes.",
         "element": "curse",
-        "personas": {"Anubis": 36, "Orlov": 0, "Pazuzu": 0, "White Rider": 41}
+        "personas": { "Anubis": 36, "Orlov": 0, "Pazuzu": 0, "White Rider": 41 }
     },
     "Maeigaon": {
         "cost": 2200,
@@ -1918,16 +1918,16 @@ const skillMapRoyal: SkillMap = {
     },
     "Maeiha": {
         "cost": 1000,
-        "effect": "Deal weak Curse damage to all foes.",
+        "effect": "Deal light Curse damage to all foes.",
         "element": "curse",
-        "personas": {"Choronzon": 29, "Nue": 0, "Regent": 0}
+        "personas": { "Choronzon": 29, "Nue": 0, "Regent": 0 }
     },
     "Mafrei": {
         "cost": 1000,
-        "effect": "Deal weak Nuclear damage to all foes.",
+        "effect": "Deal light Nuclear damage to all foes.",
         "element": "nuclear",
         "fuse": ["Makami"],
-        "personas": {"Makami": 17, "Regent": 0, "Suzaku": 19},
+        "personas": { "Makami": 17, "Regent": 0, "Suzaku": 19 },
         "talk": "Hunting Wolf Spirit (Makami)"
     },
     "Mafreidyne": {
@@ -1935,13 +1935,13 @@ const skillMapRoyal: SkillMap = {
         "effect": "Deal heavy Nuclear damage to all foes.",
         "element": "nuclear",
         "fuse": ["Titania"],
-        "personas": {"Asura": 79, "Bishamonten": 69, "Crystal Skull": 0, "Lilith": 62, "Trumpeter": 0}
+        "personas": { "Asura": 79, "Bishamonten": 69, "Crystal Skull": 0, "Lilith": 62, "Trumpeter": 0 }
     },
     "Mafreila": {
         "cost": 1600,
         "effect": "Deal medium Nuclear damage to all foes.",
         "element": "nuclear",
-        "personas": {"Ananta": 0, "Mithras": 0, "Orlov": 0, "Phoenix": 26},
+        "personas": { "Ananta": 0, "Mithras": 0, "Orlov": 0, "Phoenix": 26 },
         "talk": "Dark Sun (Mithras)"
     },
     "Magaru": {
@@ -1949,7 +1949,7 @@ const skillMapRoyal: SkillMap = {
         "effect": "Deal small Wind damage to all foes.",
         "element": "wind",
         "fuse": ["Kelpie"],
-        "personas": {"Ame-no-Uzume": 0, "High Pixie": 22, "Nekomata": 0, "Regent": 0},
+        "personas": { "Ame-no-Uzume": 0, "High Pixie": 22, "Nekomata": 0, "Regent": 0 },
         "talk": "Captivating Dancer (Ame-no-Uzume)"
     },
     "Magarudyne": {
@@ -1988,7 +1988,7 @@ const skillMapRoyal: SkillMap = {
         "effect": "Deal heavy Curse damage to all foes and inflict Confuse/Fear/Despair (medium odds).",
         "element": "curse",
         "unique": "Magatsu-Izanagi",
-        "personas": {"Magatsu-Izanagi": 0, "Magatsu-Izanagi Picaro": 0}
+        "personas": { "Magatsu-Izanagi": 0, "Magatsu-Izanagi Picaro": 0 }
     },
     "Magic Ability": {
         "card": "Network Fusion",
@@ -2000,7 +2000,7 @@ const skillMapRoyal: SkillMap = {
         "cost": 1400,
         "element": "bless",
         "fuse": ["Archangel"],
-        "personas": {"Clotho": 0, "Isis": 0, "Mithra": 0, "Unicorn": 0},
+        "personas": { "Clotho": 0, "Isis": 0, "Mitra": 0, "Unicorn": 0 },
         "talk": "She of Life and Death (Isis)"
     },
     "Mahamaon": {
@@ -2029,7 +2029,7 @@ const skillMapRoyal: SkillMap = {
         "cost": 300,
         "effect": "Inflict Forget (high odds) to 1 foe.",
         "element": "ailment",
-        "personas": {"Angel": 0, "Clotho": 0, "Kaiwan": 0, "Koropokkuru": 0, "Kushi Mitama": 0, "Makami": 18},
+        "personas": { "Angel": 0, "Clotho": 0, "Kaiwan": 0, "Koropokkuru": 0, "Kushi Mitama": 0, "Makami": 18 },
         "talk": "Zealous Messenger (Angel)"
     },
     "Makajamaon": {
@@ -2053,7 +2053,7 @@ const skillMapRoyal: SkillMap = {
         "effect": "Remove magic-repellent shields from all foes.",
         "cost": 900,
         "element": "support",
-        "personas": {"Queen Mab": 46, "Yatagarasu": 0}
+        "personas": { "Queen Mab": 46, "Yatagarasu": 0 }
     },
     "Makarakarn": {
         "card": "Jazz 10/30",
@@ -2077,7 +2077,7 @@ const skillMapRoyal: SkillMap = {
         "effect": "Deal medium Bless damage to all foes.",
         "element": "bless",
         "fuse": ["Isis"],
-        "personas": {"Anubis": 0, "Daisoujou": 0, "Isis": 0, "Mithra": 34, "Orlov": 0, "Power": 43, "Principality": 0},
+        "personas": { "Anubis": 0, "Daisoujou": 0, "Isis": 0, "Mitra": 34, "Orlov": 0, "Power": 43, "Principality": 0 },
         "talk": "Divine Warrior (Power)"
     },
     "Makougaon": {
@@ -2097,17 +2097,17 @@ const skillMapRoyal: SkillMap = {
     },
     "Makouha": {
         "cost": 1000,
-        "effect": "Deal weak Bless damage to all foes.",
+        "effect": "Deal light Bless damage to all foes.",
         "element": "bless",
         "fuse": ["Angel"],
-        "personas": {"Nigi Mitama": 0, "Regent": 0}
+        "personas": { "Nigi Mitama": 0, "Regent": 0 }
     },
     "Mamudo": {
         "effect": "Small chance of instantly killing all foes.",
         "cost": 1400,
         "element": "curse",
         "fuse": ["Leanan Sidhe"],
-        "personas": {"Lamia": 30, "Leanan Sidhe": 21, "Nue": 24, "Pisaca": 29}
+        "personas": { "Lamia": 30, "Leanan Sidhe": 21, "Nue": 24, "Pisaca": 29 }
     },
     "Mamudoon": {
         "effect": "medium chance of instantly killing all foes.",
@@ -2130,31 +2130,31 @@ const skillMapRoyal: SkillMap = {
     },
     "Mapsi": {
         "cost": 1000,
-        "effect": "Deal weak Psy damage to all foes.",
+        "effect": "Deal light Psy damage to all foes.",
         "element": "psy",
-        "personas": {"Leanan Sidhe": 22, "Matador": 18, "Regent": 0, "Shiki-Ouji": 19, "Sudama": 0}
+        "personas": { "Leanan Sidhe": 22, "Matador": 18, "Regent": 0, "Shiki-Ouji": 19, "Sudama": 0 }
     },
     "Mapsio": {
         "cost": 1600,
         "effect": "Deal medium Psy damage to all foes.",
         "element": "psy",
-        "personas": {"Okuninushi": 0, "Orlov": 0, "Red Rider": 0}
+        "personas": { "Okuninushi": 0, "Orlov": 0, "Red Rider": 0 }
     },
     "Mapsiodyne": {
         "cost": 2200,
         "effect": "Deal heavy Psy damage to all foes.",
         "element": "psy",
         "fuse": ["Forneus"],
-        "personas": {"Crystal Skull": 0, "Forneus": 67, "Kohryu": 0, "Mara": 0, "Nebiros": 0, "Parvati": 59},
+        "personas": { "Crystal Skull": 0, "Forneus": 67, "Kohryu": 0, "Mara": 0, "Nebiros": 0, "Parvati": 59 },
         "talk": "Throbbing King of Desires (Mara)"
     },
     "Maragi": {
         "card": "CJ BBB",
         "cost": 1000,
-        "effect": "Deal weak Fire damage to all foes.",
+        "effect": "Deal light Fire damage to all foes.",
         "element": "fire",
         "fuse": ["Cait Sith"],
-        "personas": {"Eligor": 0, "Hua Po": 13, "Orobas": 0, "Orthrus": 0, "Regent": 0, "Orpheus F Picaro": 0}
+        "personas": { "Eligor": 0, "Hua Po": 13, "Orobas": 0, "Orthrus": 0, "Regent": 0, "Orpheus F Picaro": 0 }
     },
     "Maragidyne": {
         "cost": 2200,
@@ -2180,7 +2180,7 @@ const skillMapRoyal: SkillMap = {
         "effect": "Deal medium Fire damage to all foes.",
         "element": "fire",
         "fuse": ["Orthrus"],
-        "personas": {"Hell Biker": 40, "Orlov": 0, "Orpheus": 29, "Orpheus F": 12, "Orpheus Picaro": 0}
+        "personas": { "Hell Biker": 40, "Orlov": 0, "Orpheus": 29, "Orpheus F": 12, "Orpheus Picaro": 0 }
     },
     "Marakukaja": {
         "card": "Jazz 7/17 10/16",
@@ -2212,20 +2212,20 @@ const skillMapRoyal: SkillMap = {
         "effect": "Decrease all foes' Defense for 3 turns.",
         "element": "support",
         "fuse": ["Orobas"],
-        "personas": {"Ara Mitama": 32, "Chimera": 76, "Girimehkala": 0, "Kaiwan": 41, "Orobas": 19, "Surt": 85}
+        "personas": { "Ara Mitama": 32, "Chimera": 76, "Girimehkala": 0, "Kaiwan": 41, "Orobas": 19, "Surt": 85 }
     },
     "Marin Karin": {
         "cost": 300,
         "effect": "Inflict Brainwash (high odds) to 1 foe.",
         "element": "ailment",
-        "personas": {"Leanan Sidhe": 20, "Mokoi": 12, "Nebiros": 0, "Suzaku": 0}
+        "personas": { "Leanan Sidhe": 20, "Mokoi": 12, "Nebiros": 0, "Suzaku": 0 }
     },
     "Martyr's Gift": {
         "effect": "Reduces costs of Bless skills by 75%",
         "element": "trait",
-        "personas": {"Metatron": 0}
+        "personas": { "Metatron": 0 }
     },
-    "Masquerade": {"cost": 25, "effect": "Severe damage to 1 foe, x2 hits", "element": "phys", "unique": "Ella"},
+    "Masquerade": { "cost": 25, "effect": "Severe damage to 1 foe, x2 hits", "element": "phys", "unique": "Ella" },
     "Mastery of Magic": {
         "effect": "Low chance to decrease attack spell costs for all allies",
         "element": "trait",
@@ -2255,7 +2255,7 @@ const skillMapRoyal: SkillMap = {
         "effect": "Decrease all foes' Agility for 3 turns.",
         "element": "support",
         "fuse": ["Mandrake"],
-        "personas": {"Bugs": 0, "Forneus": 0, "Ganesha": 57, "Kurama Tengu": 0, "Lilim": 34, "Thoth": 0},
+        "personas": { "Bugs": 0, "Forneus": 0, "Ganesha": 57, "Kurama Tengu": 0, "Lilim": 34, "Thoth": 0 },
         "talk": "Killer Teddy Bear (Bugs)"
     },
     "Matarukaja": {
@@ -2291,15 +2291,15 @@ const skillMapRoyal: SkillMap = {
         "effect": "Decrease all foes' Attack power for 3 turns.",
         "element": "support",
         "fuse": ["Slime"],
-        "personas": {"Hanuman": 0, "Queen Mab": 44, "Rangda": 51, "Sarasvati": 53, "Suzaku": 21, "Orpheus Picaro": 0},
+        "personas": { "Hanuman": 0, "Queen Mab": 44, "Rangda": 51, "Sarasvati": 53, "Suzaku": 21, "Orpheus Picaro": 0 },
         "talk": "Dancing Witch (Rangda)"
     },
     "Mazio": {
         "cost": 1000,
-        "effect": "Deal weak Electric damage to all foes.",
+        "effect": "Deal light Electric damage to all foes.",
         "element": "electric",
         "fuse": ["Agathion"],
-        "personas": {"Ame-no-Uzume": 0, "Regent": 0}
+        "personas": { "Ame-no-Uzume": 0, "Regent": 0 }
     },
     "Maziodyne": {
         "cost": 2200,
@@ -2344,7 +2344,7 @@ const skillMapRoyal: SkillMap = {
         "cost": 800,
         "effect": "Cure Dizzy/Forget/Sleep/Hunger of party.",
         "element": "healing",
-        "personas": {"Clotho": 0, "Daisoujou": 44, "Nigi Mitama": 25}
+        "personas": { "Clotho": 0, "Daisoujou": 44, "Nigi Mitama": 25 }
     },
     "Media": {
         "cost": 700,
@@ -2410,7 +2410,7 @@ const skillMapRoyal: SkillMap = {
         "cost": 1500,
         "effect": "Deal medium Almighty damage to all foes.",
         "element": "almighty",
-        "personas": {"Thoth": 37},
+        "personas": { "Thoth": 37 },
         "talk": "Chanting Baboon (Thoth)"
     },
     "Megidola": {
@@ -2460,26 +2460,26 @@ const skillMapRoyal: SkillMap = {
         "effect": "Deal light Phys damage and inflict Forget (low odds) to all foes.",
         "element": "phys",
         "fuse": ["Black Ooze"],
-        "personas": {"Eligor": 20, "Naga": 0, "Oni": 24, "Quetzalcoatl": 0}
+        "personas": { "Eligor": 20, "Naga": 0, "Oni": 24, "Quetzalcoatl": 0 }
     },
     "Mighty Gaze": {
         "effect": "All-target magic damage +20%",
         "element": "trait",
-        "personas": {"Atropos": 0, "Lilith": 0, "Mara": 0, "Mot": 0, "Nue": 0, "Orobas": 0, "Regent": 0}
+        "personas": { "Atropos": 0, "Lilith": 0, "Mara": 0, "Mot": 0, "Nue": 0, "Orobas": 0, "Regent": 0 }
     },
     "Mind Slice": {
         "cost": 19,
         "effect": "Deal medium Phys damage and inflict Confuse (low odds) to all foes.",
         "element": "phys",
         "fuse": ["Mothman"],
-        "personas": {"Garuda": 0, "Rakshasa": 27}
+        "personas": { "Garuda": 0, "Rakshasa": 27 }
     },
     "Miracle Punch": {
         "cost": 8,
         "effect": "Deal medium Phys damage to 1 foe. High critical rate.",
         "element": "phys",
         "fuse": ["Obariyon"],
-        "personas": {"Ara Mitama": 0, "Black Frost": 0, "Bugs": 0, "Ganesha": 0, "Ariadne": 0, "Ariadne Picaro": 0},
+        "personas": { "Ara Mitama": 0, "Black Frost": 0, "Bugs": 0, "Ganesha": 0, "Ariadne": 0, "Ariadne Picaro": 0 },
         "talk": "Auspicious Pachyderm (Ganesha)"
     },
     "Miracle Rush": {
@@ -2488,7 +2488,7 @@ const skillMapRoyal: SkillMap = {
         "element": "phys",
         "unique": "Diego"
     },
-    "Money Boost": {"effect": "Doubles money earned after battle", "element": "passive"},
+    "Money Boost": { "effect": "Doubles money earned after battle", "element": "passive" },
     "Moral Support": {
         "effect": "Chance to cast Kaja or party-healing magic during battle.",
         "element": "passive",
@@ -2499,29 +2499,29 @@ const skillMapRoyal: SkillMap = {
         "effect": "Deal severe Almighty damage to all foes.",
         "element": "almighty",
         "unique": "Lucifer",
-        "personas": {"Lucifer": 94}
+        "personas": { "Lucifer": 94 }
     },
     "Mother's Lament": {
         "effect": "Reduces costs of Curse skills by 75%",
         "element": "trait",
-        "personas": {"Beelzebub": 0}
+        "personas": { "Beelzebub": 0 }
     },
     "Mouth of Savoring": {
         "effect": "Strengthens own SP recovery by 50%",
         "element": "trait",
-        "personas": {"Abaddon": 0, "Hastur": 0, "Orichalcum": 0, "Uriel": 0, "Yurlungur": 0}
+        "personas": { "Abaddon": 0, "Hastur": 0, "Orichalcum": 0, "Uriel": 0, "Yurlungur": 0 }
     },
     "Mudo": {
         "effect": "Small chance of instantly killing 1 foe.",
         "cost": 600,
         "element": "curse",
-        "personas": {"Lamia": 0, "Nue": 21, "Succubus": 12},
+        "personas": { "Lamia": 0, "Nue": 21, "Succubus": 12 },
         "talk": "Corpse Bird (Onmoraki)"
     },
     "Mudo Boost": {
         "effect": "Increase success rate of instant death by Curse skills.",
         "element": "passive",
-        "personas": {"Alice": 0, "Mother Harlot": 0, "Thanatos Picaro": 70}
+        "personas": { "Alice": 0, "Mother Harlot": 0, "Thanatos Picaro": 70 }
     },
     "Mudoon": {
         "effect": "medium chance of instantly killing 1 foe.",
@@ -2540,7 +2540,7 @@ const skillMapRoyal: SkillMap = {
     },
     "Myriad Slashes": {
         "cost": 20,
-        "effect": "Deal 2 to 3 times medium Phys damage to 1 foe.",
+        "effect": "Deal medium Phys damage to 1 foe 2 to 3 times.",
         "element": "phys",
         "fuse": ["Dakini"],
         "personas": {
@@ -2563,14 +2563,14 @@ const skillMapRoyal: SkillMap = {
         "effect": "Deal 3 times heavy Almighty damage to all foes.",
         "element": "almighty",
         "unique": "Izanagi-no-Okami",
-        "personas": {"Izanagi-no-Okami": 0, "Izanagi-no-Okami Picaro": 0}
+        "personas": { "Izanagi-no-Okami": 0, "Izanagi-no-Okami Picaro": 0 }
     },
-    "Naranari": {"effect": "Doubles effectiveness of SP regeneration skills", "element": "trait", "personas": {"Ardha": 0}},
+    "Naranari": { "effect": "Doubles effectiveness of SP regeneration skills", "element": "trait", "personas": { "Ardha": 0 } },
     "Negative Pile": {
         "cost": 12,
         "effect": "Deal heavy Phys damage and inflict Despair (medium odds) to 1 foe.",
         "element": "phys",
-        "personas": {"Red Rider": 42},
+        "personas": { "Red Rider": 42 },
         "talk": "Slithering Snakewoman (Lamia)"
     },
     "Neo Cadenza": {
@@ -2578,32 +2578,32 @@ const skillMapRoyal: SkillMap = {
         "effect": "Restore 50% HP of party and increase attack, defense, and evasion rate.",
         "element": "healing",
         "unique": "Orpheus F",
-        "personas": {"Orpheus F": 0, "Orpheus F Picaro": 0}
+        "personas": { "Orpheus F": 0, "Orpheus F Picaro": 0 }
     },
     "Nocturnal Flash": {
         "cost": 800,
         "effect": "Inflict Dizzy (medium odds) to all foes.",
         "element": "ailment",
         "fuse": ["Narcissus"],
-        "personas": {"Ame-no-Uzume": 15, "Hariti": 42, "Hastur": 0, "Jatayu": 0, "Norn": 0, "Oberon": 0},
+        "personas": { "Ame-no-Uzume": 15, "Hariti": 42, "Hastur": 0, "Jatayu": 0, "Norn": 0, "Oberon": 0 },
         "talk": "Self-Infatuated Star (Narcissus)"
     },
     "Nuke Amp": {
         "effect": "Strengthen Nuclear attacks by 50%.",
         "element": "passive",
         "fuse": ["Mithras"],
-        "personas": {"Bishamonten": 71, "Fafnir": 90, "Lilith": 65, "Titania": 60}
+        "personas": { "Bishamonten": 71, "Fafnir": 90, "Lilith": 65, "Titania": 60 }
     },
     "Nuke Boost": {
         "effect": "Strengthen Nuclear attacks by 25%.",
         "element": "passive",
-        "personas": {"Ananta": 50, "Phoenix": 25}
+        "personas": { "Ananta": 50, "Phoenix": 25 }
     },
     "Nuke Break": {
         "cost": 600,
         "effect": "Negate Nuclear resistances of all foes.",
         "element": "support",
-        "personas": {"Mithras": 42}
+        "personas": { "Mithras": 42 }
     },
     "Nuke Wall": {
         "cost": 1800,
@@ -2613,75 +2613,75 @@ const skillMapRoyal: SkillMap = {
     "Null Bless": {
         "effect": "Impart immunity against Bless attacks.",
         "element": "passive",
-        "personas": {"Nebiros": 80}
+        "personas": { "Nebiros": 80 }
     },
     "Null Brainwash": {
         "effect": "Impart immunity against Brainwash.",
         "element": "passive",
-        "personas": {"Arahabaki": 0}
+        "personas": { "Arahabaki": 0 }
     },
-    "Null Burn": {"effect": "Immune to Burn", "element": "passive"},
-    "Null Confuse": {"effect": "Impart immunity against Confuse.", "element": "passive", "personas": {"Kushinada": 45}},
+    "Null Burn": { "effect": "Immune to Burn", "element": "passive" },
+    "Null Confuse": { "effect": "Impart immunity against Confuse.", "element": "passive", "personas": { "Kushinada": 45 } },
     "Null Curse": {
         "effect": "Impart immunity against Curse attacks.",
         "element": "passive",
-        "personas": {"Power": 46, "Vasuki": 73}
+        "personas": { "Power": 46, "Vasuki": 73 }
     },
-    "Null Despair": {"effect": "Impart immunity against Despair.", "element": "passive"},
+    "Null Despair": { "effect": "Impart immunity against Despair.", "element": "passive" },
     "Null Dizzy": {
         "effect": "Impart immunity against Dizzy.",
         "element": "passive",
-        "personas": {"Legion": 42, "Matador": 0}
+        "personas": { "Legion": 42, "Matador": 0 }
     },
     "Null Elec": {
         "effect": "Impart immunity against Electric attacks.",
         "element": "passive",
-        "personas": {"Barong": 55}
+        "personas": { "Barong": 55 }
     },
-    "Null Fear": {"effect": "Impart immunity against Fear.", "element": "passive"},
+    "Null Fear": { "effect": "Impart immunity against Fear.", "element": "passive" },
     "Null Fire": {
         "effect": "Impart immunity against Fire attacks.",
         "element": "passive",
-        "personas": {"Decarabia": 37}
+        "personas": { "Decarabia": 37 }
     },
-    "Null Forget": {"effect": "Impart immunity against Forget.", "element": "passive", "personas": {"Anzu": 29}},
-    "Null Freeze": {"effect": "Immune to Freeze", "element": "passive"},
-    "Null Hunger": {"effect": "Immune to Hunger", "element": "passive"},
+    "Null Forget": { "effect": "Impart immunity against Forget.", "element": "passive", "personas": { "Anzu": 29 } },
+    "Null Freeze": { "effect": "Immune to Freeze", "element": "passive" },
+    "Null Hunger": { "effect": "Immune to Hunger", "element": "passive" },
     "Null Ice": {
         "effect": "Impart immunity against Ice attacks.",
         "element": "passive",
-        "personas": {"Kushinada": 48, "Parvati": 61, "Sui-Ki": 26}
+        "personas": { "Kushinada": 48, "Parvati": 61, "Sui-Ki": 26 }
     },
-    "Null Mortal": {"effect": "Nullifies damage from Bless and Curse attacks", "element": "passive"},
-    "Null Nuke": {"effect": "Impart immunity against Nuclear attacks.", "element": "passive"},
+    "Null Mortal": { "effect": "Nullifies damage from Bless and Curse attacks", "element": "passive" },
+    "Null Nuke": { "effect": "Impart immunity against Nuclear attacks.", "element": "passive" },
     "Null Phys": {
         "effect": "Impart immunity against Phys attacks.",
         "element": "passive",
-        "personas": {"Izanagi Picaro": 25}
+        "personas": { "Izanagi Picaro": 25 }
     },
-    "Null Psy": {"effect": "Impart immunity against Psy attacks.", "element": "passive"},
+    "Null Psy": { "effect": "Impart immunity against Psy attacks.", "element": "passive" },
     "Null Rage": {
         "effect": "Impart immunity against Rage.",
         "element": "passive",
-        "personas": {"Belphegor": 38, "Byakko": 50, "Daisoujou": 45}
+        "personas": { "Belphegor": 38, "Byakko": 50, "Daisoujou": 45 }
     },
-    "Null Shock": {"effect": "Immune to Shock", "element": "passive"},
-    "Null Sleep": {"effect": "Impart immunity against Sleep.", "element": "passive", "personas": {"Sandman": 26}},
+    "Null Shock": { "effect": "Immune to Shock", "element": "passive" },
+    "Null Sleep": { "effect": "Impart immunity against Sleep.", "element": "passive", "personas": { "Sandman": 26 } },
     "Null Wind": {
         "effect": "Impart immunity against Wind attacks.",
         "element": "passive",
-        "personas": {"Yatagarasu": 64}
+        "personas": { "Yatagarasu": 64 }
     },
     "Omen": {
         "effect": "Greatly increases success rate of instant death skills",
         "element": "trait",
-        "personas": {"Sandalphon": 0}
+        "personas": { "Sandalphon": 0 }
     },
     "Ominous Words": {
         "cost": 300,
         "effect": "Inflict Despair (high odds) to 1 foe.",
         "element": "ailment",
-        "personas": {"Decarabia": 0, "Lamia": 27, "Red Rider": 45},
+        "personas": { "Decarabia": 0, "Lamia": 27, "Red Rider": 45 },
         "talk": "Corpse-Eating Corpse (Pisaca)"
     },
     "One-shot Kill": {
@@ -2706,7 +2706,7 @@ const skillMapRoyal: SkillMap = {
         "effect": "Deal medium Phys damage and inflict Rage (low odds) to all foes.",
         "element": "phys",
         "fuse": ["Yaksini"],
-        "personas": {"Atavaka": 0, "Ose": 0, "Shiki-Ouji": 24, "White Rider": 0, "Yaksini": 22},
+        "personas": { "Atavaka": 0, "Ose": 0, "Shiki-Ouji": 24, "White Rider": 0, "Yaksini": 22 },
         "talk": "Cruel Leopard (Ose)"
     },
     "Oratorio": {
@@ -2714,25 +2714,25 @@ const skillMapRoyal: SkillMap = {
         "effect": "Fully restore party's HP and negate all -nda debuffs.",
         "element": "healing",
         "unique": "Messiah",
-        "personas": {"Messiah": 0, "Messiah Picaro": 0}
+        "personas": { "Messiah": 0, "Messiah Picaro": 0 }
     },
     "Pagan Allure": {
         "effect": "Magic damage +50%, Cannot exceed 100% limit",
         "element": "trait",
-        "personas": {"Satanael": 0}
+        "personas": { "Satanael": 0 }
     },
     "Panta Rhei": {
         "cost": 4200,
         "effect": "Deal severe Wind damage to 1 foe",
         "element": "wind",
         "fuse": ["Quetzalcoatl"],
-        "personas": {"Baal": 0, "Orichalcum": 0}
+        "personas": { "Baal": 0, "Orichalcum": 0 }
     },
     "Patra": {
         "cost": 400,
         "effect": "Cure Dizzy/Forget/Sleep/Hunger of 1 ally.",
         "element": "healing",
-        "personas": {"Genbu": 8, "Pixie": 3, "Silky": 9},
+        "personas": { "Genbu": 8, "Pixie": 3, "Silky": 9 },
         "talk": "Troublesome Maid (Silky)"
     },
     "Phantom Show": {
@@ -2740,12 +2740,12 @@ const skillMapRoyal: SkillMap = {
         "effect": "Inflict Sleep (high odds) to all foes.",
         "element": "ailment",
         "unique": "Raoul",
-        "personas": {"Raoul": 0}
+        "personas": { "Raoul": 0 }
     },
     "Pinch Anchor": {
         "effect": "Allows use of ambush-only skills after Baton Pass",
         "element": "trait",
-        "personas": {"Arsène": 0, "Dionysus": 0, "Neko Shogun": 0, "Raphael": 0}
+        "personas": { "Arsène": 0, "Dionysus": 0, "Neko Shogun": 0, "Raphael": 0 }
     },
     "Pinnacle of Magic": {
         "effect": "Low chance to halve attack spell costs for all allies",
@@ -2760,7 +2760,7 @@ const skillMapRoyal: SkillMap = {
     "Positive Thoughts": {
         "effect": "Extends buffs received by 2 turns",
         "element": "trait",
-        "personas": {"Vohu Manah": 0}
+        "personas": { "Vohu Manah": 0 }
     },
     "Potent Hypnosis": {
         "effect": "Extends buffs cast by 1 turn",
@@ -2782,7 +2782,7 @@ const skillMapRoyal: SkillMap = {
         "effect": "Deal medium Phys damage to 1 foe.",
         "element": "phys",
         "fuse": ["Berith"],
-        "personas": {"Archangel": 17, "Berith": 13, "Naga": 0},
+        "personas": { "Archangel": 17, "Berith": 13, "Naga": 0 },
         "talk": "Brutal Cavalryman (Berith)"
     },
     "President's Insight": {
@@ -2800,9 +2800,9 @@ const skillMapRoyal: SkillMap = {
     "Psi": {
         "card": "CJ Theater",
         "cost": 400,
-        "effect": "Deal weak Psy damage to 1 foe.",
+        "effect": "Deal light Psy damage to 1 foe.",
         "element": "psy",
-        "personas": {"Kodama": 12, "Matador": 0},
+        "personas": { "Kodama": 12, "Matador": 0 },
         "talk": "Hanging Tree Spirit (Kodama)"
     },
     "Psio": {
@@ -2824,57 +2824,57 @@ const skillMapRoyal: SkillMap = {
         "cost": 1200,
         "effect": "Deal heavy Psy damage to 1 foe.",
         "element": "psy",
-        "personas": {"Bugs": 0, "Emperor's Amulet": 0, "Forneus": 0, "Kaiwan": 40, "Mishaguji": 0, "Parvati": 0},
+        "personas": { "Bugs": 0, "Emperor's Amulet": 0, "Forneus": 0, "Kaiwan": 40, "Mishaguji": 0, "Parvati": 0 },
         "talk": "Sacrificial Pyrekeeper (Moloch)"
     },
     "Psy Amp": {
         "effect": "Strengthen Psy attacks by 50%.",
         "element": "passive",
-        "personas": {"Kohryu": 80, "Mara": 77}
+        "personas": { "Kohryu": 80, "Mara": 77 }
     },
-    "Psy Boost": {"effect": "Strengthen Psy attacks by 25%.", "element": "passive", "personas": {"Okuninushi": 55}},
+    "Psy Boost": { "effect": "Strengthen Psy attacks by 25%.", "element": "passive", "personas": { "Okuninushi": 55 } },
     "Psy Break": {
         "cost": 600,
         "effect": "Negate Psy resistances of all foes.",
         "element": "support",
-        "personas": {"Okuninushi": 56, "Parvati": 0, "Red Rider": 0}
+        "personas": { "Okuninushi": 56, "Parvati": 0, "Red Rider": 0 }
     },
     "Psy Wall": {
         "cost": 1800,
         "effect": "Create a shield on 1 ally to reduce damage of Psy attacks for 3 turns.",
         "element": "support",
-        "personas": {"Kushinada": 0, "Sarasvati": 51, "Thoth": 39},
+        "personas": { "Kushinada": 0, "Sarasvati": 51, "Thoth": 39 },
         "talk": "Unfaithful Dream-King (Oberon)"
     },
     "Psychic Bloodline": {
         "effect": "Halves costs of Psy skills",
         "element": "trait",
-        "personas": {"Emperor's Amulet": 0, "Kaiwan": 0, "Nebiros": 0, "Okuninushi": 0, "Shiki-Ouji": 0, "Shiva": 0}
+        "personas": { "Emperor's Amulet": 0, "Kaiwan": 0, "Nebiros": 0, "Okuninushi": 0, "Shiki-Ouji": 0, "Shiva": 0 }
     },
     "Psycho Blast": {
         "cost": 5400,
         "effect": "Deal severe Psy damage to all foes.",
         "element": "psy",
-        "personas": {"Chi You": 91, "Shiva": 88}
+        "personas": { "Chi You": 91, "Shiva": 88 }
     },
     "Psycho Force": {
         "cost": 4800,
         "effect": "Deal severe Psy damage to 1 foe.",
         "element": "psy",
         "fuse": ["Mara"],
-        "personas": {"Chi You": 0, "Kohryu": 0, "Mara": 78, "Orichalcum": 0, "Shiva": 0}
+        "personas": { "Chi You": 0, "Kohryu": 0, "Mara": 78, "Orichalcum": 0, "Shiva": 0 }
     },
     "Pulinpa": {
         "cost": 300,
         "effect": "Inflict Confuse (high odds) to 1 foe.",
         "element": "ailment",
-        "personas": {"Choronzon": 0, "High Pixie": 20, "Inugami": 0, "Mandrake": 0, "Nue": 22, "Onmoraki": 15},
+        "personas": { "Choronzon": 0, "High Pixie": 20, "Inugami": 0, "Mandrake": 0, "Nue": 22, "Onmoraki": 15 },
         "talk": "Gallows Flower (Mandrake)"
     },
     "Rage Boost": {
         "effect": "Increase chance of inflicting Rage.",
         "element": "passive",
-        "personas": {"Ara Mitama": 34, "Koppa Tengu": 14}
+        "personas": { "Ara Mitama": 34, "Koppa Tengu": 14 }
     },
     "Raging Temper": {
         "effect": "Low chance to strengthen Phys attacks by 40% for all allies",
@@ -2916,15 +2916,15 @@ const skillMapRoyal: SkillMap = {
     },
     "Rampage": {
         "cost": 13,
-        "effect": "Deal 1 to 3 times weak Phys damage to all foes.",
+        "effect": "Deal light Phys damage to all foes 1 to 3 times.",
         "element": "phys",
-        "personas": {"Choronzon": 0, "Ippon-Datara": 15, "Oni": 0, "Pisaca": 0, "Shiisaa": 17},
+        "personas": { "Choronzon": 0, "Ippon-Datara": 15, "Oni": 0, "Pisaca": 0, "Shiisaa": 17 },
         "talk": "Chivalrous Fiend (Oni)"
     },
     "Rare Antibody": {
         "effect": "Reduces susceptibility to ailments",
         "element": "trait",
-        "personas": {"Agathion": 0, "Black Ooze": 0, "Koh-i-Noor": 0, "Kumbhanda": 0, "Pisaca": 0, "Slime": 0}
+        "personas": { "Agathion": 0, "Black Ooze": 0, "Koh-i-Noor": 0, "Kumbhanda": 0, "Pisaca": 0, "Slime": 0 }
     },
     "Rebellion": {
         "cost": 500,
@@ -2956,18 +2956,18 @@ const skillMapRoyal: SkillMap = {
         "cost": 800,
         "effect": "Revive 1 ally with 50% HP recovered.",
         "element": "healing",
-        "personas": {"Phoenix": 23, "Queen's Necklace": 0}
+        "personas": { "Phoenix": 23, "Queen's Necklace": 0 }
     },
     "Regenerate 1": {
         "effect": "Restore 2% of max HP each turn in battle.",
         "element": "passive",
-        "personas": {"Kin-Ki": 0, "Kushi Mitama": 13, "Rakshasa": 26}
+        "personas": { "Kin-Ki": 0, "Kushi Mitama": 13, "Rakshasa": 26 }
     },
     "Regenerate 2": {
         "effect": "Recover 4% of max HP each turn in battle.",
         "element": "passive",
         "fuse": ["Rakshasa"],
-        "personas": {"Hecatoncheires": 0, "Hope Diamond": 0, "Koumokuten": 0}
+        "personas": { "Hecatoncheires": 0, "Hope Diamond": 0, "Koumokuten": 0 }
     },
     "Regenerate 3": {
         "card": "CJ Art Museum",
@@ -2987,95 +2987,95 @@ const skillMapRoyal: SkillMap = {
     "Relentless": {
         "effect": "Damage that strikes foe weaknesses +50%",
         "element": "trait",
-        "personas": {"Gabriel": 0, "Kali": 0, "Seiryu": 0, "Stone of Scone": 0, "Trumpeter": 0}
+        "personas": { "Gabriel": 0, "Kali": 0, "Seiryu": 0, "Stone of Scone": 0, "Trumpeter": 0 }
     },
     "Relief Bloodline": {
         "effect": "Halves costs of Support skills",
         "element": "trait",
-        "personas": {"Clotho": 0, "Kikuri-Hime": 0, "Nigi Mitama": 0, "Queen's Necklace": 0, "Sarasvati": 0}
+        "personas": { "Clotho": 0, "Kikuri-Hime": 0, "Nigi Mitama": 0, "Queen's Necklace": 0, "Sarasvati": 0 }
     },
     "Repel Bless": {
         "effect": "Repel Bless attacks.",
         "element": "passive",
         "fuse": ["Raphael"],
-        "personas": {"Lucifer": 97, "Mother Harlot": 88}
+        "personas": { "Lucifer": 97, "Mother Harlot": 88 }
     },
-    "Repel Curse": {"effect": "Repel Curse attacks.", "element": "passive", "personas": {"Sandalphon": 78}},
-    "Repel Elec": {"effect": "Repel Electric attacks.", "element": "passive", "fuse": ["Mot"], "personas": {"Mot": 77}},
+    "Repel Curse": { "effect": "Repel Curse attacks.", "element": "passive", "personas": { "Sandalphon": 78 } },
+    "Repel Elec": { "effect": "Repel Electric attacks.", "element": "passive", "fuse": ["Mot"], "personas": { "Mot": 77 } },
     "Repel Fire": {
         "effect": "Repel Fire attacks.",
         "element": "passive",
-        "personas": {"Black Frost": 71, "Vishnu": 87}
+        "personas": { "Black Frost": 71, "Vishnu": 87 }
     },
     "Repel Ice": {
         "effect": "Repel Ice attacks.",
         "element": "passive",
         "fuse": ["Parvati"],
-        "personas": {"Beelzebub": 91}
+        "personas": { "Beelzebub": 91 }
     },
     "Repel Nuke": {
         "effect": "Repel Nuclear attacks.",
         "element": "passive",
         "fuse": ["Lilith"],
-        "personas": {"Seiryu": 63, "Uriel": 83}
+        "personas": { "Seiryu": 63, "Uriel": 83 }
     },
     "Repel Phys": {
         "effect": "Repel Phys attacks.",
         "element": "passive",
-        "personas": {"Chi You": 0, "Girimehkala": 50, "Kaguya": 22, "Kaguya Picaro": 31}
+        "personas": { "Chi You": 0, "Girimehkala": 50, "Kaguya": 22, "Kaguya Picaro": 31 }
     },
-    "Repel Psy": {"effect": "Repel Psy attacks.", "element": "passive", "fuse": ["Kali"], "personas": {"Kali": 67}},
+    "Repel Psy": { "effect": "Repel Psy attacks.", "element": "passive", "fuse": ["Kali"], "personas": { "Kali": 67 } },
     "Repel Wind": {
         "effect": "Repel Wind attacks.",
         "element": "passive",
         "fuse": ["Byakhee"],
-        "personas": {"Hastur": 89}
+        "personas": { "Hastur": 89 }
     },
-    "Resist Bless": {"effect": "Reduce damage from Bless attacks.", "element": "passive", "personas": {"Anubis": 38}},
+    "Resist Bless": { "effect": "Reduce damage from Bless attacks.", "element": "passive", "personas": { "Anubis": 38 } },
     "Resist Brainwash": {
         "effect": "Reduce susceptibility to Brainwash.",
         "element": "passive",
-        "personas": {"Kelpie": 8}
+        "personas": { "Kelpie": 8 }
     },
-    "Resist Burn": {"effect": "Halves susceptibility to Burn", "element": "passive"},
-    "Resist Confuse": {"effect": "Reduce susceptibility to Confuse.", "element": "passive", "personas": {"Pixie": 6}},
-    "Resist Curse": {"effect": "Reduce damage from Curse attacks.", "element": "passive"},
+    "Resist Burn": { "effect": "Halves susceptibility to Burn", "element": "passive" },
+    "Resist Confuse": { "effect": "Reduce susceptibility to Confuse.", "element": "passive", "personas": { "Pixie": 6 } },
+    "Resist Curse": { "effect": "Reduce damage from Curse attacks.", "element": "passive" },
     "Resist Despair": {
         "effect": "Reduce susceptibility to Despair.",
         "element": "passive",
-        "personas": {"Isis": 27, "Makami": 19}
+        "personas": { "Isis": 27, "Makami": 19 }
     },
     "Resist Dizzy": {
         "effect": "Reduce susceptibility to Dizzy.",
         "element": "passive",
-        "personas": {"Ippon-Datara": 0, "Saki Mitama": 10}
+        "personas": { "Ippon-Datara": 0, "Saki Mitama": 10 }
     },
-    "Resist Elec": {"effect": "Reduce damage from Electric attacks.", "element": "passive"},
+    "Resist Elec": { "effect": "Reduce damage from Electric attacks.", "element": "passive" },
     "Resist Fear": {
         "effect": "Reduce susceptibility to Fear.",
         "element": "passive",
-        "personas": {"Kodama": 17, "Obariyon": 10, "Zouchouten": 34}
+        "personas": { "Kodama": 17, "Obariyon": 10, "Zouchouten": 34 }
     },
-    "Resist Fire": {"effect": "Reduce damage from Fire attacks.", "element": "passive"},
+    "Resist Fire": { "effect": "Reduce damage from Fire attacks.", "element": "passive" },
     "Resist Forget": {
         "effect": "Reduce susceptibility to Forget.",
         "element": "passive",
-        "personas": {"Genbu": 11, "Hua Po": 12}
+        "personas": { "Genbu": 11, "Hua Po": 12 }
     },
-    "Resist Freeze": {"effect": "Halves susceptibility to Freeze", "element": "passive"},
-    "Resist Hunger": {"effect": "Halves susceptibility to Hunger", "element": "passive"},
-    "Resist Ice": {"effect": "Reduce damage from Ice attacks.", "element": "passive"},
-    "Resist Nuke": {"effect": "Reduce damage from Nuclear attacks.", "element": "passive"},
-    "Resist Phys": {"effect": "Reduce damage from Phys attacks.", "element": "passive"},
-    "Resist Psy": {"effect": "Reduce damage from Psy attacks.", "element": "passive", "personas": {"Ganesha": 56}},
-    "Resist Rage": {"effect": "Reduce susceptibility to Rage.", "element": "passive"},
-    "Resist Shock": {"effect": "Halves susceptibility to Shock", "element": "passive"},
+    "Resist Freeze": { "effect": "Halves susceptibility to Freeze", "element": "passive" },
+    "Resist Hunger": { "effect": "Halves susceptibility to Hunger", "element": "passive" },
+    "Resist Ice": { "effect": "Reduce damage from Ice attacks.", "element": "passive" },
+    "Resist Nuke": { "effect": "Reduce damage from Nuclear attacks.", "element": "passive" },
+    "Resist Phys": { "effect": "Reduce damage from Phys attacks.", "element": "passive" },
+    "Resist Psy": { "effect": "Reduce damage from Psy attacks.", "element": "passive", "personas": { "Ganesha": 56 } },
+    "Resist Rage": { "effect": "Reduce susceptibility to Rage.", "element": "passive" },
+    "Resist Shock": { "effect": "Halves susceptibility to Shock", "element": "passive" },
     "Resist Sleep": {
         "effect": "Reduce susceptibility to Sleep.",
         "element": "passive",
-        "personas": {"Cait Sith": 6, "Jack-o'-Lantern": 7}
+        "personas": { "Cait Sith": 6, "Jack-o'-Lantern": 7 }
     },
-    "Resist Wind": {"effect": "Reduce damage from Wind attacks.", "element": "passive", "personas": {"Fuu-Ki": 27}},
+    "Resist Wind": { "effect": "Reduce damage from Wind attacks.", "element": "passive", "personas": { "Fuu-Ki": 27 } },
     "Retaliating Body": {
         "effect": "Doubles damage from Counter skills",
         "element": "trait",
@@ -3090,13 +3090,13 @@ const skillMapRoyal: SkillMap = {
             "Yoshitsune": 0
         }
     },
-    "Reverse Rub": {"effect": "Inflict Rage (100%) to 1 ally.", "element": "ailment", "unique": "Enemies"},
+    "Reverse Rub": { "effect": "Inflict Rage (100%) to 1 ally.", "element": "ailment", "unique": "Enemies" },
     "Revolution": {
         "cost": 500,
         "effect": "Increase all foes and allies' critical rate for 3 turns.",
         "element": "support",
         "fuse": ["Ganesha"],
-        "personas": {"Baal": 0, "Hanuman": 0, "Koumokuten": 0, "Kumbhanda": 47, "Melchizedek": 60, "Yurlungur": 45},
+        "personas": { "Baal": 0, "Hanuman": 0, "Koumokuten": 0, "Kumbhanda": 47, "Melchizedek": 60, "Yurlungur": 45 },
         "talk": "Pagan Saviour (Melchizedek)"
     },
     "Riot Gun": {
@@ -3104,7 +3104,7 @@ const skillMapRoyal: SkillMap = {
         "effect": "Deal severe Gun damage to all foes.",
         "element": "gun",
         "fuse": ["Cu Chulainn"],
-        "personas": {"Satanael": 0, "Shiva": 85, "Vishnu": 90}
+        "personas": { "Satanael": 0, "Shiva": 85, "Vishnu": 90 }
     },
     "Rising Slash": {
         "cost": 14,
@@ -3165,13 +3165,13 @@ const skillMapRoyal: SkillMap = {
         "cost": 4000,
         "element": "bless",
         "unique": "Daisoujou",
-        "personas": {"Daisoujou": 41}
+        "personas": { "Daisoujou": 41 }
     },
-    "Samurai's Ruling": {"effect": "Raises critical rate and Magic evasion", "element": "passive"},
+    "Samurai's Ruling": { "effect": "Raises critical rate and Magic evasion", "element": "passive" },
     "Savior Bloodline": {
         "effect": "Halves costs of Recovery skills",
         "element": "trait",
-        "personas": {"Atavaka": 0, "Bishamonten": 0, "Isis": 0, "Kushinada": 0, "Mandrake": 0, "Queen's Necklace": 0}
+        "personas": { "Atavaka": 0, "Bishamonten": 0, "Isis": 0, "Kushinada": 0, "Mandrake": 0, "Queen's Necklace": 0 }
     },
     "Scoundrel Eyes": {
         "effect": "Raises evasion rate against Phys attacks for all allies",
@@ -3200,15 +3200,15 @@ const skillMapRoyal: SkillMap = {
     },
     "Shining Arrows": {
         "cost": 2200,
-        "effect": "Deal 4 to 8 times weak Bless damage to all foes.",
+        "effect": "Deal light Bless damage to all foes 4 to 8 times.",
         "element": "bless",
         "unique": "Kaguya",
-        "personas": {"Kaguya": 0, "Kaguya Picaro": 0}
+        "personas": { "Kaguya": 0, "Kaguya Picaro": 0 }
     },
     "Shock Boost": {
         "effect": "Increase chance of inflicting Shock.",
         "element": "passive",
-        "personas": {"Baphomet": 62, "Mothman": 0, "Naga": 26, "Raja Naga": 57, "Take-Minakata": 32, "Thunderbird": 0}
+        "personas": { "Baphomet": 62, "Mothman": 0, "Naga": 26, "Raja Naga": 57, "Take-Minakata": 32, "Thunderbird": 0 }
     },
     "Skillful Combo": {
         "effect": "Raises damage dealt after Baton Pass",
@@ -3228,33 +3228,33 @@ const skillMapRoyal: SkillMap = {
     "Skillful Technique": {
         "effect": "Technical damage +25%",
         "element": "trait",
-        "personas": {"Leanan Sidhe": 0, "Makami": 0, "Mithras": 0, "Parvati": 0, "Regent": 0, "Scathach": 0, "Thoth": 0}
+        "personas": { "Leanan Sidhe": 0, "Makami": 0, "Mithras": 0, "Parvati": 0, "Regent": 0, "Scathach": 0, "Thoth": 0 }
     },
     "Skull Cracker": {
         "cost": 10,
         "effect": "Deal medium Phys damage and inflict Confuse (medium odds) to 1 foe.",
         "element": "phys",
-        "personas": {"Mokoi": 10, "Mothman": 0, "Nue": 0, "Shiisaa": 0},
+        "personas": { "Mokoi": 10, "Mothman": 0, "Nue": 0, "Shiisaa": 0 },
         "talk": "Night Chimera (Nue)"
     },
     "Sledgehammer": {
         "cost": 10,
         "effect": "Deal medium Phys damage and inflict Dizzy (medium odds) to 1 foe.",
         "element": "phys",
-        "personas": {"Black Ooze": 0, "Ippon-Datara": 0, "Kin-Ki": 28, "Sui-Ki": 0},
+        "personas": { "Black Ooze": 0, "Ippon-Datara": 0, "Kin-Ki": 28, "Sui-Ki": 0 },
         "talk": "Embittered Blacksmith (Ippon-Datara)"
     },
     "Sleep Boost": {
         "effect": "Increase chance of inflicting Sleep.",
         "element": "passive",
-        "personas": {"Sandman": 28, "Succubus": 11},
+        "personas": { "Sandman": 28, "Succubus": 11 },
         "talk": "Twilight Prostitute (Succubus)"
     },
     "Snap": {
         "cost": 9,
         "effect": "Deal medium Gun damage to 1 foe.",
         "element": "gun",
-        "personas": {"Obariyon": 0, "Oni": 0},
+        "personas": { "Obariyon": 0, "Oni": 0 },
         "talk": "Night-Walking Warrior (Mokoi)"
     },
     "Soul Chain": {
@@ -3262,17 +3262,17 @@ const skillMapRoyal: SkillMap = {
         "effect": "Recover 20 SP when performing Baton Pass.",
         "element": "passive"
     },
-    "Soul Touch": {"effect": "Recover 5 SP after Baton Pass", "element": "passive"},
+    "Soul Touch": { "effect": "Recover 5 SP after Baton Pass", "element": "passive" },
     "Speed Master": {
         "effect": "Automatic Sukukaja at the start of battle.",
         "element": "passive",
-        "personas": {"Hell Biker": 0, "Jatayu": 57, "Kaiwan": 38, "Suzaku": 20, "Magatsu-Izanagi Picaro": 52}
+        "personas": { "Hell Biker": 0, "Jatayu": 57, "Kaiwan": 38, "Suzaku": 20, "Magatsu-Izanagi Picaro": 52 }
     },
     "Spell Master": {
         "card": "Jazz 1/29",
         "effect": "Half SP cost for magic skills.",
         "element": "passive",
-        "personas": {"Ishtar": 89, "Kohryu": 82, "Lucifer": 95, "Mada": 96, "Uriel": 86, "Tsukiyomi Picaro": 61}
+        "personas": { "Ishtar": 89, "Kohryu": 82, "Lucifer": 95, "Mada": 96, "Uriel": 86, "Tsukiyomi Picaro": 61 }
     },
     "Spirit Drain": {
         "cost": 300,
@@ -3290,20 +3290,20 @@ const skillMapRoyal: SkillMap = {
             "Tsukiyomi Picaro": 0
         }
     },
-    "Spirit Leech": {"effect": "Drains 150 SP from 1 foe.", "element": "almighty", "unique": "Enemies"},
+    "Spirit Leech": { "effect": "Drains 150 SP from 1 foe.", "element": "almighty", "unique": "Enemies" },
     "Stagnant Air": {
         "cost": 500,
         "effect": "Increase susceptibility to all ailments of all foes and allies.",
         "element": "almighty",
         "fuse": ["Legion"],
-        "personas": {"Forneus": 66, "Kumbhanda": 0, "Moloch": 0, "Pazuzu": 49, "Pisaca": 0}
+        "personas": { "Forneus": 66, "Kumbhanda": 0, "Moloch": 0, "Pazuzu": 49, "Pisaca": 0 }
     },
     "Static Electricity": {
         "effect": "Increases chance of inflicting Shock on downed foes",
         "element": "trait",
-        "personas": {"Mothman": 0, "Oberon": 0, "Pixie": 0, "Queen Mab": 0}
+        "personas": { "Mothman": 0, "Oberon": 0, "Pixie": 0, "Queen Mab": 0 }
     },
-    "Stealth": {"effect": "Lowers chance of being targeted", "element": "passive"},
+    "Stealth": { "effect": "Lowers chance of being targeted", "element": "passive" },
     "Stomach Blow": {
         "effect": "Medium Physical damage to 1 foe and inflict Hunger.",
         "element": "phys",
@@ -3312,7 +3312,7 @@ const skillMapRoyal: SkillMap = {
     "Striking Weight": {
         "effect": "Phys damage +20%",
         "element": "trait",
-        "personas": {"Bicorn": 0, "Hope Diamond": 0, "Ippon-Datara": 0, "Kelpie": 0, "Naga": 0, "Obariyon": 0}
+        "personas": { "Bicorn": 0, "Hope Diamond": 0, "Ippon-Datara": 0, "Kelpie": 0, "Naga": 0, "Obariyon": 0 }
     },
     "Subrecover HP": {
         "effect": "After battle, 10% HP recovery for backup allies.",
@@ -3339,7 +3339,7 @@ const skillMapRoyal: SkillMap = {
         "cost": 800,
         "effect": "Increase 1 ally's Agility for 3 turns.",
         "element": "support",
-        "personas": {"Cait Sith": 7, "Kelpie": 9, "Koppa Tengu": 0, "Matador": 0, "Orobas": 0, "Queen's Necklace": 0},
+        "personas": { "Cait Sith": 7, "Kelpie": 9, "Koppa Tengu": 0, "Matador": 0, "Orobas": 0, "Queen's Necklace": 0 },
         "talk": "Noisy Mountain Spirit (Sudama)"
     },
     "Sukunda": {
@@ -3357,7 +3357,7 @@ const skillMapRoyal: SkillMap = {
         },
         "talk": "Piggyback Demon (Obariyon)"
     },
-    "Summon": {"effect": "Summon ally reinforcements.", "element": "almighty", "unique": "Enemies"},
+    "Summon": { "effect": "Summon ally reinforcements.", "element": "almighty", "unique": "Enemies" },
     "Support Plus 1": {
         "card": "Jazz 1",
         "effect": "Adds Masukunda to Moral Support pool",
@@ -3385,12 +3385,12 @@ const skillMapRoyal: SkillMap = {
     "Survival Trick": {
         "effect": "Survive one instant death attack with 1 HP remaining.",
         "element": "passive",
-        "personas": {"Alice": 88, "Forneus": 65, "Satanael": 0},
+        "personas": { "Alice": 88, "Forneus": 65, "Satanael": 0 },
         "talk": "Abyssal King of Avarice (Abaddon)"
     },
     "Swift Strike": {
         "cost": 17,
-        "effect": "Deal 2 to 4 times weak Phys damage to all foes.",
+        "effect": "Deal miniscule Phys damage to all foes 2-4 times.",
         "element": "phys",
         "personas": {
             "Byakko": 0,
@@ -3406,10 +3406,10 @@ const skillMapRoyal: SkillMap = {
     },
     "Sword Dance": {
         "cost": 21,
-        "effect": "Deal grave Phys damage to 1 foe with high critical.",
+        "effect": "Deal colossal Phys damage to 1 foe with high critical.",
         "element": "phys",
         "fuse": ["Atavaka"],
-        "personas": {"Metatron": 0, "Michael": 89, "Raphael": 0, "Sandalphon": 79}
+        "personas": { "Metatron": 0, "Michael": 89, "Raphael": 0, "Sandalphon": 79 }
     },
     "Tactical Spirit": {
         "effect": "Chance to halve Support skill costs for all allies",
@@ -3420,7 +3420,7 @@ const skillMapRoyal: SkillMap = {
         "effect": "Allows use of consumables without expending them after Baton Pass",
         "element": "trait",
         "unique": "Ariadne",
-        "personas": {"Ariadne": 0, "Ariadne Picaro": 0}
+        "personas": { "Ariadne": 0, "Ariadne Picaro": 0 }
     },
     "Tarukaja": {
         "card": "CJ Sky Tree",
@@ -3467,34 +3467,34 @@ const skillMapRoyal: SkillMap = {
         "cost": 300,
         "effect": "Inflict Rage (high odds) to 1 foe.",
         "element": "ailment",
-        "personas": {"Ara Mitama": 0, "Koppa Tengu": 13, "Shiki-Ouji": 0, "Thoth": 0},
+        "personas": { "Ara Mitama": 0, "Koppa Tengu": 13, "Shiki-Ouji": 0, "Thoth": 0 },
         "talk": "Foolish Monk (Koppa Tengu)"
     },
     "Tempest Slash": {
         "cost": 17,
-        "effect": "Deal 3 to 5 times minuscule Phys damage to 1 foe.",
+        "effect": "Deal minuscule Phys damage to 1 foe 3 to 5 times .",
         "element": "phys",
-        "personas": {"Ganesha": 0, "Hanuman": 0, "Kumbhanda": 43, "Ose": 43},
+        "personas": { "Ganesha": 0, "Hanuman": 0, "Kumbhanda": 43, "Ose": 43 },
         "talk": "Nimble Monkey King (Hanuman)"
     },
     "Tentarafoo": {
         "cost": 800,
         "effect": "Inflict Confuse (medium odds) to all foes.",
         "element": "ailment",
-        "personas": {"Hell Biker": 38, "Mithras": 0, "Mothman": 35, "Pazuzu": 0, "Raja Naga": 0, "Sarasvati": 0}
+        "personas": { "Hell Biker": 38, "Mithras": 0, "Mothman": 35, "Pazuzu": 0, "Raja Naga": 0, "Sarasvati": 0 }
     },
     "Terror Claw": {
         "cost": 8,
         "effect": "Deal medium Phys damage and inflict Fear (medium odds) to 1 foe.",
         "element": "phys",
-        "personas": {"Andras": 0, "Kelpie": 10, "Nekomata": 0, "Zouchouten": 32},
+        "personas": { "Andras": 0, "Kelpie": 10, "Nekomata": 0, "Zouchouten": 32 },
         "talk": "Ascended Feline (Nekomata)"
     },
     "Tetra Break": {
         "effect": "Remove physical-repellent shields from all foes.",
         "cost": 900,
         "element": "support",
-        "personas": {"Fuu-Ki": 0, "Hanuman": 67, "Legion": 40, "Mara": 0, "Mithras": 41, "Yurlungur": 48},
+        "personas": { "Fuu-Ki": 0, "Hanuman": 67, "Legion": 40, "Mara": 0, "Mithras": 41, "Yurlungur": 48 },
         "talk": "Fused Ghost (Legion)"
     },
     "Tetraja": {
@@ -3518,38 +3518,38 @@ const skillMapRoyal: SkillMap = {
         "cost": 2400,
         "element": "support",
         "fuse": ["Scathach"],
-        "personas": {"Bishamonten": 72, "Decarabia": 33, "Asterius": 60},
+        "personas": { "Bishamonten": 72, "Decarabia": 33, "Asterius": 60 },
         "talk": "Vicious Pentagram (Decarabia)"
     },
     "Thermal Conduct": {
         "effect": "Increases chance of inflicting Burn after Baton Pass",
         "element": "trait",
-        "personas": {"Baphomet": 0, "Cait Sith": 0, "Eligor": 0, "Hua Po": 0, "Jack-o'-Lantern": 0, "Orthrus": 0}
+        "personas": { "Baphomet": 0, "Cait Sith": 0, "Eligor": 0, "Hua Po": 0, "Jack-o'-Lantern": 0, "Orthrus": 0 }
     },
     "Thermopylae": {
         "cost": 3000,
-        "effect": "Increase party's Attack, Defense and Agility for 3 turns. Only usable if the party is being ambushed.",
+        "effect": "Increase party's Attack, Defense and Agility for 3 turns. Only usable if the party is surrounded.",
         "element": "support",
-        "personas": {"Attis": 0, "Dionysus": 72, "Mithra": 38}
+        "personas": { "Attis": 0, "Dionysus": 72, "Mitra": 38 }
     },
     "Thunder Reign": {
         "cost": 4800,
         "effect": "Deal severe Electric damage to 1 foe.",
         "element": "electric",
         "fuse": ["Dionysus"],
-        "personas": {"Odin": 0, "Orichalcum": 0}
+        "personas": { "Odin": 0, "Orichalcum": 0 }
     },
     "Titanomachia": {
         "cost": 3400,
         "effect": "Deal severe Fire damage to all foes and inflict Fear (high odds).",
         "element": "fire",
         "unique": "Asterius",
-        "personas": {"Asterius": 0, "Asterius Picaro": 0}
+        "personas": { "Asterius": 0, "Asterius Picaro": 0 }
     },
     "Touch n' Go": {
         "effect": "Apply Sukukaja when performing Baton Pass.",
         "element": "passive",
-        "personas": {"Fortuna": 49, "Gabriel": 81}
+        "personas": { "Fortuna": 49, "Gabriel": 81 }
     },
     "Treasure Reboot": {
         "effect": "Chance to revive search objects in the area after battle.",
@@ -3564,20 +3564,20 @@ const skillMapRoyal: SkillMap = {
     "Trigger Happy": {
         "effect": "Increase critical rate of Gun attacks.",
         "element": "passive",
-        "personas": {"Vasuki": 70}
+        "personas": { "Vasuki": 70 }
     },
     "Triple Down": {
         "cost": 16,
-        "effect": "Deal 3 times small Gun damage to all foes.",
+        "effect": "Deal light Gun damage to all foes 3 times.",
         "element": "gun",
         "fuse": ["Shiki-Ouji"],
-        "personas": {"Bugs": 52, "Vasuki": 0, "White Rider": 0}
+        "personas": { "Bugs": 52, "Vasuki": 0, "White Rider": 0 }
     },
     "Tyrant's Mind": {
         "effect": "All damage +25%, Can exceed 100% limit",
         "element": "passive",
         "unique": "Satanel",
-        "personas": {"Satanael": 98}
+        "personas": { "Satanael": 98 }
     },
     "Tyrant's Will": {
         "card": "Ring of Pride",
@@ -3607,8 +3607,8 @@ const skillMapRoyal: SkillMap = {
             "Stone of Scone": 0
         }
     },
-    "Undying Fury": {"effect": "Phys damage +30%", "element": "trait", "personas": {"Zaou-Gongen": 0}},
-    "Universal Law": {"effect": "Technical damage +50%", "element": "trait", "personas": {"Kohryu": 0}},
+    "Undying Fury": { "effect": "Phys damage +30%", "element": "trait", "personas": { "Zaou-Gongen": 0 } },
+    "Universal Law": { "effect": "Technical damage +50%", "element": "trait", "personas": { "Kohryu": 0 } },
     "Unparalleled Eyes": {
         "effect": "Greatly raises evasion rate against Phys attacks for all allies",
         "element": "trait",
@@ -3618,20 +3618,20 @@ const skillMapRoyal: SkillMap = {
         "effect": "Impart immunity against all mental ailments.",
         "element": "passive",
         "unique": "Asura",
-        "personas": {"Asura": 81}
+        "personas": { "Asura": 81 }
     },
     "Vacuum Wave": {
         "cost": 4800,
         "effect": "Deal severe Wind damage to all foes.",
         "element": "wind",
-        "personas": {"Baal": 87, "Hastur": 0, "Vishnu": 85}
+        "personas": { "Baal": 87, "Hastur": 0, "Vishnu": 85 }
     },
-    "Vahana's Wings": {"effect": "Reduces costs of Wind skills by 75%", "element": "trait", "personas": {"Vishnu": 0}},
+    "Vahana's Wings": { "effect": "Reduces costs of Wind skills by 75%", "element": "trait", "personas": { "Vishnu": 0 } },
     "Vajra Blast": {
         "effect": "Deal medium Phys damage to all foes.",
         "cost": 13,
         "element": "phys",
-        "personas": {"Archangel": 19, "Kin-Ki": 0},
+        "personas": { "Archangel": 19, "Kin-Ki": 0 },
         "talk": "Samurai Killer (Kin-Ki)"
     },
     "Vault Guardian": {
@@ -3656,50 +3656,50 @@ const skillMapRoyal: SkillMap = {
         "effect": "Deal medium Phys damage to all foes.",
         "element": "phys",
         "fuse": ["Kin-Ki"],
-        "personas": {"Yaksini": 24}
+        "personas": { "Yaksini": 24 }
     },
     "Victory Cry": {
         "effect": "Recover full HP and SP after a successful battle.",
         "element": "passive",
-        "personas": {"Satanael": 99, "Izanagi-no-Okami": 0, "Izanagi-no-Okami Picaro": 0}
+        "personas": { "Satanael": 99, "Izanagi-no-Okami": 0, "Izanagi-no-Okami Picaro": 0 }
     },
     "Vitality of the Tree": {
         "effect": "Allows use of ambush-only skills under normal conditions",
         "element": "trait",
-        "personas": {"Attis": 0}
+        "personas": { "Attis": 0 }
     },
     "Vorpal Blade": {
         "cost": 23,
         "effect": "Deal severe Phys damage to all foes.",
         "element": "phys",
         "fuse": ["Oberon"],
-        "personas": {"Kali": 68, "Scathach": 81, "Siegfried": 89, "Tsukiyomi": 55, "Tsukiyomi Picaro": 60},
+        "personas": { "Kali": 68, "Scathach": 81, "Siegfried": 89, "Tsukiyomi": 55, "Tsukiyomi Picaro": 60 },
         "talk": "The Blackened Fury (Kali)"
     },
     "Wage War": {
         "cost": 800,
         "effect": "Inflict Rage (medium odds) to all foes.",
         "element": "ailment",
-        "personas": {"Barong": 0, "Girimehkala": 47, "Koppa Tengu": 15, "Sui-Ki": 27, "Yaksini": 0},
+        "personas": { "Barong": 0, "Girimehkala": 47, "Koppa Tengu": 15, "Sui-Ki": 27, "Yaksini": 0 },
         "talk": "Human-Eating Lady (Yaksini)"
     },
-    "Wealth of Lotus": {"effect": "Extends buffs cast by 2 turns", "element": "trait", "personas": {"Lakshmi": 0}},
+    "Wealth of Lotus": { "effect": "Extends buffs cast by 2 turns", "element": "trait", "personas": { "Lakshmi": 0 } },
     "Wild Thunder": {
         "cost": 5400,
         "effect": "Deal severe Electric damage to all foes.",
         "element": "electric",
-        "personas": {"Odin": 86, "Thor": 71}
+        "personas": { "Odin": 86, "Thor": 71 }
     },
     "Will of the Sword": {
         "effect": "Charge-type effects +200% damage instead, Begins battle with Concentrate",
         "element": "trait",
-        "personas": {"Futsunushi": 0}
+        "personas": { "Futsunushi": 0 }
     },
     "Wind Amp": {
         "effect": "Strengthen Wind attacks by 50%.",
         "element": "passive",
         "fuse": ["Fuu-Ki"],
-        "personas": {"Garuda": 59, "Hastur": 87, "Jatayu": 54, "Quetzalcoatl": 71, "Vishnu": 88},
+        "personas": { "Garuda": 59, "Hastur": 87, "Jatayu": 54, "Quetzalcoatl": 71, "Vishnu": 88 },
         "talk": "Warped Abyss (Hastur)"
     },
     "Wind Bloodline": {
@@ -3718,21 +3718,21 @@ const skillMapRoyal: SkillMap = {
     "Wind Boost": {
         "effect": "Strengthen Wind attacks by 25%.",
         "element": "passive",
-        "personas": {"Fuu-Ki": 25, "Kurama Tengu": 32},
+        "personas": { "Fuu-Ki": 25, "Kurama Tengu": 32 },
         "talk": "Reviled Dictator (Baal)"
     },
     "Wind Break": {
         "cost": 600,
         "effect": "Negate Wind resistances of all foes.",
         "element": "support",
-        "personas": {"Anzu": 0, "Nekomata": 20, "Yatagarasu": 61},
+        "personas": { "Anzu": 0, "Nekomata": 20, "Yatagarasu": 61 },
         "talk": "Thief of Tablets (Anzu)"
     },
     "Wind Wall": {
         "cost": 1800,
         "effect": "Create a shield on 1 ally to reduce damage of Wind attacks for 3 turns.",
         "element": "support",
-        "personas": {"Apsaras": 16, "Kushinada": 46, "Kushi Mitama": 14, "Rakshasa": 0, "Saki Mitama": 0, "Sudama": 21}
+        "personas": { "Apsaras": 16, "Kushinada": 46, "Kushi Mitama": 14, "Rakshasa": 0, "Saki Mitama": 0, "Sudama": 21 }
     },
     "Wings of Wisdom": {
         "card": "Ring of Wrath",
@@ -3743,9 +3743,9 @@ const skillMapRoyal: SkillMap = {
     },
     "Zio": {
         "cost": 400,
-        "effect": "Deal weak Electric damage to 1 foe.",
+        "effect": "Deal light Electric damage to 1 foe.",
         "element": "electric",
-        "personas": {"Agathion": 7, "Pixie": 0}
+        "personas": { "Agathion": 7, "Pixie": 0 }
     },
     "Ziodyne": {
         "cost": 1200,

--- a/indexRoyal.html
+++ b/indexRoyal.html
@@ -31,6 +31,7 @@
         var personaMap = personaMapRoyal;
         var skillMap = skillMapRoyal;
         var itemMap = itemMapRoyal;
+        var inheritanceChart = inheritanceChartRoyal;
     </script>
     <script src="src/DataUtil.js"></script>
     <script src="src/FusionCalculator.js"></script>

--- a/src/DataUtil.js
+++ b/src/DataUtil.js
@@ -206,6 +206,10 @@ function getItem(itemName) {
     })
     return itemData;
 }
+function getInheritance(inheritanceType) {
+    return inheritanceChart[inheritanceType];
+}
+
 function getSkillPersonaList(skill) {
     var arr = [];
     for (var key in skill.personas) {

--- a/src/DataUtil.ts
+++ b/src/DataUtil.ts
@@ -214,13 +214,15 @@ function getItem(itemName: string) {
     let itemData = [];
     let item = itemMap[itemName];
     itemData.push({
-        skillCard: item.skillCard,
         name: itemName,
         type: item.type,
         description: item.description
     })
 
     return itemData;
+}
+function getInheritance(inheritanceType: string) {
+    return inheritanceChart[inheritanceType];
 }
 
 function getSkillPersonaList(skill: SkillData): string {

--- a/src/PersonaController.js
+++ b/src/PersonaController.js
@@ -96,11 +96,13 @@ var PersonaController = /** @class */ (function () {
         this.$scope.persona.inheritanceHeader1 = inheritanceHeader.slice(0,6);
         this.$scope.persona.inheritanceHeader2 = inheritanceHeader.slice(6);
 
-        var inheritanceType = compediumEntry.inherits;
-        var inheritance = getInheritance(inheritanceType);
-        this.$scope.persona.inheritance = inheritance;
-        this.$scope.persona.inheritance1 = inheritance.slice(0,6);
-        this.$scope.persona.inheritance2 = inheritance.slice(6);
+        if(compediumEntry.inherits) {
+            var inheritanceType = compediumEntry.inherits;
+            var inheritance = getInheritance(inheritanceType);
+            this.$scope.persona.inheritance = inheritance;
+            this.$scope.persona.inheritance1 = inheritance.slice(0,6);
+            this.$scope.persona.inheritance2 = inheritance.slice(6);
+        }
     }
     PersonaController.prototype.paginateAndFilter = function (fusionFromTo, filterFunc) {
         if (fusionFromTo.pageNum < 0)

--- a/src/PersonaController.js
+++ b/src/PersonaController.js
@@ -89,6 +89,18 @@ var PersonaController = /** @class */ (function () {
         // Note: skillList are skills in a sorted list for displaying with Angular.
         // It's different from the existing skills property which is a map.
         this.$scope.persona.skillList = getSkills(personaName);
+
+        //inheritance data
+        var inheritanceHeader = ["Physical", "Gun", "Fire", "Ice", "Electric", "Wind", "Psychic", "Nuclear", "Bless", "Curse", "Healing", "Ailment"];
+        this.$scope.persona.inheritanceHeader = inheritanceHeader;
+        this.$scope.persona.inheritanceHeader1 = inheritanceHeader.slice(0,6);
+        this.$scope.persona.inheritanceHeader2 = inheritanceHeader.slice(6);
+
+        var inheritanceType = compediumEntry.inherits;
+        var inheritance = getInheritance(inheritanceType);
+        this.$scope.persona.inheritance = inheritance;
+        this.$scope.persona.inheritance1 = inheritance.slice(0,6);
+        this.$scope.persona.inheritance2 = inheritance.slice(6);
     }
     PersonaController.prototype.paginateAndFilter = function (fusionFromTo, filterFunc) {
         if (fusionFromTo.pageNum < 0)

--- a/src/PersonaController.ts
+++ b/src/PersonaController.ts
@@ -108,13 +108,13 @@ class PersonaController {
         this.$scope.persona.inheritanceHeader1 = inheritanceHeader.slice(0,6);
         this.$scope.persona.inheritanceHeader2 = inheritanceHeader.slice(6);
 
-        let inheritanceType = compediumEntry.inherits;
-        let inheritance = getInheritance(inheritanceType);
-        this.$scope.persona.inheritance = inheritance;
-        this.$scope.persona.inheritance1 = inheritance.slice(0,6);
-        this.$scope.persona.inheritance2 = inheritance.slice(6);
-
-
+        if(compediumEntry.inherits) {
+            let inheritanceType = compediumEntry.inherits;
+            let inheritance = getInheritance(inheritanceType);
+            this.$scope.persona.inheritance = inheritance;
+            this.$scope.persona.inheritance1 = inheritance.slice(0,6);
+            this.$scope.persona.inheritance2 = inheritance.slice(6);
+        }
     }
 
     private paginateAndFilter(fusionFromTo: FusionDataModel, filterFunc) {

--- a/src/PersonaController.ts
+++ b/src/PersonaController.ts
@@ -101,6 +101,20 @@ class PersonaController {
         // Note: skillList are skills in a sorted list for displaying with Angular.
         // It's different from the existing skills property which is a map.
         this.$scope.persona.skillList = getSkills(personaName);
+
+        //inheritance data
+        let inheritanceHeader = ["Physical", "Gun", "Fire", "Ice", "Electric", "Wind", "Psychic", "Nuclear", "Bless", "Curse", "Healing", "Ailment"];
+        this.$scope.persona.inheritanceHeader = inheritanceHeader;
+        this.$scope.persona.inheritanceHeader1 = inheritanceHeader.slice(0,6);
+        this.$scope.persona.inheritanceHeader2 = inheritanceHeader.slice(6);
+
+        let inheritanceType = compediumEntry.inherits;
+        let inheritance = getInheritance(inheritanceType);
+        this.$scope.persona.inheritance = inheritance;
+        this.$scope.persona.inheritance1 = inheritance.slice(0,6);
+        this.$scope.persona.inheritance2 = inheritance.slice(6);
+
+
     }
 
     private paginateAndFilter(fusionFromTo: FusionDataModel, filterFunc) {

--- a/style.css
+++ b/style.css
@@ -110,6 +110,9 @@ tr:hover td:last-child {
 .rp, .Repel { color: #fbbd08 !important; }
 .ab, .Absorb { color: #21ba45 !important; }
 
+.✓ { color: #31ce3e !important; }
+.✘ { color: #db2828 !important; }
+
 .left-border {
     border-left: 1px solid rgba(34,36,38,.1) !important;
 }

--- a/view/list.html
+++ b/view/list.html
@@ -15,6 +15,8 @@
         <th><a ng-click="sortBy = 'level'; sortReverse = !sortReverse">Level</a></th>
         <th><a ng-click="sortBy = 'name'; sortReverse = !sortReverse">Name</a></th>
         <th><a ng-click="sortBy = 'arcana'; sortReverse = !sortReverse">Arcana</a></th>
+
+        <th class="mobile-hidden"><a ng-click="sortBy = 'inherits'; sortReverse = !sortReverse">Inherits</a></th>
         <th class="mobile-hidden"><a ng-click="sortBy = 'strength'; sortReverse = !sortReverse">Strength</a></th>
         <th class="mobile-hidden"><a ng-click="sortBy = 'magic'; sortReverse = !sortReverse">Magic</a></th>
         <th class="mobile-hidden"><a ng-click="sortBy = 'endurance'; sortReverse = !sortReverse">Endurance</a></th>
@@ -30,6 +32,8 @@
         <th class="mobile-hidden"><a ng-click="sortBy = 'nuclearValue'; sortReverse = !sortReverse">Nuclear</a></th>
         <th class="mobile-hidden"><a ng-click="sortBy = 'blessValue'; sortReverse = !sortReverse">Bless</a></th>
         <th class="mobile-hidden"><a ng-click="sortBy = 'curseValue'; sortReverse = !sortReverse">Curse</a></th>
+
+        <th class="mobile-hidden"><a ng-click="sortBy = 'area'; sortReverse = !sortReverse">Mementos Location</th>
     </tr>
     </thead>
     <tbody>
@@ -40,6 +44,9 @@
             <span class="dlc-label" ng-if="persona.dlc">DLC</span>
         </td>
         <td class="left-border">{{persona.arcana}}</td>
+        
+        <td class="mobile-hidden left-border" ng-if="persona.inherits">{{persona.inherits}}</td>
+        <td class="mobile-hidden left-border" ng-if="!persona.inherits">-</td>
 
         <td class="mobile-hidden left-border">{{persona.strength}}</td>
         <td class="mobile-hidden">{{persona.magic}}</td>
@@ -56,6 +63,9 @@
         <td class="mobile-hidden {{persona.nuclear}}">{{persona.nuclear}}</td>
         <td class="mobile-hidden {{persona.bless}}">{{persona.bless}}</td>
         <td class="mobile-hidden {{persona.curse}}">{{persona.curse}}</td>
+
+        <td class="mobile-hidden left-border {{persona.area}}"><span title="{{persona.floor}}" class="dlc-label" 
+            style="background-color:#c3c8cb" ng-if="persona.floor">?</span> {{persona.area}}</td>
     </tr>
     </tbody>
 </table>

--- a/view/persona.html
+++ b/view/persona.html
@@ -113,6 +113,7 @@
         </tbody>
     </table>
 
+    <br>
     <div ng-if="persona.inherits">
     <h3>Inheritance</h3>
     <h4>Type: {{persona.inherits}}</h4>

--- a/view/persona.html
+++ b/view/persona.html
@@ -9,6 +9,9 @@
         <span style='color: slateblue;' ng:show='persona.note'>{{persona.note}}</span>
         <span style='color: slateblue;' ng:show='persona.dlc'>This is a DLC persona!</span>
     </div>
+    <div ng-if="persona.area"><h3>Mementos Location:</h3>
+        Path of {{persona.area}}<br>Floor(s): {{persona.floor}}</div>
+    
 
     <h3>Itemization</h3>
     <div ng:if='persona.item' style="margin-top:10px">
@@ -105,6 +108,48 @@
         <tbody>
         <tr>
             <td ng:repeat="s in persona.elems2 track by $index" class="{{s}}">{{s}}</td>
+        </tr>
+        </tbody>
+    </table>
+
+    <h3>Inheritance</h3>
+    <h4>Type: {{persona.inherits}}</h4>
+    <table class="ui table unstackable striped mobile-hidden">
+        <thead>
+        <tr>
+            <th ng:repeat="i in persona.inheritanceHeader">{{i}}</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr>
+            <td ng:repeat="i in persona.inheritance track by $index" class="{{i}}">{{i}}</td>
+        </tr>
+        </tbody>
+    </table>
+
+    <!--split the table into 2 for mobile-->
+    <table class="ui table unstackable striped desktop-hidden">
+        <thead>
+        <tr>
+            <th ng:repeat="s in persona.inheritanceHeader1">{{s}}</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr>
+            <td ng:repeat="s in persona.inheritance1 track by $index" class="{{s}}">{{s}}</td>
+        </tr>
+        </tbody>
+    </table>
+
+    <table class="ui table unstackable striped desktop-hidden">
+        <thead>
+        <tr>
+            <th ng:repeat="s in persona.inheritanceHeader2">{{s}}</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr>
+            <td ng:repeat="s in persona.inheritance2 track by $index" class="{{s}}">{{s}}</td>
         </tr>
         </tbody>
     </table>

--- a/view/persona.html
+++ b/view/persona.html
@@ -9,6 +9,7 @@
         <span style='color: slateblue;' ng:show='persona.note'>{{persona.note}}</span>
         <span style='color: slateblue;' ng:show='persona.dlc'>This is a DLC persona!</span>
     </div>
+    <br>
     <div ng-if="persona.area"><h3>Mementos Location:</h3>
         Path of {{persona.area}}<br>Floor(s): {{persona.floor}}</div>
     
@@ -112,6 +113,7 @@
         </tbody>
     </table>
 
+    <div ng-if="persona.inherits">
     <h3>Inheritance</h3>
     <h4>Type: {{persona.inherits}}</h4>
     <table class="ui table unstackable striped mobile-hidden">
@@ -153,7 +155,7 @@
         </tr>
         </tbody>
     </table>
-
+    </div>
     <h3>Skills</h3>
     <table id="skillTable" class="ui table unstackable striped">
         <thead>


### PR DESCRIPTION
This pull request adds a few enhancements and minor fixes:

Adds the Mementos locations for personas that can be found in Mementos/palaces. This add a column to the main index and allows for sorting by area. An icon that can be hovered over will show the floors it is available on. This column is hidden in the mobile version, so this info is also displayed at the top of the persona's info page. I did not show palace locations as this constitutes spoilers. Fixes #23 

Alters some text to better match the in-game text, such as "weak" damage being changed to "light". In the case of Swift Strike, damage becomes "miniscule" in the Royal version since it was nerfed. "Akasha Arts" was also renamed to "Akashic Arts" in Royal, so this was altered as well. "Mithra" also became "Mitra", since he is Mitra in P5 despite being Mithra in other megaten entries. Fixes #80  

Adds inheritance data and sorting by inheritance types. This appears as an additional "Inherits" column on desktop in the main index (hidden on mobile), as well as a table of inheritable skill types on the persona's info page. This table is split into two for mobile to follow suit with the other tables. Almighty, Passive, and Support are not included in the table header since they can be inherited by any type, but Almighty inheritance types will still have this table. Rare personas do not have this table, since they don't inherit anything. Fixes #37  

Also fixes an issue with Leanan Sidhe's itemization where it wasn't properly flagged as a skill card. Item maps also have had the unused skill card entries removed since the data is being pulled from the skill map.